### PR TITLE
Test for slowlog

### DIFF
--- a/test.js
+++ b/test.js
@@ -1568,6 +1568,21 @@ tests.ENABLE_OFFLINE_QUEUE_FALSE = function () {
     });
 };
 
+tests.SLOWLOG = function () {
+    var name = "SLOWLOG";
+    client.slowlog('reset',require_string("OK", name));
+    client.config('set', 'slowlog-log-slower-than', 0,require_string("OK", name));
+    client.set('foo','bar',require_string("OK", name));
+	client.get('foo',require_string("bar", name));
+	client.slowlog('get',function(err,res){
+		assert.equal(res.length, 4, name);
+		assert.equal(res[0][3].length, 2, name);
+		assert.deepEqual(res[1][3], ['set', 'foo', 'bar'], name);
+		assert.deepEqual(res[3][3], ['slowlog', 'reset'], name);
+		next(name);
+	});
+}
+
 // TODO - need a better way to test auth, maybe auto-config a local Redis server or something.
 // Yes, this is the real password.  Please be nice, thanks.
 tests.auth = function () {


### PR DESCRIPTION
Hi, as discussed at the [issue#264](https://github.com/mranney/node_redis/issues/264).

Here is the pull request with a test for slowlog. The new parser seem to work well for slowlog.

For the old parser, i have a patch here [gist](https://gist.github.com/3795279). Those still on old parser can use this.

Nitesh
