### PR TITLE
Emitting error event when connection permanently goes down

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ resume sending when you get `drain`.
 
 `client` will emit `idle` when there are no outstanding commands that are awaiting a response.
 
+### "reconnecting"
+
+`client` will emit `reconnecting` when trying to reconnect to the Redis server after losing the connection. Listeners
+are passed an object containing `delay` (in ms) and `attempt` (the attempt #) attributes.
+
 ## redis.createClient(port, host, options)
 
 Create a new client connection.  `port` defaults to `6379` and `host` defaults

--- a/index.js
+++ b/index.js
@@ -508,8 +508,10 @@ RedisClient.prototype.connection_gone = function (why) {
     if (this.max_attempts && this.attempts >= this.max_attempts) {
         this.retry_timer = null;
         // TODO - some people need a "Redis is Broken mode" for future commands that errors immediately, and others
-        // want the program to exit.  Right now, we just log, which doesn't really help in either case.
+        // want the program to exit.  Right now, we just log, which doesn't really help in either case, and emit
+        // an error event.
         console.error("node_redis: Couldn't get Redis connection after " + this.max_attempts + " attempts.");
+        this.emit('error', new Error("Redis connection in broken state"));
         return;
     }
 
@@ -529,6 +531,7 @@ RedisClient.prototype.connection_gone = function (why) {
             self.retry_timer = null;
             // TODO - engage Redis is Broken mode for future commands, or whatever
             console.error("node_redis: Couldn't get Redis connection after " + self.retry_totaltime + "ms.");
+            this.emit('error', new Error("Redis connection in broken state"));
             return;
         }
 


### PR DESCRIPTION
Also documenting the "reconnecting" event.

Happy to discuss this further, but either way, when working with sharded Redis instances (for instance using https://github.com/blindsey/redis-shard) it's helpful to have some way to know when a Redis server seems to have totally gone down so that we can send out alerts, remove it from the cluster, spin up another server, etc.