### PR TITLE
List hiredis as an optional dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "devDependencies": {
         "metrics": ">=0.1.5"
     },
+    "optionalDependencies": {
+        "hiredis": "*"
+    }
     "repository": {
         "type": "git",
         "url": "git://github.com/mranney/node_redis.git"


### PR DESCRIPTION
This will cause npm to attempt to install hiredis when installing redis,
but if the hiredis installation fails, it won't cause the redis install
to abort.

The optionalDependencies feature was added pretty much explicitly
for the redis->hiredis use case. :)
