### PR TITLE
Add code property to redis errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,7 +302,15 @@ RedisClient.prototype.init_parser = function () {
         if (reply instanceof Error) {
             self.return_error(reply);
         } else {
-            self.return_error(new Error(reply));
+            var err, match = /^([A-Z]+)\s+(.+)$/.exec(reply);
+            if (match) {
+                err = new Error(match[2]);
+                err.code = match[1];
+            } else {
+                err = new Error(reply);
+                err.code = 'ERR';
+            }
+            self.return_error(err);
         }
     });
     this.reply_parser.on("reply", function (reply) {


### PR DESCRIPTION
The [redis protocol](http://redis.io/topics/protocol) implies all error responses will begin with an all-caps error code, which could be included in the `code` property of the parsed error object.

```js
function require_error(label, code) {
  return function (err, results) {
    assert.notEqual(err, null, label + " err is null, but an error is expected here.");
    assert.strictEqual(err.code, code, label + " expected err with code " + code + ", got code: " + err.code);
    return true;
  };
}

client.evalsha("ffffffffffffffffffffffffffffffffffffffff", 0, require_error("EVALSHA", "NOSCRIPT"));
```