### PR TITLE
String is not an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,12 +114,15 @@ RedisClient.prototype.initialize_retry_vars = function () {
 
 // flush offline_queue and command_queue, erroring any items with a callback first
 RedisClient.prototype.flush_and_error = function (message) {
-    var command_obj;
+    var command_obj, error;
+
+    error = new Error(message);
+
     while (this.offline_queue.length > 0) {
         command_obj = this.offline_queue.shift();
         if (typeof command_obj.callback === "function") {
             try {
-                command_obj.callback(message);
+                command_obj.callback(error);
             } catch (callback_err) {
                 process.nextTick(function () {
                     throw callback_err;
@@ -133,7 +136,7 @@ RedisClient.prototype.flush_and_error = function (message) {
         command_obj = this.command_queue.shift();
         if (typeof command_obj.callback === "function") {
             try {
-                command_obj.callback(message);
+                command_obj.callback(error);
             } catch (callback_err) {
                 process.nextTick(function () {
                     throw callback_err;


### PR DESCRIPTION
RedisClient.prototype.flush_and_error now send error in callbacks instead of string. This will fix incorrect messages in  #464 (undefined in logs is not helpful at all).
