### PR TITLE
Bug when calling quit()

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function RedisClient(stream, options) {
     });
 
     this.stream.on("error", function (msg) {
-        if (this.closing) {
+        if (self.closing) {
             return;
         }
 
@@ -503,6 +503,11 @@ RedisClient.prototype.send_command = function (command, args, callback) {
         throw new Error("send_command: second argument must be an array");
     }
 
+    if (command === "quit") {
+        this.closing = true;
+        return;
+    }
+
     command_obj = new Command(command, args, false, callback);
 
     if ((!this.ready && !this.send_anyway) || !stream.writable) {
@@ -526,8 +531,6 @@ RedisClient.prototype.send_command = function (command, args, callback) {
         this.subscriptions = true;
     } else if (command === "monitor") {
         this.monitoring = true;
-    } else if (command === "quit") {
-        this.closing = true;
     } else if (this.subscriptions === true) {
         throw new Error("Connection in pub/sub mode, only pub/sub commands may be used");
     }


### PR DESCRIPTION
Fixes the case where if the quit() method is called, the closing variable checks are not honoured.  If you call quit the closing command doesn't set the closing variable inside send_command function because the "ready" boolean gets set to false when an error event is raised, this causes an endless loop of errors if the redis server connection dies.
