### PR TITLE
added check for null or undefined to last argument in each command in th...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1073,7 +1073,9 @@ Multi.prototype.exec = function (callback) {
     // TODO - get rid of all of these anonymous functions which are elegant but slow
     this.queue.forEach(function (args, index) {
         var command = args[0], obj;
-        if (typeof args[args.length - 1] === "function") {
+        
+		// if the last argument is null, undefined or a function remove it from processing.
+        if (typeof args[args.length - 1] "function" || /null|undefined/.test(args[args.length - 1])) {
             args = args.slice(1, -1);
         } else {
             args = args.slice(1);

--- a/index.js
+++ b/index.js
@@ -1072,10 +1072,12 @@ Multi.prototype.exec = function (callback) {
     // drain queue, callback will catch "QUEUED" or error
     // TODO - get rid of all of these anonymous functions which are elegant but slow
     this.queue.forEach(function (args, index) {
-        var command = args[0], obj;
+        var command = args[0],
+			finalArg = args[args.length - 1],
+			obj;
         
 		// if the last argument is null, undefined or a function remove it from processing.
-        if (typeof args[args.length - 1] "function" || /null|undefined/.test(args[args.length - 1])) {
+        if (typeof finalArg == "function" || /null|undefined/.test(finalArg)) {
             args = args.slice(1, -1);
         } else {
             args = args.slice(1);


### PR DESCRIPTION
Hello!

I'm writing a node-redis ORM of sorts at the moment and I've come across an issue. It's not a blocking issue but the change would assist the creation of higher-level modules. The easiest way to explain this is with examples, so here goes:

Here is a higher-level function I have written, the function obviously shouldn't care whether the **client** arguments is a single or multi client, 

```javascript
function createIndexForKey(client, key, value, resourceId, cb) {

	var args = [
		KEY_PREFIX + ':' + key + ':' + value + ':id',
		KEY_PREFIX + ':' + resourceId
	];

	if(cb){
		args.push(cb);
	}

	client.set.apply(this, args);
}
```

Here's how it would look with the change:

```javascript
function createIndexForKey(client, key, value, resourceId, cb) {
	client.set(KEY_PREFIX + ':' + key + ':' + value + ':id', KEY_PREFIX + ':' + resourceId, cb)
});
```

Where the issue lies is that the incoming **cb** argument may be null or undefined, so when **client** is a multi client, the null or undefined pointer is passed into the set function and added to the queue as a command argument. This then causes an error during the Multi.exec call as the pointer is processed.

Please ask if you need a better explanation.

Lee.