### PR TITLE
fixed RedisClient.prototype.end()

### DIFF
--- a/index.js
+++ b/index.js
@@ -826,6 +826,7 @@ RedisClient.prototype.end = function () {
     this.stream._events = {};
     this.connected = false;
     this.ready = false;
+    this.closing = true;
     return this.stream.end();
 };
 


### PR DESCRIPTION
An uncaught exception will be raised when the retry timer tries to
reconnect and encounter an error, for all event listeners of the stream
were removed in line 826. It should set closing varable to be true.
