### PR TITLE
Improve the validation of auth_pass

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ RedisClient.prototype.on_connect = function () {
 
     this.init_parser();
 
-    if (this.auth_pass !== undefined) {
+    if (this.auth_pass != undefined) { // use != to coalesce null and undefined
         this.do_auth();
     } else {
         this.emit("connect");

--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ RedisClient.prototype.on_connect = function () {
 
     this.init_parser();
 
-    if (this.auth_pass) {
+    if (this.auth_pass !== undefined) {
         this.do_auth();
     } else {
         this.emit("connect");


### PR DESCRIPTION
If ``auth_pass`` is set, but the value is falsy (e.g: an empty string), ``do_auth`` will not be evaluated, so the callback of ``client.auth(pass, callback)`` will never be called. Instead of check ``if(auth_pass)``, now we use ``if(auth_pass !== undefined)`` to prevent such situation.

Although pass the empty string or other falsy sutff as a password make no sense, but we should leave this validation to the redis and at least let the callback of ``client.auth(pass, callback)`` be evaluated. 