### PR TITLE
Parser Fix Bundle

### DIFF
--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -117,13 +117,13 @@ ReplyParser.prototype._parseResult = function (type) {
         offset = this._offset;
         packetHeader = new Packet(type, this.parseHeader());
 
-        if (packetHeader.size > this._bytesRemaining()) {
-            this._offset = offset - 1;
-            return -1;
-        }
-
         if (packetHeader.size < 0) {
             return null;
+        }
+
+        if (packetHeader.size > this._bytesRemaining()) {
+            this._offset = offset - 1;
+            throw new IncompleteReadBuffer("Wait for more data.");
         }
 
         var reply = [ ];

--- a/test.js
+++ b/test.js
@@ -291,6 +291,35 @@ tests.MULTI_6 = function () {
         });
 };
 
+tests.MULTI_7 = function () {
+    var name = "MULTI_7";
+
+    if (bclient.reply_parser.name != "javascript") {
+        console.log("Skipping wire-protocol test for 3rd-party parser");
+        return next(name);
+    }
+
+    var p = require("./lib/parser/javascript");
+    var parser = new p.Parser(false);
+    var reply_count = 0;
+    function check_reply(reply) {
+        assert.deepEqual(reply, [['a']], "Expecting multi-bulk reply of [['a']]");
+        reply_count++;
+        assert.notEqual(reply_count, 4, "Should only parse 3 replies");
+    }
+    parser.on("reply", check_reply);
+
+    parser.execute(new Buffer('*1\r\n*1\r\n$1\r\na\r\n'));
+
+    parser.execute(new Buffer('*1\r\n*1\r'));
+    parser.execute(new Buffer('\n$1\r\na\r\n'));
+
+    parser.execute(new Buffer('*1\r\n*1\r\n'));
+    parser.execute(new Buffer('$1\r\na\r\n'));
+
+    next(name);
+};
+
 tests.FWD_ERRORS_1 = function () {
     var name = "FWD_ERRORS_1";
 


### PR DESCRIPTION
Includes three key fixes for the built-in parser:
1. Correctly bubbles non-parser exceptions back to the caller.
2. Fixes an offset error on WATCH/MULTI/EXEC aborted transactions.
3. Fixes a command queue error when a TCP packet break is in the middle of a nested MULTIBULK reply, which causes a cascade of errors.

This replaces PR #361 and fixes #377 #289 #373 #364 #325 and probably #316
