### PR TITLE
Consolidate special hash helpers across client + multi client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ channel name as `channel` and the new count of subscriptions for this client as 
 
 ## client.multi([commands])
 
-`MULTI` commands are queued up until an `` is issued, and then all commands are run atomically by
+`MULTI` commands are queued up until an `EXEC` is issued, and then all commands are run atomically by
 Redis.  The interface in `node_redis` is to return an individual `Multi` object by calling `client.multi()`.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Output:
 Multiple values in a hash can be set by supplying an object:
 
     client.HMSET(key2, {
-        "0123456789": "abcdefghij", // NOTE: the key and value must both be strings
+        "0123456789": "abcdefghij", // NOTE: the value must be number or string
         "some manner of key": "a type of value"
     });
 
@@ -371,7 +371,7 @@ channel name as `channel` and the new count of subscriptions for this client as 
 
 ## client.multi([commands])
 
-`MULTI` commands are queued up until an `EXEC` is issued, and then all commands are run atomically by
+`MULTI` commands are queued up until an `` is issued, and then all commands are run atomically by
 Redis.  The interface in `node_redis` is to return an individual `Multi` object by calling `client.multi()`.
 
 ```js

--- a/index.js
+++ b/index.js
@@ -650,6 +650,11 @@ RedisClient.prototype.send_command = function (command, args, callback) {
         throw new Error("First argument to send_command must be the command name string, not " + typeof command);
     }
 
+    // If command is called with all arguments (including key and callback) given as a single array, make it args
+    if (args.length === 1 && Array.isArray(args[0])){
+      args = args[0];
+    }
+
     if (Array.isArray(args)) {
         if (typeof callback === "function") {
             // probably the fastest way:

--- a/index.js
+++ b/index.js
@@ -1002,7 +1002,7 @@ RedisClient.prototype.hcommand = function(command, args){
 }
 
 RedisClient.prototype.hmsetObj = function(obj, callback){
-  var args = [], keys = Object.keys(obj);
+  var args = [], keys = Object.keys(obj), key;
 
   for (var i = 0, il = keys.length; i < il; i++) {
       key = keys[i];

--- a/index.js
+++ b/index.js
@@ -912,12 +912,12 @@ RedisClient.prototype.auth = function () {
 RedisClient.prototype.AUTH = RedisClient.prototype.auth;
 
 RedisClient.prototype.hmget = function () {
-    this.send_command.apply(this, hcommand.call(this, 'hmget', arguments));
+    this.send_command.apply(this, hcommand('hmget', arguments));
 };
 RedisClient.prototype.HMGET = RedisClient.prototype.hmget;
 
 RedisClient.prototype.hmset = function () {
-    var args = hcommand.call(this, 'hmset', arguments);
+    var args = hcommand('hmset', arguments);
     if(!args)
       return false;
     return this.send_command.apply(this, args);
@@ -925,13 +925,13 @@ RedisClient.prototype.hmset = function () {
 RedisClient.prototype.HMSET = RedisClient.prototype.hmset;
 
 Multi.prototype.hmget = function () {
-    this.queue.push(hcommand.call(this, 'hmget', arguments));
+    this.queue.push(hcommand('hmget', arguments));
     return this;
 };
 
-function hcommand(command, arguments){
+function hcommand(command, args){
   var callback;
-  var args = to_array(arguments);
+  args = to_array(args);
   var r = [command]; // Command name
   if("function" == typeof args[args.length -1])
     callback = args.pop();
@@ -981,7 +981,7 @@ function hmsetObj(obj, callback){
 }
 
 Multi.prototype.hmset = function () {
-    var args = hcommand.call(this, 'hmset', arguments);
+    var args = hcommand('hmset', arguments);
     if(!args)
       return this;
     this.queue.push(args);
@@ -1001,7 +1001,7 @@ Multi.prototype.exec = function (callback) {
         // where args ~ [ 'hash', [ 'key1', 'key2' ] ]
         if(~['hmget', 'hdel'].indexOf(command.toLowerCase()) && Array.isArray(args[2])){
           // Call hcommand helper to transform args to ~ [ 'hmget', [ 'hash', 'key1', 'key2' ] ]
-          args = hcommand.call(this, command, args.slice(1));
+          args = hcommand(command, args.slice(1));
         }
 
         if (typeof args[args.length - 1] === "function") {

--- a/index.js
+++ b/index.js
@@ -674,11 +674,11 @@ RedisClient.prototype.send_command = function (command, args, callback) {
         throw new Error("send_command: second argument must be an array");
     }
 
-    // if the last argument is an array and command is sadd, expand it out:
+    // if the last argument is an array, expand it out:
     //     client.sadd(arg1, [arg2, arg3, arg4], cb);
     //  converts to:
     //     client.sadd(arg1, arg2, arg3, arg4, cb);
-    if ((command === 'sadd' || command === 'SADD') && args.length > 0 && Array.isArray(args[args.length - 1])) {
+    if (args.length > 1 && Array.isArray(args[args.length - 1])) {
         args = args.slice(0, -1).concat(args[args.length - 1]);
     }
 
@@ -1013,7 +1013,7 @@ RedisClient.prototype.hmsetObj = function(obj, callback){
       }
       args.push(obj[key]);
   }
-  return args
+  return args;
 }
 
 Multi.prototype.hcommand = RedisClient.prototype.hcommand;

--- a/test.js
+++ b/test.js
@@ -1585,6 +1585,16 @@ tests.HMSET_THROWS_ON_OBJECTS = function () {
     next(name);
 };
 
+tests.ARGUMENT_FORMATS = function(){
+    var name = 'ARGUMENT_FORMATS';
+    // All as array, no callback
+    client.MSETNX(["mset3", "val3", "mset4", "val4"]);
+    // All as array, callback
+    client.zadd(["some zset", 123456, "with callback", require_number(1, name)]);
+    // Variadic
+    client.hset("some hash", 'testfield', 'testvalue', last(name, require_number(1, name)));
+}
+
 tests.ENABLE_OFFLINE_QUEUE_TRUE = function () {
     var name = "ENABLE_OFFLINE_QUEUE_TRUE";
     var cli = redis.createClient(9999, null, {

--- a/test.js
+++ b/test.js
@@ -198,13 +198,15 @@ tests.MULTI_5 = function () {
         ["mget", ["multifoo", "some", "random value", "keys"]],
         ["incr", "multifoo"],
         ["hmset", 'hash', 'key1', 1, 'key2', 2],
-        ["hmget", 'hash', ['key1', 'key2']]
+        ["hmget", 'hash', ['key1', 'key2']],
+        ["hdel", 'hash', ['key1', 'key2']]
     ])
     .exec(function (err, replies) {
-        assert.strictEqual(replies.length, 4, name);
+        assert.strictEqual(replies.length, 5, name);
         assert.strictEqual(replies[0].length, 4, name);
         assert.strictEqual(replies[2], 'OK', name);
         assert.deepEqual(replies[3], ['1', '2'] , name);
+        assert.equal(replies[4], 2, name);
         next(name);
     });
 };
@@ -611,6 +613,24 @@ tests.HINCRBY = function () {
     client.hset("hash incr", "value", 10, require_number(1, name));
     client.HINCRBY("hash incr", "value", 1, require_number(11, name));
     client.HINCRBY("hash incr", "value 2", 1, last(name, require_number(1, name)));
+};
+
+tests.HDEL = function () {
+    var name = 'HDEL';
+    var key = "hdel test hash";
+    var hash = {
+      'field1' : 'value1',
+      'field2' : 2,
+      'field3' : 'value3',
+      'field4' : 'value4',
+      'field5' : 'value5',
+    }
+    client.hmset(key, hash, require_string('OK', name));
+
+    client.hdel(key, 'field1', require_number(1, name));
+    client.hdel(key, 'field2', 'field3', require_number(2, name));
+    client.hdel(key, ['field4', 'field5'], require_number(2, name));
+    client.hlen(key, last(name, require_number(0, name)));
 };
 
 tests.SUBSCRIBE = function () {


### PR DESCRIPTION
There were many separate hash methods implemented separately for client and multi, but they were doing very similar things. I have gone through and combined them into methods shared between the normal and multi clients, to ensure consistency, improve maintainability and decrease bug susceptibility.

* Addresses #218: Allow strings and integer in obj for hmset(key, obj), but throw error when given object type
* Fixes #272: Accept array arg consistently across client and multi
* Supplemented with tests and whole suite passing.