### PR TITLE
[fix] remove try catch wrapping around the callback thats passed in by the module user

### DIFF
--- a/index.js
+++ b/index.js
@@ -541,18 +541,6 @@ RedisClient.prototype.return_error = function (err) {
     }
 };
 
-// if a callback throws an exception, re-throw it on a new stack so the parser can keep going.
-// put this try/catch in its own function because V8 doesn't optimize this well yet.
-function try_callback(callback, reply) {
-    try {
-        callback(null, reply);
-    } catch (err) {
-        process.nextTick(function () {
-            throw err;
-        });
-    }
-}
-
 // hgetall converts its replies to an Object.  If the reply is empty, null is returned.
 function reply_to_object(reply) {
     var obj = {}, j, jl, key, val;
@@ -627,7 +615,7 @@ RedisClient.prototype.return_reply = function (reply) {
                 reply = reply_to_object(reply);
             }
 
-            try_callback(command_obj.callback, reply);
+            command_obj.callback(null, reply);
         } else if (exports.debug_mode) {
             console.log("no callback for reply: " + (reply && reply.toString && reply.toString()));
         }
@@ -653,7 +641,7 @@ RedisClient.prototype.return_reply = function (reply) {
                 // reply[1] can be null
                 var reply1String = (reply[1] === null) ? null : reply[1].toString();
                 if (command_obj && typeof command_obj.callback === "function") {
-                    try_callback(command_obj.callback, reply1String);
+                    command_obj.callback(null, reply1String);
                 }
                 this.emit(type, reply1String, reply[2]); // channel, count
             } else {


### PR DESCRIPTION
fixes #453. I don't see any reason to wrap the user's code in a try
catch as it can have unexpected consequences.