### PR TITLE
Removed usage of undefined variable current_retry_delay

### DIFF
--- a/index.js
+++ b/index.js
@@ -883,9 +883,9 @@ commands.forEach(function (command) {
 
 // store db in this.select_db to restore it on reconnect
 RedisClient.prototype.select = function (db, callback) {
-	var self = this;
+    var self = this;
 
-	this.send_command('select', [db], function (err, res) {
+    this.send_command('select', [db], function (err, res) {
         if (err === null) {
             self.selected_db = db;
         }


### PR DESCRIPTION
The  undefined variable was used only in debug messages, so functionality was not impacted, but the debug message was misleading.

I was trying how my application handle redis server errors and noticed it.
