### PR TITLE
fix reconnection error when call client.end()

### DIFF
--- a/index.js
+++ b/index.js
@@ -920,6 +920,7 @@ RedisClient.prototype.end = function () {
     this.connected = false;
     this.ready = false;
     this.closing = true;
+    clearTimeout(this.retry_timer);
     return this.stream.destroySoon();
 };
 


### PR DESCRIPTION
When the client is waiting for reconnecting, and then call `client.end()`, it will throw a error.