### PR TITLE
Unexpected exception when reconnecting in pub/sub mode if selected_db is not null

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,6 +282,8 @@ RedisClient.prototype.on_ready = function () {
 
     // magically restore any modal commands from a previous connection
     if (this.selected_db !== null) {
+        // this trick works if and only if the following send_command
+        // never goes into the offline queue
         var pub_sub_mode = this.pub_sub_mode;
         this.pub_sub_mode = false;
         this.send_command('select', [this.selected_db]);


### PR DESCRIPTION
RedisClient might enter pub/sub mode after at least one SELECT command issued. When reconnecting after connection gone, the SELECT command is issued after restoring pub_sub_command to true, which causes an exception.
