### PR TITLE
Flexible connections for sentinel support

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,11 @@ RedisClient.prototype.initialize_retry_vars = function () {
 
 // flush offline_queue and command_queue, erroring any items with a callback first
 RedisClient.prototype.flush_and_error = function (message) {
+
+    if (this.options.disable_flush) {
+        return;
+    }
+
     var command_obj;
     while (this.offline_queue.length > 0) {
         command_obj = this.offline_queue.shift();


### PR DESCRIPTION
This supports [redis-sentinel-client](https://github.com/DocuSignDev/node-redis-sentinel-client). The changes are mostly cherry-picked from [tanguylebarzic's fork](https://github.com/tanguylebarzic/node_redis) and [our/DocuSignDev's fork](https://github.com/DocuSignDev/node_redis).

There is a discussion about how to support sentinels here: https://github.com/mranney/node_redis/issues/302
The idea of supporting pluggable connection managers is mentioned there, and may be more robust. I'm submitting this PR so the changes needed for my sentinel implementation are documented.

Thank you.