### PR TITLE
Fix TypeError when handling multi exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -1058,7 +1058,6 @@ Multi.prototype.exec = function (callback) {
                 } else {
                     errors.push(new Error(err));
                 }
-                self.queue.splice(index, 1);
             }
         });
     }, this);


### PR DESCRIPTION
When errors occurs using multi/exec, avoid "TypeError: Cannot read property 'length' of undefined"
