### PR TITLE
fix #537 hmset do not save null field

### DIFF
--- a/index.js
+++ b/index.js
@@ -1039,6 +1039,7 @@ RedisClient.prototype.hmset = function (args, callback) {
         tmp_keys = Object.keys(args[1]);
         for (i = 0, il = tmp_keys.length; i < il ; i++) {
             key = tmp_keys[i];
+            if(args[1][key] == null) continue;
             tmp_args.push(key);
             tmp_args.push(args[1][key]);
         }


### PR DESCRIPTION
We offen make an mistake that save null value to 'null' string and undefined value to 'undefined' string.

If you're trying to remove a field value from an existing hash you should likely be using HDEL anyway.

see #537.