### PR TITLE
Something to generalize accepted types

### DIFF
--- a/index.js
+++ b/index.js
@@ -945,8 +945,8 @@ RedisClient.prototype.hmset = function (args, callback) {
         for (i = 0, il = tmp_keys.length; i < il ; i++) {
             key = tmp_keys[i];
             tmp_args.push(key);
-            if (typeof args[1][key] !== "string") {
-                var err = new Error("hmset expected value to be a string", key, ":", args[1][key]);
+            if (isPrimitive(args[1][key])) {
+                var err = new Error("hmset expected object values to be primitive", key, ":", args[1][key]);
                 if (callback) {
                     return callback(err);
                 } else {

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,3 +9,12 @@ try {
 }
 
 module.exports = util;
+
+// Returns true if the passed variable is a string, integer, or float
+function isPrimitive(val) {
+	var type = typeof val;
+	return
+		type === "string" ||
+		type === "float" ||
+		type === "integer";
+}


### PR DESCRIPTION
I know that redis only accepts string types, but technically there's no reason not to accept those same types when passed as arguments.  I've created a new method called "isPrimitive" which detects whether the passed value is a string, integer, or float, and allows any of these to be coerced to a string type.
