### PR TITLE
Revert eval caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var net = require("net"),
     Queue = require("./lib/queue"),
     to_array = require("./lib/to_array"),
     events = require("events"),
-    crypto = require("crypto"),
     parsers = [], commands,
     connection_id = 0,
     default_port = 6379,
@@ -1059,35 +1058,6 @@ RedisClient.prototype.multi = function (args) {
 RedisClient.prototype.MULTI = function (args) {
     return new Multi(this, args);
 };
-
-
-// stash original eval method
-var eval_orig = RedisClient.prototype.eval;
-// hook eval with an attempt to evalsha for cached scripts
-RedisClient.prototype.eval = RedisClient.prototype.EVAL = function () {
-    var self = this,
-        args = to_array(arguments),
-        callback;
-
-    if (typeof args[args.length - 1] === "function") {
-        callback = args.pop();
-    }
-
-    // replace script source with sha value
-    var source = args[0];
-    args[0] = crypto.createHash("sha1").update(source).digest("hex");
-
-    self.evalsha(args, function (err, reply) {
-        if (err && /NOSCRIPT/.test(err.message)) {
-            args[0] = source;
-            eval_orig.call(self, args, callback);
-
-        } else if (callback) {
-            callback(err, reply);
-        }
-    });
-};
-
 
 exports.createClient = function (port_arg, host_arg, options) {
     var port = port_arg || default_port,


### PR DESCRIPTION
This reverts my previous attempt at automatically caching `eval` scripts. The current implementation does not support calling with an array of arguments (e.g. `eval(args, callback)`). And after much internal struggle, I decided this automagic probably isn't best suited in `eval`.

I may re-implement this at a later date in some other form and/or under another method name.

@DTrejo I tried to `git revert ...`, but conflicts wouldn't let it happen gracefully, so this is the best I can do. There were no tests or docs added specifically for this change.
