### PR TITLE
When handling the "error reply" event from the parser, we now bubble up ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,7 +279,11 @@ RedisClient.prototype.init_parser = function () {
 
     // "reply error" is an error sent back by Redis
     this.reply_parser.on("reply error", function (reply) {
-        self.return_error(new Error(reply));
+        if (reply instanceof Error) {
+            self.return_error(reply);
+        } else {
+            self.return_error(new Error(reply));
+        }
     });
     this.reply_parser.on("reply", function (reply) {
         self.return_reply(reply);


### PR DESCRIPTION
...the Error object if it's one instead of wrapping it in another Error.

I doubt this is related to #374, but I'll mention it just to avoid confusion.

Basically, the JavaScript parser returns errors as strings whereas the hiredis parser returns errors as Error objects. It means this piece of code used to wrap the reply Error object in a new Error object before returning it. The consequence of this is that the innermost Error object's .toString() got called to serve as the outermost Error object's error message. Error.toString() returns "Error: " + Error.message. Hence, if you were to use hiredis you would be stuck with "Error: " at the beginning of all your errors in your client, even in .message.
