### PR TITLE
Command queue error after pubsub

### DIFF
--- a/index.js
+++ b/index.js
@@ -628,6 +628,8 @@ RedisClient.prototype.return_reply = function (reply) {
             return elem.replace(/\\"/g, '"');
         });
         this.emit("monitor", timestamp, args);
+    } else if (type === "message" || type === "pmessage") {
+        // No error here, we are simply processing a message sent before exiting pubsub
     } else {
         throw new Error("node_redis command queue state error. If you can reproduce this, please report it.");
     }


### PR DESCRIPTION
Don't throw a command queue error if a pubsub message is processed after exiting pubsub mode.  This can happen due to a race and is not a bug, just ignore the message.

#### Ready to merge checklist
- [ ] test(s) in test.js
- [ ] tests will fail without the PR, but succeed once applied
- [ ] merges cleanly
- [x] coding style (4-space indents, looks similar to other code)