### PR TITLE
Fix "this" reference for parser_module

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,7 +244,7 @@ RedisClient.prototype.init_parser = function () {
         if (exports.debug_mode) {
             console.log("Using default parser module: " + parsers[0].name);
         }
-        this.parser_module = parsers[0];
+        self.parser_module = parsers[0];
     }
 
     this.parser_module.debug_mode = exports.debug_mode;


### PR DESCRIPTION
The intent here is to store the parser used in
RedisClient.parser_module, which works fine when explicitly setting
a parser by name, but the default parser case improperly assigns
the used parser to "this" instead of "self".
