### PR TITLE
Make return_buffers work with ints

### DIFF
--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -37,7 +37,7 @@ function small_toString(buf, start, end) {
 
 ReplyParser.prototype._parseResult = function (type) {
     var start, end, offset, packetHeader;
-  
+
     if (type === 43 || type === 45) { // + or -
         // up to the delimiter
         end = this._packetEndOffset() - 1;
@@ -71,6 +71,10 @@ ReplyParser.prototype._parseResult = function (type) {
         if (end > this._buffer.length) {
             this._offset = start;
             throw new Error("too far");
+        }
+
+        if (this.options.return_buffers) {
+            return this._buffer.slice(start, end);
         }
 
         // return the coerced numeric value
@@ -177,7 +181,7 @@ ReplyParser.prototype.execute = function (buffer) {
                     break;
                 }
 
-                this.send_reply(+ret);
+                this.send_reply(ret);
             } else if (type === 36) { // $
                 ret = this._parseResult(type);
 
@@ -246,7 +250,7 @@ ReplyParser.prototype.append = function (newBuffer) {
 
         this._buffer.copy(tmpBuffer, 0, this._offset);
         newBuffer.copy(tmpBuffer, remaining, 0);
-        
+
         this._buffer = tmpBuffer;
     }
 


### PR DESCRIPTION
The parser returns buffers when `return_buffers` is `true` in every case except for integers. However, it can be useful to return a Buffer instead of an integer when the number is larger than the maximum allowed by JavaScript.

The [test case](https://github.com/mjijackson/node_redis/blob/return_buffers_ints/test.js#L104-116) shows an example of starting with the largest number in JavaScript and using a parser that returns buffers with `incr` to get the next number in the sequence.
