### PR TITLE
Fix for [GH-165] - createClient to properly assign parser_module

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ RedisClient.prototype.init_parser = function () {
     if (this.options.parser) {
         if (! parsers.some(function (parser) {
             if (parser.name === self.options.parser) {
-                this.parser_module = parser;
+                self.parser_module = parser;
                 if (exports.debug_mode) {
                     console.log("Using parser module: " + self.parser_module.name);
                 }


### PR DESCRIPTION
`createClient` does not assign parser_module properly if parser name specified in `options` object

Please merge (and probably bump package.json version and rebase)

Thx!
