### PR TITLE
fix #186, multi/exec callback error

### DIFF
--- a/index.js
+++ b/index.js
@@ -954,7 +954,11 @@ Multi.prototype.exec = function (callback) {
                 if (typeof cur[cur.length - 1] === "function") {
                     cur[cur.length - 1](err);
                 } else {
-                    throw new Error(err);
+                    if (callback) {
+                    	callback(new Error(err));
+                    } else {
+                    	throw new Error(err);
+                    }
                 }
                 self.queue.splice(index, 1);
             }


### PR DESCRIPTION
code:

```
client.multi().hset('foo').incr('bar').exec(callback)
```

throws error, but it should be in callback
