### PR TITLE
add specific event type

### DIFF
--- a/index.js
+++ b/index.js
@@ -668,6 +668,7 @@ RedisClient.prototype.return_reply = function (reply) {
 
             if (type === "message") {
                 this.emit("message", reply[1].toString(), reply[2]); // channel, message
+                this.emit(reply[1].toString(), reply[2]);
             } else if (type === "pmessage") {
                 this.emit("pmessage", reply[1].toString(), reply[2].toString(), reply[3]); // pattern, channel, message
             } else if (type === "subscribe" || type === "unsubscribe" || type === "psubscribe" || type === "punsubscribe") {


### PR DESCRIPTION
The way I see it, there are two distinct types of events used with redis: worker queue and events. The main difference is that with the first, an event needs to be handled once, with the 2nd - multiple number of times.

When using redis the 2nd way, you usually have limited SHARED clients (because you don't want to have one connection to redis per client), and so each client in effect receives EVERYONE's messages, and filters them - this is error prone and heavy because it needs to be done for each client.

This change makes it possible to only listen to the event you subscribe to.
