### PR TITLE
Improving server_info

### DIFF
--- a/index.js
+++ b/index.js
@@ -362,7 +362,7 @@ RedisClient.prototype.on_ready = function () {
 };
 
 RedisClient.prototype.on_info_cmd = function (err, res) {
-    var self = this, obj = {}, lines, retry_time;
+    var self = this, obj = {}, lines, retry_time, sub_lines;
 
     if (err) {
         return self.emit("error", new Error("Ready check failed: " + err.message));
@@ -373,7 +373,18 @@ RedisClient.prototype.on_info_cmd = function (err, res) {
     lines.forEach(function (line) {
         var parts = line.split(':');
         if (parts[1]) {
-            obj[parts[0]] = parts[1];
+            if (/^db[0-9]*$/.test(parts[0])) {
+              obj[parts[0]] = {};
+                sub_lines = parts[1].split(',');
+                sub_lines.forEach(function (sub_line) {
+                    var sub_parts = sub_line.split('=');
+                    if (sub_parts[1]) {
+                        obj[parts[0]][sub_parts[0]] = sub_parts[1];
+                    }
+                });
+            } else {
+                obj[parts[0]] = parts[1];
+            }
         }
     });
 

--- a/test.js
+++ b/test.js
@@ -144,6 +144,16 @@ tests.INCR = function () {
     });
 };
 
+tests.INFO = function() {
+    var name = "INFO";
+    client.set( "key", "value", function(err, result) {
+        client.info(function(err, result) {
+          assert.equal(client.server_info.db0.hasOwnProperty("keys"), true)
+          next(name);
+        });
+    });
+}
+
 tests.MULTI_1 = function () {
     var name = "MULTI_1", multi1, multi2;
 


### PR DESCRIPTION
Improving server_info object by parsing the db* keys of redis-info.
earlier it was
server_info = { .. 
 db0: 'keys=1,expires=0,avg_ttl=0',
  db9: 'keys=49,expires=49,avg_ttl=2588996447',
.. }
changed this to
server_info = { ..
  db0: { keys: '1', expires: '0', avg_ttl: '0' },
  db9: { keys: '49', expires: '49', avg_ttl: '2588996447' }
..}