### PR TITLE
Fix for bug where you can't save an object with arrays AND buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -409,7 +409,7 @@ RedisClient.prototype.send_command = function () {
 
         for (i = 0, il = args.length, arg; i < il; i += 1) {
             arg = args[i];
-            if (arg.length === undefined) {
+            if (!(arg instanceof Buffer || arg instanceof String)) {
                 arg = String(arg);
             }
 

--- a/test.js
+++ b/test.js
@@ -287,6 +287,17 @@ tests.HSET = function () {
     client.HSET(key, field2, value2, last(name, require_number(0, name)));
 };
 
+tests.HMSET_BUFFER_AND_ARRAY = function () {
+    // Saving a buffer and an array to the same document should not error
+    var key = "test hash",
+        field1 = "buffer",
+        value1 = new Buffer("abcdefghij"),
+        field2 = "array",
+        value2 = [],
+        name = "HSET";
+
+    client.HMSET(key, field1, value1, field2, value2, last(name, require_string("OK", name)));
+};
 
 tests.HMGET = function () {
     var key1 = "test hash 1", key2 = "test hash 2", name = "HMGET";


### PR DESCRIPTION
I found a bug in the client for saving an object with buffers on it. I don't have exact reproducible code but here's pseudocode:

redis.hmset(key, 'buffer', Buffer(), 'array', []);

I wrote a test for it. If you add that test to your suite without the fix in index.js it will fail. The error was checking if (arg.length === undefined) cast it to a string. That code branch only happens if there are buffers passed in as values. But if you also pass in an array ([].length !== undefined) so it won't get cast to a string.

Andy
