### PR TITLE
only execute callback when callback exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -710,7 +710,7 @@ RedisClient.prototype.send_command = function (command, args, callback) {
     if (command === 'set' || command === 'setex') {
         if(args[args.length - 1] === undefined || args[args.length - 1] === null) {
             var err = new Error('send_command: ' + command + ' value must not be undefined or null');
-            return callback(err);
+            return callback && callback(err);
         }
     }
     

--- a/test.js
+++ b/test.js
@@ -1780,6 +1780,8 @@ tests.OPTIONAL_CALLBACK_UNDEFINED = function () {
     client.del("op_cb2");
     client.set("op_cb2", "y", undefined);
     client.get("op_cb2", last(name, require_string("y", name)));
+
+    client.set("op_cb_undefined", undefined, undefined);
 };
 
 tests.ENABLE_OFFLINE_QUEUE_TRUE = function () {


### PR DESCRIPTION
because document said: Note that in either form the callback is optional

callback in  send_command function may be undefined. 

so only execute callback when callback exists
