### PR TITLE
fix error handling; call command callbacks on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,15 +69,15 @@ function RedisClient(stream, options) {
             console.warn(message);
         }
         self.offline_queue.forEach(function (args) {
-            if (typeof args[2] === "function") {
-                args[2](message);
+            if (typeof args.callback === "function") {
+                args.callback(message);
             }
         });
         self.offline_queue = new Queue();
 
         self.command_queue.forEach(function (args) {
-            if (typeof args[2] === "function") {
-                args[2](message);
+            if (typeof args.callback === "function") {
+                args.callback(message);
             }
         });
         self.command_queue = new Queue();
@@ -325,8 +325,8 @@ RedisClient.prototype.connection_gone = function (why) {
     }
 
     this.command_queue.forEach(function (args) {
-        if (typeof args[2] === "function") {
-            args[2]("Server connection closed");
+        if (typeof args.callback === "function") {
+            args.callback("Server connection closed");
         }
     });
     this.command_queue = new Queue();


### PR DESCRIPTION
Hi,

if there is a error event the callbacks of the queued commands are not called. I hopefully fixed the issue. Please double check my commit.

Apart from that I find the way we handle errors quite strange. Imange 1000 commands which get queued before the first error event. All the 1000 callbacks of the commands get called with the first error event. Now before the next error event I insert another 1000 commnds in the queue. These get called and deleted with the next error event after the retry_timeout hits. With increasing timeout it takes more and more time for your commands to return.

In the send_command function I would check if we are in an error state and if we are in an error state I would call the callback immediately with the error instead of calling all the errors on the next error event.

Anyway thx for your awesome work.

Regards
Philipp
