### PR TITLE
Fix cases where the offset is out of range (javascript parser)

### DIFF
--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -125,12 +125,12 @@ ReplyParser.prototype._parseResult = function (type) {
         for (i = 0; i < packetHeader.size; i++) {
             ntype = this._buffer[this._offset++];
 
-            if (this._offset === this._buffer.length) {
+            if (this._offset > this._buffer.length) {
                 throw new Error("too far");
             }
             res = this._parseResult(ntype);
             if (res === undefined) {
-              res = null;
+                res = null;
             }
             reply.push(res);
         }


### PR DESCRIPTION
The rewind condition is bypassed if the offset is bigger than the buffer length, screwing up the parser.

I merged [pull request ](https://github.com/mranney/node_redis/pull/275) by @JerrySievert  in my fork so you might want to add this first.
