### PR TITLE
Added rethrowing of callback errors when there is no domain active on a new stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .tern-port
+.project

--- a/index.js
+++ b/index.js
@@ -576,7 +576,9 @@ function try_callback(client, callback, reply) {
             process.domain.emit('error', err);
             process.domain.exit();
         } else {
-            client.emit("error", err);
+            process.nextTick(function() {
+                throw err;
+            });
         }
     }
 }

--- a/test.js
+++ b/test.js
@@ -408,9 +408,10 @@ tests.FWD_ERRORS_2 = function () {
     var toThrow = new Error("Forced exception");
     var recordedError = null;
 
-    var originalHandler = client.listeners("error").pop();
-    client.removeAllListeners("error");
-    client.once("error", function (err) {
+    var originalHandler = process.listeners("uncaughtException")[0];
+    process.removeAllListeners("uncaughtException");
+
+    process.once("uncaughtException", function (err) {
         recordedError = err;
     });
 
@@ -419,7 +420,7 @@ tests.FWD_ERRORS_2 = function () {
     });
 
     setTimeout(function () {
-        client.listeners("error").push(originalHandler);
+        process.on("uncaughtException", originalHandler);
         assert.equal(recordedError, toThrow, "Should have caught our forced exception");
         next(name);
     }, 150);
@@ -954,7 +955,7 @@ tests.HMGET = function () {
     client.HMSET(key3, {
         "0123456789": "abcdefghij",
         "some manner of key": "a type of value"
-    }, require_string("OK", name));    
+    }, require_string("OK", name));
 
     client.HMGET(key1, "0123456789", "some manner of key", function (err, reply) {
         assert.strictEqual("abcdefghij", reply[0].toString(), name);


### PR DESCRIPTION
See:
https://github.com/mranney/node_redis/issues/591
