### PR TITLE
Unexpected exception when reconnecting in pub/sub mode if selected_db is not null

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,6 +295,7 @@ RedisClient.prototype.on_ready = function () {
         var callback = function () {
             callback_count--;
             if (callback_count === 0) {
+                self.send_offline_queue();
                 self.emit("ready");
             }
         };
@@ -308,6 +309,7 @@ RedisClient.prototype.on_ready = function () {
             self.send_command(parts[0] + "scribe", [parts[1]], callback);
         });
         if (trigger_ready) {
+            this.send_offline_queue();
             this.emit("ready");
         }
         return;


### PR DESCRIPTION
RedisClient might enter pub/sub mode after at least one SELECT command issued. When reconnecting after connection gone, the SELECT command is issued after restoring pub_sub_command to true, which causes an exception.
