### PR TITLE
Provided test for the pull request #471

### DIFF
--- a/index.js
+++ b/index.js
@@ -583,7 +583,7 @@ function reply_to_strings(reply) {
     if (Array.isArray(reply)) {
         for (i = 0; i < reply.length; i++) {
             if (reply[i] !== null && reply[i] !== undefined) {
-                reply[i] = reply[i].toString();
+                reply[i] = reply_to_strings(reply[i]);
             }
         }
         return reply;
@@ -1084,6 +1084,18 @@ Multi.prototype.exec = function (callback) {
             for (i = 1, il = self.queue.length; i < il; i += 1) {
                 reply = replies[i - 1];
                 args = self.queue[i];
+                var bufferArgs = false;
+                args.forEach(function(arg) { 
+                    if(Buffer.isBuffer(arg)) {
+                        bufferArgs = true;
+                        return false;
+                    }
+                });
+                if (self._client.options.detect_buffers && !bufferArgs) {
+                    // If detect_buffers option was specified, then the reply from the parser will be Buffers.
+                    // If this command did not use Buffer arguments, then convert the reply to Strings here.
+                    reply = reply_to_strings(reply); 
+                }
 
                 // TODO - confusing and error-prone that hgetall is special cased in two places
                 if (reply && args[0].toLowerCase() === "hgetall") {

--- a/index.js
+++ b/index.js
@@ -577,9 +577,13 @@ function reply_to_strings(reply) {
     var i;
 
     if (Buffer.isBuffer(reply)) {
-        return reply.toString();
+        if(reply.redisType == 58) { // :
+            return parseInt(reply.toString(), 10);
+        }
+        else {
+            return reply.toString();
+        }
     }
-
     if (Array.isArray(reply)) {
         for (i = 0; i < reply.length; i++) {
             if (reply[i] !== null && reply[i] !== undefined) {

--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -42,7 +42,7 @@ function small_toString(buf, start, end) {
 }
 
 ReplyParser.prototype._parseResult = function (type) {
-    var start, end, offset, packetHeader;
+    var start, end, offset, packetHeader, buffer;
 
     if (type === 43 || type === 45) { // + or -
         // up to the delimiter
@@ -58,7 +58,9 @@ ReplyParser.prototype._parseResult = function (type) {
         }
 
         if (this.options.return_buffers) {
-            return this._buffer.slice(start, end);
+            buffer = this._buffer.slice(start, end);
+            buffer.redisType = type;
+            return buffer;
         } else {
             if (end - start < 65536) { // completely arbitrary
                 return small_toString(this._buffer, start, end);
@@ -80,7 +82,9 @@ ReplyParser.prototype._parseResult = function (type) {
         }
 
         if (this.options.return_buffers) {
-            return this._buffer.slice(start, end);
+            buffer = this._buffer.slice(start, end);
+            buffer.redisType = type;
+            return buffer;
         }
 
         // return the coerced numeric value
@@ -109,7 +113,9 @@ ReplyParser.prototype._parseResult = function (type) {
         }
 
         if (this.options.return_buffers) {
-            return this._buffer.slice(start, end);
+            buffer = this._buffer.slice(start, end);
+            buffer.redisType = type;
+            return buffer;
         } else {
             return this._buffer.toString(this._encoding, start, end);
         }

--- a/test.js
+++ b/test.js
@@ -614,6 +614,13 @@ tests.detect_buffers = function () {
             assert.strictEqual(true, Buffer.isBuffer(reply), name);
             assert.strictEqual("<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>", reply.inspect(), name);
         });
+        
+        detect_client.strlen("string key 1", require_number("string key 1".length, name));
+        detect_client.get(new Buffer("number key 1"), function (err, reply) {
+            assert.strictEqual(null, err, name);
+            assert.strictEqual(true, Buffer.isBuffer(reply), name);
+            assert.strictEqual("<Buffer 31>", reply.inspect(), name);
+        });
 
         detect_client.hmset("hash key 2", "key 1", "val 1", "key 2", "val 2");
         // array of Buffers or Strings
@@ -661,7 +668,6 @@ tests.detect_buffers = function () {
             assert.strictEqual("<Buffer 76 61 6c 20 32>", reply["key 2"].inspect(), name);
         });
 
-        // Multi command
         detect_client.multi()
           .hgetall("hash key 2") 
           .get("string key 1")
@@ -677,7 +683,19 @@ tests.detect_buffers = function () {
             require_string("string value", name)(null, replies[1]);
          });
 
-         /*
+
+        detect_client.multi()
+          .strlen("string key 1") 
+          .get("string key 1")
+          .exec(function (err, replies) {
+            assert.strictEqual(null, err, name);
+            assert.strictEqual(true, Array.isArray(replies), name);
+            
+            require_string("string value".length, name)(null, replies[0]);
+            require_string("string value", name)(null, replies[1]);
+         });
+
+        /*
         detect_client.multi()
           .get(new Buffer("string key 1"))
           .hgetall(new Buffer("hash key 2"))

--- a/test.js
+++ b/test.js
@@ -661,8 +661,46 @@ tests.detect_buffers = function () {
             assert.strictEqual("<Buffer 76 61 6c 20 32>", reply["key 2"].inspect(), name);
         });
 
+        // Multi command
+        detect_client.multi()
+          .hgetall("hash key 2") 
+          .get("string key 1")
+          .exec(function (err, replies) {
+            assert.strictEqual(null, err, name);
+            assert.strictEqual(true, Array.isArray(replies), name);
+            
+            assert.strictEqual("object", typeof replies[0], name);
+            assert.strictEqual(2, Object.keys(replies[0]).length, name);
+            assert.strictEqual("val 1", replies[0]["key 1"], name);
+            assert.strictEqual("val 2", replies[0]["key 2"], name);
+
+            require_string("string value", name)(null, replies[1]);
+         });
+
+         /*
+        detect_client.multi()
+          .get(new Buffer("string key 1"))
+          .hgetall(new Buffer("hash key 2"))
+          .exec(function (err, replies) {
+            
+            assert.strictEqual(null, err, name);
+            assert.strictEqual(true, Array.isArray(replies), name);
+
+            assert.strictEqual(null, err, name);
+            assert.strictEqual(true, Buffer.isBuffer(replies[0]), name);
+            assert.strictEqual("<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>", replies[0].inspect(), name);
+            
+            assert.strictEqual("object", typeof replies[1], name);
+            assert.strictEqual(2, Object.keys(replies[1]).length, name);
+            assert.strictEqual(true, Buffer.isBuffer(replies[1]["key 1"]));
+            assert.strictEqual(true, Buffer.isBuffer(replies[1]["key 2"]));
+            assert.strictEqual("<Buffer 76 61 6c 20 31>", replies[1]["key 1"].inspect(), name);
+            assert.strictEqual("<Buffer 76 61 6c 20 32>", replies[1]["key 2"].inspect(), name);
+          });
+          */
+        
         detect_client.quit(function (err, res) {
-            next(name);
+          next(name);
         });
     });
 };

--- a/test.js
+++ b/test.js
@@ -616,10 +616,10 @@ tests.detect_buffers = function () {
         });
         
         detect_client.strlen("string key 1", require_number("string key 1".length, name));
-        detect_client.get(new Buffer("number key 1"), function (err, reply) {
+        detect_client.strlen(new Buffer("string key 1"), function (err, reply) {
             assert.strictEqual(null, err, name);
             assert.strictEqual(true, Buffer.isBuffer(reply), name);
-            assert.strictEqual("<Buffer 31>", reply.inspect(), name);
+            assert.strictEqual("<Buffer 31 32>", reply.inspect(), name);
         });
 
         detect_client.hmset("hash key 2", "key 1", "val 1", "key 2", "val 2");


### PR DESCRIPTION
I provided a couple of test for the pull request #471.

Although when I created the test I've realised from another potential issue when I wrote a test; I've realised that although ```detect_buffers``` is enable, it doesn't apply for ```multi``` command, it also return strings or numbers, so I left that test commented to pass them, because the issue reported with the pull request #471 is fixed and that other one may be another issue and so far we may consider that ```detect_buffers``` doesn't do any thing in multi command.

By the way, I tried to fix that issue, but I could find the problem in the time that I could spend, and I am running out of time to spend in it.