### PR TITLE
Partial fix for null multi bulk response

### DIFF
--- a/index.js
+++ b/index.js
@@ -784,23 +784,25 @@ Multi.prototype.exec = function (callback) {
 
         var i, il, j, jl, reply, args, obj, key, val;
 
-        for (i = 1, il = self.queue.length; i < il; i += 1) {
-            reply = replies[i - 1];
-            args = self.queue[i];
-            
-            // Convert HGETALL reply to object
-            if (reply && args[0].toLowerCase() === "hgetall") {
-                obj = {};
-                for (j = 0, jl = reply.length; j < jl; j += 2) {
-                    key = reply[j].toString();
-                    val = reply[j + 1];
-                    obj[key] = val;
+        if (replies) {
+            for (i = 1, il = self.queue.length; i < il; i += 1) {
+                reply = replies[i - 1];
+                args = self.queue[i];
+                
+                // Convert HGETALL reply to object
+                if (reply && args[0].toLowerCase() === "hgetall") {
+                    obj = {};
+                    for (j = 0, jl = reply.length; j < jl; j += 2) {
+                        key = reply[j].toString();
+                        val = reply[j + 1];
+                        obj[key] = val;
+                    }
+                    replies[i - 1] = reply = obj;
                 }
-                replies[i - 1] = reply = obj;
-            }
-            
-            if (typeof args[args.length - 1] === "function") {
-                args[args.length - 1](null, reply);
+                
+                if (typeof args[args.length - 1] === "function") {
+                    args[args.length - 1](null, reply);
+                }
             }
         }
 

--- a/test.js
+++ b/test.js
@@ -204,6 +204,18 @@ tests.MULTI_6 = function () {
         });
 };
 
+tests.WATCH_MULTI = function () {
+  var name = 'WATCH_MULTI';
+
+  client.watch(name);
+  var multi = client.multi();
+  multi.incr(name);
+  client.incr(name);
+  multi.exec(function (err, replies) {
+    next(name);
+  });
+};
+
 tests.HSET = function () {
     var key = "test hash",
         field1 = new Buffer("0123456789"),


### PR DESCRIPTION
Hi Matt

The following error is currently thrown when a multi/exec is aborted because a watch detects a key modification.

```
client: TypeError: Cannot read property '0' of null
at Object.callback (/usr/local/lib/node/.npm/redis/0.3.7/package/index.js:789:30)
```

The simple test illustrates this, although bizarrely the watch stops the test suite from completing. I've no idea if the null check for replies is an appropriate way of dealing with the issue, but it met my needs for now, so I thought I'd send you a pull request.

Paul
