### PR TITLE
fix keys test for redis 2.6 (issue 290)

### DIFF
--- a/test.js
+++ b/test.js
@@ -1003,16 +1003,16 @@ tests.SADD2 = function () {
     client.sadd("set0", ["member0", "member1", "member2"], require_number(3, name));
     client.smembers("set0", function (err, res) {
         assert.strictEqual(res.length, 3);
-        assert.strictEqual(res[0], "member0");
-        assert.strictEqual(res[1], "member1");
-        assert.strictEqual(res[2], "member2");
+        assert(res.indexOf("member0") > -1, name);
+        assert(res.indexOf("member1") > -1, name);
+        assert(res.indexOf("member2") > -1, name);
     });
     client.SADD("set1", ["member0", "member1", "member2"], require_number(3, name));
     client.smembers("set1", function (err, res) {
         assert.strictEqual(res.length, 3);
-        assert.strictEqual(res[0], "member0");
-        assert.strictEqual(res[1], "member1");
-        assert.strictEqual(res[2], "member2");
+        assert(res.indexOf("member0") > -1, name);
+        assert(res.indexOf("member1") > -1, name);
+        assert(res.indexOf("member2") > -1, name);
         next(name);
     });
 };


### PR DESCRIPTION
This fixes the 'KEYS' test for Redis 2.6, identified at [issue 290](https://github.com/mranney/node_redis/issues/290).

(Note, that's not the only failing test on 2.6, I'll try to fix the others too)
