### PR TITLE
Support commands consisting of multiple words

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,15 @@ This will display:
 
 `send command` is data sent into Redis and `on_data` is data received from Redis.
 
+## Multi-word commands
+
+To execute redis multi-word commands like `SCRIPT LOAD` or `CLIENT LIST` pass
+the second word as first parameter:
+
+    client.script('load', 'return 1');
+    client.multi().script('load', 'return 1').exec(...);
+    client.multi([['script', 'load', 'return 1']]).exec(...);
+
 ## client.send_command(command_name, args, callback)
 
 Used internally to send commands to Redis.  For convenience, nearly all commands that are published on the Redis

--- a/index.js
+++ b/index.js
@@ -865,7 +865,9 @@ commands = set_union(["get", "set", "setnx", "setex", "append", "strlen", "del",
     "persist", "slaveof", "debug", "config", "subscribe", "unsubscribe", "psubscribe", "punsubscribe", "publish", "watch", "unwatch", "cluster",
     "restore", "migrate", "dump", "object", "client", "eval", "evalsha"], require("./lib/commands"));
 
-commands.forEach(function (command) {
+commands.forEach(function (fullCommand) {
+    var command = fullCommand.split(' ')[0];
+
     RedisClient.prototype[command] = function (args, callback) {
         if (Array.isArray(args) && typeof callback === "function") {
             return this.send_command(command, args, callback);

--- a/test.js
+++ b/test.js
@@ -369,6 +369,17 @@ tests.EVAL_1 = function () {
     }
 };
 
+tests.SCRIPT_LOAD = function() {
+    var name = "SCRIPT_LOAD",
+        command = "return 1",
+        commandSha = crypto.createHash('sha1').update(command).digest('hex');
+
+    bclient.script("load", command, function(err, result) {
+        assert.strictEqual(result.toString(), commandSha);
+        next(name);
+    });
+};
+
 tests.WATCH_MULTI = function () {
     var name = 'WATCH_MULTI', multi;
 


### PR DESCRIPTION
Currently redis multi-word commands like `SCRIPT LOAD` or `CLIENT LIST` are present, but do not work, because redis expects the words to arrive in individual fields.

This patch adds supports for these commands by registering the first word of such commands. The above can then be executed like:

```
redis.script('load', 'return 1');
redis.multi().script('load', 'return 1').exec(...);
redis.multi([['script', 'load', 'return 1']]).exec(...);

redis.client('list');
redis.multi().client('list').exec(...);
redis.multi([['client', 'list']]).exec(...);
```

As this patch only affects the initialisation of multi-word commands there are no performance impacts to expect.

The current solution has a small catch as prefixes that occur multiple times (like `CLIENT` from `CLIENT LIST` and `CLIENT KILL`) gets added multiple times and therefore overwritten. This has currently no impacts, but might yield unexpected results in future modifications. I could change that.

There is an alternative approach in #181. As this one modifies late stage command processing, it might have a performance impact. The command syntax is different there:

```
redis['script load']('return 1');
redis.multi()['script load']('return 1').exec(...);
redis.multi([['script load', 'return 1']]).exec(...);
```
#### Ready to merge checklist
- [ ] test(s) in test.js
- [ ] tests will fail without the PR, but succeed once applied
- [ ] docs, if applicable
- [ ] merges cleanly
- [x] coding style (4-space indents, looks similar to other code)
