### PR TITLE
a generally faster javascript parser

### DIFF
--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -109,10 +109,12 @@ FasterReplyParser.prototype._parseResult = function (type) {
         }
 
         var reply = [ ];
+        var ntype, i;
+
         offset = this._offset - 1;
 
-        for (var i = 0; i < packetHeader.size; i++) {
-            var ntype = this._buffer[this._offset++];
+        for (i = 0; i < packetHeader.size; i++) {
+            ntype = this._buffer[this._offset++];
 
             if (this._offset === this._buffer.length) {
                 throw new Error('too far');
@@ -126,12 +128,12 @@ FasterReplyParser.prototype._parseResult = function (type) {
 
 FasterReplyParser.prototype.execute = function (buffer) {
     this.append(buffer);
-    var type;
+
+    var type, ret, offset;
+
     while (true) {
-        var offset = this._offset;
+        offset = this._offset;
         try {
-            var ret;
-      
             // at least 4 bytes: :1\r\n
             if (this._bytesRemaining() < 4) {
                 break;
@@ -142,21 +144,27 @@ FasterReplyParser.prototype.execute = function (buffer) {
             
             if (type === 43) { // +
                 ret = this._parseResult(type);
+
                 if (ret === null) {
                   break;
                 }
+
                 this.send_reply(ret);
             } else  if (type === 45) { // -
                 ret = this._parseResult(type);
+
                 if (ret === null) {
                   break;
                 }
+
                 this.send_error(ret);
             } else if (type === 58) { // :
                 ret = this._parseResult(type);
+
                 if (ret === null) {
                   break;
                 }
+
                 this.send_reply(+ret);
             } else if (type === 36) { // $
                 ret = this._parseResult(type);
@@ -164,12 +172,15 @@ FasterReplyParser.prototype.execute = function (buffer) {
                 if (ret === null) {
                   break;
                 }
+
                 this.send_reply(ret);
             } else if (type === 42) { // *
                 // set a rewind point. if a failure occurs,
                 // wait for the next execute()/append() and try again
                 offset = this._offset - 1;
+
                 ret = this._parseResult(type);
+
                 if (ret === -1) {
                     this._offset = offset;
                     break;
@@ -178,8 +189,8 @@ FasterReplyParser.prototype.execute = function (buffer) {
                 this.send_reply(ret);
             }
         } catch(err) {
-            // catch the error (not enough data), rewind, and wait
-            // for the next packet to appear
+              // catch the error (not enough data), rewind, and wait
+              // for the next packet to appear
               this._offset = offset;
               break;
         }
@@ -211,9 +222,9 @@ FasterReplyParser.prototype.append = function(newBuffer) {
     if (Buffer.concat !== undefined) {
         this._buffer = Buffer.concat([this._buffer.slice(this._offset), newBuffer]);
     } else {
-        var remaining = this._bytesRemaining();
-        var newLength = remaining + newBuffer.length;
-        var tmpBuffer = new Buffer(newLength);
+        var remaining = this._bytesRemaining(),
+            newLength = remaining + newBuffer.length,
+            tmpBuffer = new Buffer(newLength);
 
         this._buffer.copy(tmpBuffer, 0, this._offset);
         newBuffer.copy(tmpBuffer, remaining, 0);
@@ -259,7 +270,7 @@ FasterReplyParser.prototype.parser_error = function (message) {
 FasterReplyParser.prototype.send_error = function (reply) {
     this.emit("reply error", reply);
 };
-var count = 0;
+
 FasterReplyParser.prototype.send_reply = function (reply) {
     this.emit("reply", reply);
 };


### PR DESCRIPTION
taking what felixge put forward in his node-mysql talk at nodeconf, i implemented what tends to be a 15-20% throughput improved parser in javascript (according to multi_bench.js).

i am confident that some improvements can be made on this code, as well as some speedups.

it survives tests and stress-testing via benchmarks for me.

let me know what you think.
