### PR TITLE
Handle undefined redis_version

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,9 +378,11 @@ RedisClient.prototype.on_info_cmd = function (err, res) {
     });
 
     obj.versions = [];
-    obj.redis_version.split('.').forEach(function (num) {
-        obj.versions.push(+num);
-    });
+    if( obj.redis_version ){
+        obj.redis_version.split('.').forEach(function (num) {
+            obj.versions.push(+num);
+        });
+    }
 
     // expose info key/vals to users
     this.server_info = obj;


### PR DESCRIPTION
Apparently some servers don't send the redis_version with the INFO command (_cough_ redis cloud _cough_). This causes the app to crash violently (yay node!).
