### PR TITLE
Sending Arrays in Redis Multi Commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -994,7 +994,14 @@ commands.forEach(function (fullCommand) {
     RedisClient.prototype[command.toUpperCase()] = RedisClient.prototype[command];
 
     Multi.prototype[command] = function () {
-        this.queue.push([command].concat(to_array(arguments)));
+        if(Array.isArray(arguments[0])){
+            this.queue.push([command].concat(arguments[0]));
+        }else if(Array.isArray(arguments[1])){
+            this.queue.push([command].concat([arguments[0]]).concat(arguments[1]));
+        }else{
+            this.queue.push([command].concat(to_array(arguments)));
+        }
+
         return this;
     };
     Multi.prototype[command.toUpperCase()] = Multi.prototype[command];

--- a/test.js
+++ b/test.js
@@ -300,25 +300,6 @@ tests.MULTI_4 = function () {
         });
 };
 
-tests.MULTI_4 = function () {
-    var name = "MULTI_4";
-
-    client.multi()
-        .mset('some', '10', 'keys', '20')
-        .incr('some')
-        .incr('keys')
-        .mget('some', 'keys')
-        .exec(function (err, replies) {
-            assert.strictEqual(null, err);
-            assert.equal('OK', replies[0]);
-            assert.equal(11, replies[1]);
-            assert.equal(21, replies[2]);
-            assert.equal(11, replies[3][0].toString());
-            assert.equal(21, replies[3][1].toString());
-            next(name);
-        });
-};
-
 tests.MULTI_5 = function () {
     var name = "MULTI_5";
 
@@ -332,6 +313,28 @@ tests.MULTI_5 = function () {
         assert.strictEqual(replies[0].length, 4, name);
         next(name);
     });
+};
+
+tests.MULTI_6 = function () {
+    var name = "MULTI_6";
+
+    client.multi()
+        .hmset("multihash", "a", "foo", "b", 1)
+        .hmset("multihash", {
+            extra: "fancy",
+            things: "here"
+        })
+        .hgetall("multihash")
+        .exec(function (err, replies) {
+            assert.strictEqual(null, err);
+            assert.equal("OK", replies[0]);
+            assert.equal(Object.keys(replies[2]).length, 4);
+            assert.equal("foo", replies[2].a);
+            assert.equal("1", replies[2].b);
+            assert.equal("fancy", replies[2].extra);
+            assert.equal("here", replies[2].things);
+            next(name);
+        });
 };
 
 tests.MULTI_7 = function () {

--- a/test.js
+++ b/test.js
@@ -300,6 +300,25 @@ tests.MULTI_4 = function () {
         });
 };
 
+tests.MULTI_4 = function () {
+    var name = "MULTI_4";
+
+    client.multi()
+        .mset('some', '10', 'keys', '20')
+        .incr('some')
+        .incr('keys')
+        .mget('some', 'keys')
+        .exec(function (err, replies) {
+            assert.strictEqual(null, err);
+            assert.equal('OK', replies[0]);
+            assert.equal(11, replies[1]);
+            assert.equal(21, replies[2]);
+            assert.equal(11, replies[3][0].toString());
+            assert.equal(21, replies[3][1].toString());
+            next(name);
+        });
+};
+
 tests.MULTI_5 = function () {
     var name = "MULTI_5";
 
@@ -313,28 +332,6 @@ tests.MULTI_5 = function () {
         assert.strictEqual(replies[0].length, 4, name);
         next(name);
     });
-};
-
-tests.MULTI_6 = function () {
-    var name = "MULTI_6";
-
-    client.multi()
-        .hmset("multihash", "a", "foo", "b", 1)
-        .hmset("multihash", {
-            extra: "fancy",
-            things: "here"
-        })
-        .hgetall("multihash")
-        .exec(function (err, replies) {
-            assert.strictEqual(null, err);
-            assert.equal("OK", replies[0]);
-            assert.equal(Object.keys(replies[2]).length, 4);
-            assert.equal("foo", replies[2].a);
-            assert.equal("1", replies[2].b);
-            assert.equal("fancy", replies[2].extra);
-            assert.equal("here", replies[2].things);
-            next(name);
-        });
 };
 
 tests.MULTI_7 = function () {
@@ -416,6 +413,23 @@ tests.MULTI_8 = function () {
             next(name);
         });
     });
+};
+
+tests.MULTI_9 = function () {
+    var name = "MULTI_9";
+
+    client.multi()
+        .zadd("foobar", [1, "foo", 2, "bar"])
+        .expire("foobar", 20)
+        .zrange(["foobar", 0, -1])
+        .exec(function (err, replies) {
+            assert.strictEqual(null, err);
+            assert.equal(2, replies[0]);
+            assert.equal(1, replies[1]);
+            assert.equal("foo", replies[2][0]);
+            assert.equal("bar", replies[2][1]);
+            next(name);
+        });
 };
 
 tests.FWD_ERRORS_1 = function () {


### PR DESCRIPTION
While chaining multiple commands to client.multi(), the commands only accepted comma separated arguments directly. I made a small change in the index file that allows params to be passed in arrays. The command was earlier being sent to the queue as a multi dimensional array which made the command fail.

Therefore earlier, only client.multi().zadd('foobar', 1, 'foo', 2, 'bar' ) was getting accepted. 
With the new change, the command can be sent as  
client.multi().zadd(['foobar', 1, 'foo', 2, 'bar']) or
client.multi().zadd('foobar',[ 1, 'foo', 2, 'bar'])
and it would work correctly. It would be a very useful fields for commands where multiple arguments need to be passed. I personally thought it was possible until the code returned with nothing.

Hope we can consider this change. I have also written a test MULTI_9 which passed.