### PR TITLE
Export utils and commands to share (with sentinel client, or others)

### DIFF
--- a/index.js
+++ b/index.js
@@ -886,6 +886,8 @@ commands = set_union(["get", "set", "setnx", "setex", "append", "strlen", "del",
     "persist", "slaveof", "debug", "config", "subscribe", "unsubscribe", "psubscribe", "punsubscribe", "publish", "watch", "unwatch", "cluster",
     "restore", "migrate", "dump", "object", "client", "eval", "evalsha"], require("./lib/commands"));
 
+exports.commands = commands;
+
 commands.forEach(function (fullCommand) {
     var command = fullCommand.split(' ')[0];
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var net = require("net"),
     util = require("./lib/util"),
+    reply_to_object = require("./lib/utils").reply_to_object,
     Queue = require("./lib/queue"),
     to_array = require("./lib/to_array"),
     events = require("events"),
@@ -535,23 +536,6 @@ function try_callback(callback, reply) {
             throw err;
         });
     }
-}
-
-// hgetall converts its replies to an Object.  If the reply is empty, null is returned.
-function reply_to_object(reply) {
-    var obj = {}, j, jl, key, val;
-
-    if (reply.length === 0) {
-        return null;
-    }
-
-    for (j = 0, jl = reply.length; j < jl; j += 2) {
-        key = reply[j].toString();
-        val = reply[j + 1];
-        obj[key] = val;
-    }
-
-    return obj;
 }
 
 function reply_to_strings(reply) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,20 @@
+// hgetall converts its replies to an Object.  If the reply is empty, null is returned.
+function reply_to_object(reply) {
+    var obj = {}, j, jl, key, val;
+
+    if (reply.length === 0) {
+        return null;
+    }
+
+    for (j = 0, jl = reply.length; j < jl; j += 2) {
+        key = reply[j].toString();
+        val = reply[j + 1];
+        obj[key] = val;
+    }
+
+    return obj;
+}
+
+module.exports = {
+    reply_to_object: reply_to_object
+};

--- a/test_utils.js
+++ b/test_utils.js
@@ -1,0 +1,90 @@
+// test runner utils, separated from mranney's test.js.
+
+var assert = require('assert');
+
+exports.buffers_to_strings = function buffers_to_strings(arr) {
+    return arr.map(function (val) {
+        return val.toString();
+    });
+};
+
+exports.require_number = function require_number(expected, label, callback) {
+    return function (err, results) {
+        assert.strictEqual(null, err, label + " expected " + expected + ", got error: " + err);
+        assert.strictEqual(expected, results, label + " " + expected + " !== " + results);
+        assert.strictEqual(typeof results, "number", label);
+        if (typeof callback === 'function') callback();
+        return true;
+    };
+};
+
+exports.require_number_any = function require_number_any(label, callback) {
+    return function (err, results) {
+        assert.strictEqual(null, err, label + " expected any number, got error: " + err);
+        assert.strictEqual(typeof results, "number", label + " " + results + " is not a number");
+        if (typeof callback === 'function') callback();
+        return true;
+    };
+};
+
+exports.require_number_pos = function require_number_pos(label, callback) {
+    return function (err, results) {
+        assert.strictEqual(null, err, label + " expected positive number, got error: " + err);
+        assert.strictEqual(true, (results > 0), label + " " + results + " is not a positive number");
+        if (typeof callback === 'function') callback();
+        return true;
+    };
+};
+
+exports.require_string = function require_string(str, label, callback) {
+    return function (err, results) {
+        assert.strictEqual(null, err, label + " expected string '" + str + "', got error: " + err);
+        assert.strictEqual(str, results, label + " " + str + " does not match " + results);
+        if (typeof callback === 'function') callback();
+        return true;
+    };
+};
+
+exports.require_null = function require_null(label, callback) {
+    return function (err, results) {
+        assert.strictEqual(null, err, label + " expected null, got error: " + err);
+        assert.strictEqual(null, results, label + ": " + results + " is not null");
+        if (typeof callback === 'function') callback();
+        return true;
+    };
+};
+
+exports.require_error = function require_error(label, callback) {
+    return function (err, results) {
+        assert.notEqual(err, null, label + " err is null, but an error is expected here.");
+        if (typeof callback === 'function') callback();
+        return true;
+    };
+};
+
+exports.is_empty_array = function is_empty_array(obj) {
+    return Array.isArray(obj) && obj.length === 0;
+};
+
+exports.server_version_at_least = function server_version_at_least(connection, desired_version) {
+    // Return true if the server version >= desired_version
+    var version = connection.server_info.versions;
+    for (var i = 0; i < 3; i++) {
+        if (version[i] > desired_version[i]) return true;
+        if (version[i] < desired_version[i]) return false;
+    }
+    return true;
+};
+
+
+function MockLogger(){
+  var self = this;
+  this.msgs = [];
+  this.toConsole = false;
+}
+MockLogger.prototype.log = function() {
+  var args = Array.prototype.slice.call(arguments);
+  this.msgs.push(args);
+  if (this.toConsole) console.log.apply(this, args);
+};
+exports.MockLogger = MockLogger;


### PR DESCRIPTION
This supports [redis-sentinel-client](https://github.com/DocuSignDev/node-redis-sentinel-client). It should not change or break any node_redis functionality, it simply separates and/or exports pieces that can be used by other modules. (Which should be good architecture regardless of the sentinel client or other modules using it.)

Thanks!