### PR TITLE
Fix for multi operations with detect_buffers enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -583,7 +583,7 @@ function reply_to_strings(reply) {
     if (Array.isArray(reply)) {
         for (i = 0; i < reply.length; i++) {
             if (reply[i] !== null && reply[i] !== undefined) {
-                reply[i] = reply[i].toString();
+                reply[i] = reply_to_strings(reply[i]);
             }
         }
         return reply;
@@ -1084,6 +1084,18 @@ Multi.prototype.exec = function (callback) {
             for (i = 1, il = self.queue.length; i < il; i += 1) {
                 reply = replies[i - 1];
                 args = self.queue[i];
+                var bufferArgs = false;
+                args.forEach(function(arg) { 
+                    if(Buffer.isBuffer(arg)) {
+                        bufferArgs = true;
+                        return false;
+                    }
+                });
+                if (self._client.options.detect_buffers && !bufferArgs) {
+                    // If detect_buffers option was specified, then the reply from the parser will be Buffers.
+                    // If this command did not use Buffer arguments, then convert the reply to Strings here.
+                    reply = reply_to_strings(reply); 
+                }
 
                 // TODO - confusing and error-prone that hgetall is special cased in two places
                 if (reply && args[0].toLowerCase() === "hgetall") {

--- a/index.js
+++ b/index.js
@@ -577,12 +577,7 @@ function reply_to_strings(reply) {
     var i;
 
     if (Buffer.isBuffer(reply)) {
-        if(reply.redisType == 58) { // :
-            return parseInt(reply.toString(), 10);
-        }
-        else {
-            return reply.toString();
-        }
+		return reply.toString();
     }
     if (Array.isArray(reply)) {
         for (i = 0; i < reply.length; i++) {

--- a/index.js
+++ b/index.js
@@ -577,9 +577,13 @@ function reply_to_strings(reply) {
     var i;
 
     if (Buffer.isBuffer(reply)) {
-        return reply.toString();
+        if(reply.redisType == 58) { // :
+            return parseInt(reply.toString(), 10);
+        }
+        else {
+            return reply.toString();
+        }
     }
-
     if (Array.isArray(reply)) {
         for (i = 0; i < reply.length; i++) {
             if (reply[i] !== null && reply[i] !== undefined) {

--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -59,7 +59,6 @@ ReplyParser.prototype._parseResult = function (type) {
 
         if (this.options.return_buffers) {
             buffer = this._buffer.slice(start, end);
-            buffer.redisType = type;
             return buffer;
         } else {
             if (end - start < 65536) { // completely arbitrary
@@ -79,12 +78,6 @@ ReplyParser.prototype._parseResult = function (type) {
         if (end > this._buffer.length) {
             this._offset = start;
             throw new IncompleteReadBuffer("Wait for more data.");
-        }
-
-        if (this.options.return_buffers) {
-            buffer = this._buffer.slice(start, end);
-            buffer.redisType = type;
-            return buffer;
         }
 
         // return the coerced numeric value
@@ -114,7 +107,6 @@ ReplyParser.prototype._parseResult = function (type) {
 
         if (this.options.return_buffers) {
             buffer = this._buffer.slice(start, end);
-            buffer.redisType = type;
             return buffer;
         } else {
             return this._buffer.toString(this._encoding, start, end);

--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -42,7 +42,7 @@ function small_toString(buf, start, end) {
 }
 
 ReplyParser.prototype._parseResult = function (type) {
-    var start, end, offset, packetHeader;
+    var start, end, offset, packetHeader, buffer;
 
     if (type === 43 || type === 45) { // + or -
         // up to the delimiter
@@ -58,7 +58,9 @@ ReplyParser.prototype._parseResult = function (type) {
         }
 
         if (this.options.return_buffers) {
-            return this._buffer.slice(start, end);
+            buffer = this._buffer.slice(start, end);
+            buffer.redisType = type;
+            return buffer;
         } else {
             if (end - start < 65536) { // completely arbitrary
                 return small_toString(this._buffer, start, end);
@@ -80,7 +82,9 @@ ReplyParser.prototype._parseResult = function (type) {
         }
 
         if (this.options.return_buffers) {
-            return this._buffer.slice(start, end);
+            buffer = this._buffer.slice(start, end);
+            buffer.redisType = type;
+            return buffer;
         }
 
         // return the coerced numeric value
@@ -109,7 +113,9 @@ ReplyParser.prototype._parseResult = function (type) {
         }
 
         if (this.options.return_buffers) {
-            return this._buffer.slice(start, end);
+            buffer = this._buffer.slice(start, end);
+            buffer.redisType = type;
+            return buffer;
         } else {
             return this._buffer.toString(this._encoding, start, end);
         }


### PR DESCRIPTION
This fixes #263 where multi operations that properly should return arrays, return strings instead when detect_buffers: true.