### PR TITLE
Failing send_command faster when there's no connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -747,6 +747,11 @@ RedisClient.prototype.send_command = function (command, args, callback) {
 
     if (callback && process.domain) callback = process.domain.bind(callback);
 
+    if (callback && !this.connected) {
+        callback(new Error('Not connected'));
+        return;
+    }
+
     // if the last argument is an array and command is sadd or srem, expand it out:
     //     client.sadd(arg1, [arg2, arg3, arg4], cb);
     //  converts to:


### PR DESCRIPTION
When redis is down, issuing commands takes a long time to fail (sometimes 3~5 seconds) because its trying to talk with a disconnected redis. 

I'm just checking the state and failing faster if there's no connection.
