### PR TITLE
Dont' assume SET ordering in tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -994,16 +994,16 @@ tests.SADD2 = function () {
     client.sadd("set0", ["member0", "member1", "member2"], require_number(3, name));
     client.smembers("set0", function (err, res) {
         assert.strictEqual(res.length, 3);
-        assert.strictEqual(res[0], "member0");
-        assert.strictEqual(res[1], "member1");
-        assert.strictEqual(res[2], "member2");
+        assert.ok(~res.indexOf("member0"));
+        assert.ok(~res.indexOf("member1"));
+        assert.ok(~res.indexOf("member2"));
     });
     client.SADD("set1", ["member0", "member1", "member2"], require_number(3, name));
     client.smembers("set1", function (err, res) {
         assert.strictEqual(res.length, 3);
-        assert.strictEqual(res[0], "member0");
-        assert.strictEqual(res[1], "member1");
-        assert.strictEqual(res[2], "member2");
+        assert.ok(~res.indexOf("member0"));
+        assert.ok(~res.indexOf("member1"));
+        assert.ok(~res.indexOf("member2"));
         next(name);
     });
 };


### PR DESCRIPTION
Small fix to test assertions for sadd/smembers. Simply checks the index of the member rather than assuming ordering on a SET, since they don't guarantee order and all.

Error used to be:

``` shell
- sadd2:
Uncaught exception: AssertionError: "member2" === "member0"
    at tests.SADD2 (/Users/gjohnson/Projects/bitcrunch/node_modules/redis/test.js:998:16)
    at try_callback (/Users/gjohnson/Projects/bitcrunch/node_modules/redis/index.js:520:9)
    at RedisClient.return_reply (/Users/gjohnson/Projects/bitcrunch/node_modules/redis/index.js:590:13)
    at ReplyParser.RedisClient.init_parser (/Users/gjohnson/Projects/bitcrunch/node_modules/redis/index.js:263:14)
    at ReplyParser.EventEmitter.emit (events.js:96:17)
    at ReplyParser.send_reply (/Users/gjohnson/Projects/bitcrunch/node_modules/redis/lib/parser/javascript.js:297:10)
    at ReplyParser.execute (/Users/gjohnson/Projects/bitcrunch/node_modules/redis/lib/parser/javascript.js:211:22)
    at RedisClient.on_data (/Users/gjohnson/Projects/bitcrunch/node_modules/redis/index.js:476:27)
    at Socket.<anonymous> (/Users/gjohnson/Projects/bitcrunch/node_modules/redis/index.js:79:14)
    at Socket.EventEmitter.emit (events.js:96:17)
```
