### PR TITLE
don't dequeue the command queue if a message or pmessage is received

### DIFF
--- a/index.js
+++ b/index.js
@@ -562,8 +562,14 @@ function reply_to_strings(reply) {
 RedisClient.prototype.return_reply = function (reply) {
     var command_obj, len, type, timestamp, argindex, args, queue_len;
 
-    command_obj = this.command_queue.shift(),
-    queue_len   = this.command_queue.getLength();
+    if (Array.isArray(reply))
+        type = reply[0].toString();
+
+    // Don't dequeue if a (p)message arrives
+    if (type !== "message" && type !== "pmessage")
+        command_obj = this.command_queue.shift();
+
+    queue_len = this.command_queue.getLength();
 
     if (this.pub_sub_mode === false && queue_len === 0) {
         this.emit("idle");
@@ -593,8 +599,6 @@ RedisClient.prototype.return_reply = function (reply) {
         }
     } else if (this.pub_sub_mode || (command_obj && command_obj.sub_command)) {
         if (Array.isArray(reply)) {
-            type = reply[0].toString();
-
             if (type === "message") {
                 this.emit("message", reply[1].toString(), reply[2]); // channel, message
             } else if (type === "pmessage") {


### PR DESCRIPTION
If a published message arrives while waiting for a reply to a command,
it will mistakenly shift the queue and consume the command's entry, and
that command's callback will not be called.
