### PR TITLE
If there's an error in SELECT and there's no callback, emit the error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -978,6 +978,8 @@ RedisClient.prototype.select = function (db, callback) {
         }
         if (typeof(callback) === 'function') {
             callback(err, res);
+        } else if (err) {
+            self.emit('error', err);
         }
     });
 };

--- a/test.js
+++ b/test.js
@@ -865,6 +865,16 @@ tests.reconnect_select_db_after_pubsub = function() {
     });
 };
 
+tests.select_error_emits_if_no_callback = function () {
+    var name = "select_error_emits_if_no_callback";
+
+    client.on('error', with_timeout(name, function (err) {
+        require_error(name)(err);
+        next(name);
+    }, 500));
+    client.select(9999);
+};
+
 tests.idle = function () {
   var name = "idle";
 


### PR DESCRIPTION
When SELECT is called without a callback, and there's an error (for example, trying to SELECT a DB > 15 when the database number is set to 16 in redis.conf), it should be emitted from the client. Prior to this Pull Request, it would fail silently.
