### PR TITLE
param socket_keepalive to set keep-alive on socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ every command on a client.
 * `socket_nodelay`: defaults to `true`. Whether to call setNoDelay() on the TCP stream, which disables the
 Nagle algorithm on the underlying socket.  Setting this option to `false` can result in additional throughput at the
 cost of more latency.  Most applications will want this set to `true`.
+* `socket_keepalive` defaults to `false`. Whether the keep-alive functionality is enabled on the underlying socket. 
 * `no_ready_check`: defaults to `false`. When a connection is established to the Redis server, the server might still
 be loading the database from disk.  While loading, the server not respond to any commands.  To work around this,
 `node_redis` has a "ready check" which sends the `INFO` command to the server.  The response from the `INFO` command

--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@ function RedisClient(stream, options) {
     if (this.options.socket_nodelay === undefined) {
         this.options.socket_nodelay = true;
     }
+    if (this.options.socket_keepalive === undefined) {
+        this.options.socket_keepalive = false;
+    }
     this.should_buffer = false;
     this.command_queue_high_water = this.options.command_queue_high_water || 1000;
     this.command_queue_low_water = this.options.command_queue_low_water || 0;
@@ -249,6 +252,7 @@ RedisClient.prototype.on_connect = function () {
     if (this.options.socket_nodelay) {
         this.stream.setNoDelay();
     }
+    this.stream.setKeepAlive(this.options.socket_keepalive);
     this.stream.setTimeout(0);
 
     this.init_parser();


### PR DESCRIPTION
Provide an option to enable [`setKeepAlive`](http://nodejs.org/api/net.html#net_socket_setkeepalive_enable_initialdelay) on the node TCP Socket for long running connections. This is a better option than pinging manually as mentioned in https://github.com/mranney/node_redis/issues/530 and https://github.com/mranney/node_redis/issues/247
