### PR TITLE
After a connection error, selected db, if it was set, is not restored

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ function RedisClient(stream, options) {
     this.server_info = {};
     this.auth_pass = null;
     this.parser_module = null;
-
+    this.selected_db = null;	// save the selected db here, used when reconnecting
+	
     var self = this;
 
     this.stream.on("connect", function () {
@@ -139,7 +140,12 @@ RedisClient.prototype.do_auth = function () {
             self.auth_callback(err, res);
             self.auth_callback = null;
         }
-
+		
+        // restore the selected db if needed
+        if (this.selected_db !== null) { 
+            this.send_command('select', [this.selected_db]);
+        }
+		
         // now we are really connected
         self.emit("connect");
         if (self.options.no_ready_check) {
@@ -174,6 +180,12 @@ RedisClient.prototype.on_connect = function () {
     if (this.auth_pass) {
         this.do_auth();
     } else {
+    	
+        // restore the selected db if needed
+        if (this.selected_db !== null) { 
+            this.send_command('select', [this.selected_db]);
+        }
+
         this.emit("connect");
 
         if (this.options.no_ready_check) {
@@ -681,6 +693,24 @@ commands.forEach(function (command) {
     };
     Multi.prototype[command.toUpperCase()] = Multi.prototype[command];
 });
+
+// store db in this.select_db to restore it on reconnect
+RedisClient.prototype.select = function (db, callback) {
+		
+	var self = this;
+	
+	this.send_command('select', [db], function (err, res) {
+		if (err === null) {
+			self.selected_db = db;			
+		}
+		if (typeof(callback) !== 'undefined') {
+			callback(err, res);
+		}
+		
+	});
+}
+RedisClient.prototype.SELECT = RedisClient.prototype.select;
+
 
 // Stash auth for connect and reconnect.  Send immediately if already connected.
 RedisClient.prototype.auth = function () {


### PR DESCRIPTION
override select method to store selected db in client instance and restore selected db on connect when an error happened
