### PR TITLE
Make retry vars still hold in an authrization failer

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,6 +229,8 @@ RedisClient.prototype.do_auth = function () {
 
         // now we are really connected
         self.emit("connect");
+        self.initialize_retry_vars();
+
         if (self.options.no_ready_check) {
             self.on_ready();
         } else {
@@ -248,7 +250,6 @@ RedisClient.prototype.on_connect = function () {
     this.connections += 1;
     this.command_queue = new Queue();
     this.emitted_end = false;
-    this.initialize_retry_vars();
     if (this.options.socket_nodelay) {
         this.stream.setNoDelay();
     }
@@ -260,6 +261,7 @@ RedisClient.prototype.on_connect = function () {
         this.do_auth();
     } else {
         this.emit("connect");
+        this.initialize_retry_vars();
 
         if (this.options.no_ready_check) {
             this.on_ready();


### PR DESCRIPTION
Only resetting the the retry_vars if the connection is actually established. Otherwise the reconnection could infinitely attempt to reconnect on an auth failure regardless of `max_attempts`, `retry_delay` etc. 

**Example:**
1. Send in `max_attempts:5`
2. Redis accepts the socket connection, but rejects at the auth level (invalid auth, max clients etc)
3. `node_redis` thought the connection was successful and reset the rety_vars 
4. However, `do_auth` emits an `error` event on a failure auth, which starts a reconnection

This change only resets the retry variables if the connection was actually successful. 
