### PR TITLE
Fixed an issue with detect_buffers set to true for an hgetall request in multi

### DIFF
--- a/index.js
+++ b/index.js
@@ -506,6 +506,17 @@ function reply_to_object(reply) {
     return obj;
 }
 
+function reply_from_array(reply) {
+    var i;
+    for (i = 0; i < reply.length; i++) {
+        if (Array.isArray(reply[i])) {
+            reply_from_array(reply[i]);
+        } else if (Buffer.isBuffer(reply[i])) {
+          reply[i] = reply[i].toString();
+        }
+    }
+}
+
 function reply_to_strings(reply) {
     var i;
 
@@ -514,10 +525,7 @@ function reply_to_strings(reply) {
     }
 
     if (Array.isArray(reply)) {
-        for (i = 0; i < reply.length; i++) {
-            reply[i] = reply[i].toString();
-        }
-        return reply;
+        reply_from_array(reply);
     }
 
     return reply;


### PR DESCRIPTION
Fixed an issue with returned data getting corrupted when the detect_buffers options is set to true.
This happens when you have a hgetall request in a multi.
Basically the data contains the returned data contains an Array within an Array and you are doing a one level of parsing. I made Arrays to be parsed recursively

E.g.
var redisClient = redis.createClient(redisSettings.port, redisSettings.host, {detect_buffers: true});
redisClient.auth(redisSettings.password);
redisClient.select(redisSettings.database);

var multi = redisClient.multi();
multi.hgetall('dayatest')
multi.exec(function(err, replies){
    console.log(replies)
});
///
Redis input
hset dayatest foo "bar"
hset dayatest foo1 "bar1"
////
The above code gives the results as 
[ { '1': undefined,
    f: 'o',
    o: '1',
    b: 'a',
    r: ',',
    ',': 'b',
    a: 'r' } ]
instead of [ { foo: 'bar', foo1: 'bar1' } ]
