### PR TITLE
Don't bind to domain, it prevents callbacks from execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -565,22 +565,6 @@ RedisClient.prototype.return_error = function (err) {
     }
 };
 
-// if a callback throws an exception, re-throw it on a new stack so the parser can keep going.
-// if a domain is active, emit the error on the domain, which will serve the same function.
-// put this try/catch in its own function because V8 doesn't optimize this well yet.
-function try_callback(client, callback, reply) {
-    try {
-        callback(null, reply);
-    } catch (err) {
-        if (process.domain) {
-            process.domain.emit('error', err);
-            process.domain.exit();
-        } else {
-            client.emit("error", err);
-        }
-    }
-}
-
 // hgetall converts its replies to an Object.  If the reply is empty, null is returned.
 function reply_to_object(reply) {
     var obj = {}, j, jl, key, val;
@@ -658,7 +642,7 @@ RedisClient.prototype.return_reply = function (reply) {
                 reply = reply_to_object(reply);
             }
 
-            try_callback(this, command_obj.callback, reply);
+            command_obj.callback(undefined, reply);
         } else if (exports.debug_mode) {
             console.log("no callback for reply: " + (reply && reply.toString && reply.toString()));
         }
@@ -684,7 +668,7 @@ RedisClient.prototype.return_reply = function (reply) {
                 // reply[1] can be null
                 var reply1String = (reply[1] === null) ? null : reply[1].toString();
                 if (command_obj && typeof command_obj.callback === "function") {
-                    try_callback(this, command_obj.callback, reply1String);
+                    command_obj.callback(undefined, reply1String);
                 }
                 this.emit(type, reply1String, reply[2]); // channel, count
             } else {


### PR DESCRIPTION
I ran in to this really obsecure bug that when using redis together with domains it prevented the callbacks from being executed. After hours long of debugging I managed to track it down to removed line below.

The removal should not affect the domains support it self as the `try_callback` method that executes the callbacks already does a domain check, emits the errors and closes the domain.
