### PR TITLE
send_command() patch

### DIFF
--- a/index.js
+++ b/index.js
@@ -688,7 +688,7 @@ RedisClient.prototype.send_command = function (command, args, callback) {
     
     elem_count = command_comps.length;
     elem_count += args.length;
-    
+
     command_str = "*" + elem_count + "\r\n";
     
     for (i = 0; i < command_comps.length; i ++) {


### PR DESCRIPTION
Added support for space-delimited commands (e.g.`DEBUG OBJECT`) by treating each word in the command as its own 'element' in the multi-bulk request. Prior to this change, send_command() failed to execute the 5 redis commands consisting of more than one word:
- `CONFIG GET`
- `CONFIG SET`
- `CONFIG RESETSTAT`
- `DEBUG OBJECT`
- `DEBUG SEGFAULT`

If we take the `DEBUG OBJECT` example:

The old approach bundled the command as a single element in the multi-bulk request:

```
*2
$12
DEBUG OBJECT
$7
testkey

```

This resulted in Redis returning the error: " ERR unknown command 'debug object' ".

The patched approach first parses the command string for multiple words, and then gives each word its own element in the request:

```
*3
$5
DEBUG
$6
OBJECT
$7
testkey
```

This results in improved coverage of commands supported by `send_command()`, and provides future-proofing for new Redis commands consisting of multiple words.
