### PR TITLE
Implemented unref option

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ function RedisClient(stream, options) {
     this.stream = stream;
     this.options = options = options || {};
 
+    if (options.unref) {
+      this.stream.unref();
+    }
     this.connection_id = ++connection_id;
     this.connected = false;
     this.ready = false;

--- a/test-unref.js
+++ b/test-unref.js
@@ -1,0 +1,11 @@
+var redis = require('./');
+
+var PORT = process.argv[2] || 6379;
+var HOST = process.argv[3] || '127.0.0.1';
+
+var client = redis.createClient(PORT, HOST, { unref: true });
+
+client.on('ready', function () {
+  // test fails if this is called
+  process.exit(-1);
+});

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ var redis = require("./index"),
     bclient = redis.createClient(PORT, HOST, { return_buffers: true }),
     assert = require("assert"),
     crypto = require("crypto"),
+    spawn = require("child_process").spawn,
     util = require("./lib/util"),
     test_db_num = 15, // this DB will be flushed and used for testing
     tests = {},
@@ -1981,6 +1982,16 @@ tests.reconnectRetryMaxDelay = function() {
             assert.ok(lasted < 1000);
             next(name);
         }
+    });
+};
+
+tests.unref = function () {
+    var name = 'unref';
+    var testunref = spawn('node', [ './test-unref.js', HOST, PORT ]);
+
+    testunref.on('exit', function (code) {
+        assert.notEqual(code, 255);
+        next(name);
     });
 };
 


### PR DESCRIPTION
If the `unref: true` option is passed, stream.unref() is called. This allow to have a redis client that does not suspend termination of a process.
