### PR TITLE
Make return_buffers work with channel names.

### DIFF
--- a/index.js
+++ b/index.js
@@ -596,9 +596,9 @@ RedisClient.prototype.return_reply = function (reply) {
             type = reply[0].toString();
 
             if (type === "message") {
-                this.emit("message", reply[1].toString(), reply[2]); // channel, message
+                this.emit("message", reply[1], reply[2]); // channel, message
             } else if (type === "pmessage") {
-                this.emit("pmessage", reply[1].toString(), reply[2].toString(), reply[3]); // pattern, channel, message
+                this.emit("pmessage", reply[1].toString(), reply[2], reply[3]); // pattern, channel, message
             } else if (type === "subscribe" || type === "unsubscribe" || type === "psubscribe" || type === "punsubscribe") {
                 if (reply[2] === 0) {
                     this.pub_sub_mode = false;
@@ -613,7 +613,7 @@ RedisClient.prototype.return_reply = function (reply) {
                 if (command_obj && typeof command_obj.callback === "function") {
                     try_callback(command_obj.callback, reply[1].toString());
                 }
-                this.emit(type, reply[1].toString(), reply[2]); // channel, count
+                this.emit(type, reply[1], reply[2]); // channel, count
             } else {
                 throw new Error("subscriptions are active but got unknown reply type " + type);
             }


### PR DESCRIPTION
When using pub/sub, return_buffers is ignored and channel names are forced to be strings, making it impossible to use binary channel names when accessing redis using this library.
It turns out the .toString() on these names is superfluous as the underlying parser is already returning these correctly as either strings or node.js Buffer objects based on the return_buffer setting.

(I am fully willing to believe, however, that a more complex code change is needed to work with different parser backends, or in more circumstances; I know very little about this codebase in general.)

#### Ready to merge checklist
- [ ] test(s) in test.js
- [ ] tests will fail without the PR, but succeed once applied
- [x] docs, if applicable
- [ ] merges cleanly
- [x] coding style (4-space indents, looks similar to other code)