### PR TITLE
Allow "publish" command in pub/sub mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,6 +480,8 @@ RedisClient.prototype.send_command = function () {
         }
         command_obj.sub_command = true;
         this.subscriptions = true;
+    } else if (command === "publish") {
+        // publish command is okay in pub/sub mode
     } else if (command === "monitor") {
         this.monitoring = true;
     } else if (command === "quit") {


### PR DESCRIPTION
Is there a particular reason why "publish" commands are not allowed in pub/sub mode? It seems counter-intuitive to not be able to do the pub part of pub/sub.
