### PR TITLE
Ignore errors after .end() is called instead of causing an uncaught exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -908,6 +908,7 @@ RedisClient.prototype.pub_sub_command = function (command_obj) {
 
 RedisClient.prototype.end = function () {
     this.stream._events = {};
+    this.stream.on('error', function() { /* ignore future errors to prevent uncatchable exceptoin */ });
     this.connected = false;
     this.ready = false;
     this.closing = true;


### PR DESCRIPTION
Currently, it is possible for an error to occur on the stream after .end() is called, which clears event listeners.  This results in an uncaught exception.  In particular, if a connection is pending while .end() is called, then fails (with something like ECONNREFUSED), it triggers an uncaught exception.  This commit causes it to ignore errors after .end() is called.