### PR TITLE
call toString() method when the type of the value is number in hmset

### DIFF
--- a/index.js
+++ b/index.js
@@ -945,6 +945,9 @@ RedisClient.prototype.hmset = function (args, callback) {
         for (i = 0, il = tmp_keys.length; i < il ; i++) {
             key = tmp_keys[i];
             tmp_args.push(key);
+            if (typeof args[1][key] === 'number') {
+              args[1][key] = args[1][key].toString();
+            }
             if (typeof args[1][key] !== "string") {
                 var err = new Error("hmset expected value to be a string", key, ":", args[1][key]);
                 if (callback) {


### PR DESCRIPTION
When the second parameter is an object in HMSET, I think it's will be better to convert the value from number to string automatically by call ```toString()```method.

For example, the following code should be worked:

```javascript
client.hmset("key", {
  name: "Tom",
  order: 5
});
```