### PR TITLE
fixed RedisClient.prototype.end not clear this.retry_timer

### DIFF
--- a/index.js
+++ b/index.js
@@ -909,12 +909,12 @@ RedisClient.prototype.pub_sub_command = function (command_obj) {
 RedisClient.prototype.end = function () {
     this.stream._events = {};
 
+    //clear retry_timer
     if(this.retry_timer){
         clearTimeout(this.retry_timer);
         this.retry_timer=null;
-        this.stream.on("error", function(){
-        });
     }
+    this.stream.on("error", function(){});
 
     this.connected = false;
     this.ready = false;


### PR DESCRIPTION
we call redisClient.end(),but the redisClient.end function does not clear this.retry_timer,and remove all stream event listeners.there is no listener processing 'error' event.
this.retry_timer is waiting for timeout to reconnect redis.
when redis is closed,this.stream will throw "error" event,redisClient does not catch it.and the process will exit.

see https://github.com/mranney/node_redis/issues/476#issuecomment-44226272
thanks.
