### PR TITLE
Check that `process.domain` still exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -573,9 +573,10 @@ function try_callback(client, callback, reply) {
         callback(null, reply);
     } catch (err) {
         if (process.domain) {
-            process.domain.emit('error', err);
-            if (process.domain) {
-                process.domain.exit();
+            var currDomain = process.domain;
+            currDomain.emit('error', err);
+            if (process.domain === currDomain) {
+                currDomain.exit();
             }
         } else {
             client.emit("error", err);


### PR DESCRIPTION
There is a `domain` edge case where a user of domains may do something like

``` js
domain.on('error', function () {
  this.exit();
})
```

This causes a cascading failure in redis where it either exits the NEXT domain up the stack or tries to invoke `.exit()` of null.

I think this usage of domains is actually a user / programmer error but redis should still gaurd against it.

cc @sh1mmer
