### PR TITLE
Fixed a bug with return_reply being called and command_queue being erroneously shifted

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,7 +399,7 @@ RedisClient.prototype.return_reply = function (reply) {
     var command_obj, obj, i, len, key, val, type, timestamp, args, queue_len;
 
     // if the reply is a message, be sure not to shift command_queue
-    if (!(Array.isArray(reply) && reply[0].toString() === "message")) {
+    if (!(Array.isArray(reply) && reply[0] && reply[0].toString() === "message")) {
       command_obj = this.command_queue.shift();
     }
     


### PR DESCRIPTION
See this issue: https://github.com/mranney/node_redis/issues/94

What was happening is `return_reply` was being called with a `reply` array containing a "message" (was subscribed to a channel) whilst there was a `unsubscribe` command waiting to be processed in `command_queue`. So `return_reply` was shifting `command_queue` and assigning the waiting `unsubscribe` command to `command_obj` whilst the actual reply was just a `message`. I've made it so it checks whether it's a message before it shifts `command_queue`.
