### PR TITLE
trap exceptions from the parser, but not ones thrown by event handlers

### DIFF
--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -146,43 +146,52 @@ ReplyParser.prototype._parseResult = function (type) {
 ReplyParser.prototype.execute = function (buffer) {
     this.append(buffer);
 
-    var type, ret, offset;
+    var type, ret, offset, send_method;
 
     while (true) {
         offset = this._offset;
-        try {
-            // at least 4 bytes: :1\r\n
-            if (this._bytesRemaining() < 4) {
-                break;
-            }
+        send_method = null;
 
-            type = this._buffer[this._offset++];
+        // at least 4 bytes: :1\r\n
+        if (this._bytesRemaining() < 4) {
+            break;
+        }
 
-            if (type === 43) { // +
+        type = this._buffer[this._offset++];
+
+        if (type === 43) { // +
+            try {
                 ret = this._parseResult(type);
 
                 if (ret === null) {
                     break;
                 }
 
-                this.send_reply(ret);
-            } else  if (type === 45) { // -
+                send_method = 'send_reply';
+            } catch (err) {}
+
+        } else  if (type === 45) { // -
+            try {
                 ret = this._parseResult(type);
 
                 if (ret === null) {
                     break;
                 }
 
-                this.send_error(ret);
-            } else if (type === 58) { // :
+                send_method = 'send_error';
+            } catch (err) {}
+        } else if (type === 58) { // :
+            try {
                 ret = this._parseResult(type);
 
                 if (ret === null) {
                     break;
                 }
 
-                this.send_reply(ret);
-            } else if (type === 36) { // $
+                send_method = 'send_reply';
+            } catch (err) {}
+        } else if (type === 36) { // $
+            try {
                 ret = this._parseResult(type);
 
                 if (ret === null) {
@@ -195,8 +204,10 @@ ReplyParser.prototype.execute = function (buffer) {
                     ret = null;
                 }
 
-                this.send_reply(ret);
-            } else if (type === 42) { // *
+                send_method = 'send_reply';
+            } catch (err) {}
+        } else if (type === 42) { // *
+            try {
                 // set a rewind point. if a failure occurs,
                 // wait for the next execute()/append() and try again
                 offset = this._offset - 1;
@@ -208,10 +219,15 @@ ReplyParser.prototype.execute = function (buffer) {
                     break;
                 }
 
-                this.send_reply(ret);
-            }
-        } catch (err) {
-            // catch the error (not enough data), rewind, and wait
+                send_method = 'send_reply';
+            } catch (err) {}
+        }
+
+        if (send_method) {
+            this[send_method](ret);
+        }
+        else {
+            // if there is not enough data, rewind, and wait
             // for the next packet to appear
             this._offset = offset;
             break;


### PR DESCRIPTION
According to RedisClient.prototype.on_data, "Callbacks that throw exceptions will land in return_reply(), below.".  Although this handling is now in try_callback, exceptions thrown by "reply" callbacks are being silenced by the try/catch in lib/parser/javascript.js.  Allow those errors to be thrown to the right place.
