### PR TITLE
Add an option to handle renamed commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,17 @@ function RedisClient(stream, options) {
 
     this.old_state = null;
 
+		if(typeof options.commands_renamed !== undefined) {
+			this.options._commands_renamed = {};
+			for(var key in options.commands_renamed) {
+				if(options.commands_renamed.hasOwnProperty(key)) {
+					this.options._commands_renamed[key.toLowerCase()] = options.commands_renamed[key];
+				}
+			}
+			this.options.commands_renamed = this.options._commands_renamed;
+			delete this.options._commands_renamed;
+		}
+
     var self = this;
 
     this.stream.on("connect", function () {
@@ -720,7 +731,7 @@ function Command(command, args, sub_command, buffer_args, callback) {
 }
 
 RedisClient.prototype.send_command = function (command, args, callback) {
-    var arg, command_obj, i, il, elem_count, buffer_args, stream = this.stream, command_str = "", buffered_writes = 0, last_arg_type, lcaseCommand;
+    var arg, command_obj, i, il, elem_count, buffer_args, stream = this.stream, command_str = "", buffered_writes = 0, last_arg_type, lcaseCommand, command_renamed;
 
     if (typeof command !== "string") {
         throw new Error("First argument to send_command must be the command name string, not " + typeof command);
@@ -818,7 +829,12 @@ RedisClient.prototype.send_command = function (command, args, callback) {
     // Always use "Multi bulk commands", but if passed any Buffer args, then do multiple writes, one for each arg.
     // This means that using Buffers in commands is going to be slower, so use Strings if you don't already have a Buffer.
 
-    command_str = "*" + elem_count + "\r\n$" + command.length + "\r\n" + command + "\r\n";
+		command_renamed = lcaseCommand;
+		if(typeof this.options.commands_renamed !== undefined && this.options.commands_renamed[command_renamed]) {
+			command_renamed = this.options.commands_renamed[command_renamed];
+		}
+
+    command_str = "*" + elem_count + "\r\n$" + command_renamed.length + "\r\n" + command_renamed + "\r\n";
 
     if (! buffer_args) { // Build up a string and send entire command in one write
         for (i = 0, il = args.length, arg; i < il; i += 1) {


### PR DESCRIPTION
redis.conf :
```
  rename-command SET 807081f5afa96845a02816a28b7258c3
  rename-command GET f397808a43ceca3963e22b4e13deb672
```

client.js :
```
  var client = redis.createClient(6379, 'localhost', {
    commands_renamed: {
      set: '807081f5afa96845a02816a28b7258c3'
    }
  });

  // will return 'OK'
  client.set('key', 'value', function(err, reply) {
    console.log(err, reply);
  });

  // will return error : [Error: ERR unknown command 'get'] undefined
  client.get('key', function(err, reply) {
    console.log(err, reply);
  });
```
