### PR TITLE
Incorrect offset setting in the new js parser

### DIFF
--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -112,7 +112,6 @@ ReplyParser.prototype._parseResult = function (type) {
         packetHeader = new Packet(type, this.parseHeader());
 
         if (packetHeader.size > this._bytesRemaining()) {
-            this._offset = offset - 1;
             return -1;
         }
 


### PR DESCRIPTION
It will cause the callback functions receiving a former request's reply or QUEUED as the offset is set incorrectly.
