### PR TITLE
Fix TypeError: Cannot call method 'toString' of null

### DIFF
--- a/index.js
+++ b/index.js
@@ -365,7 +365,7 @@ RedisClient.prototype.on_info_cmd = function (err, res) {
     var self = this, obj = {}, lines, retry_time;
 
     if (err || !res) {
-        return self.emit("error", new Error("Ready check failed: " + err.message));
+        return self.emit("error", new Error("Ready check failed: " + (err && err.message)));
     }
 
     lines = res.toString().split("\r\n");

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ RedisClient.prototype.on_ready = function () {
 RedisClient.prototype.on_info_cmd = function (err, res) {
     var self = this, obj = {}, lines, retry_time;
 
-    if (err) {
+    if (err || !res) {
         return self.emit("error", new Error("Ready check failed: " + err.message));
     }
 


### PR DESCRIPTION
It should emit an error rather than throw an uncaught exception.  From our logs:

```
uncaughtException : TypeError: Cannot call method 'toString' of null
at RedisClient.on_info_cmd (/data/storify/api/node_modules/redis/index.js:320:17)
at /data/storify/api/node_modules/redis/index.js:365:14
at try_callback (/data/storify/api/node_modules/redis/index.js:520:9)
at RedisClient.return_reply (/data/storify/api/node_modules/redis/index.js:590:13)
at ReplyParser.<anonymous> (/data/storify/api/node_modules/redis/index.js:263:14)
at EventEmitter.emit (events.js:95:17)
at ReplyParser.send_reply (/data/storify/api/node_modules/redis/lib/parser/javascript.js:297:10)
at ReplyParser.execute (/data/storify/api/node_modules/redis/lib/parser/javascript.js:198:22)
at RedisClient.on_data (/data/storify/api/node_modules/redis/index.js:476:27)
at Socket.<anonymous> (/data/storify/api/node_modules/redis/index.js:79:14)
at EventEmitter.emit (events.js:95:17)
at Socket.<anonymous> (_stream_readable.js:746:14)
at EventEmitter.emit (events.js:92:17)
at emitReadable_ (_stream_readable.js:408:10)
at emitReadable (_stream_readable.js:404:5)
at readableAddChunk (_stream_readable.js:165:9)
at Readable.push (_stream_readable.js:127:10)
at onread (net.js:526:21)
```