### PR TITLE
Fix connection issues in 0.11.0 release

### DIFF
--- a/index.js
+++ b/index.js
@@ -1216,7 +1216,9 @@ RedisClient.prototype.eval = RedisClient.prototype.EVAL = function () {
 exports.createClient = function (port_arg, host_arg, options) {
   var cnxFamily, cnxOptions;
 
-  if (typeof port_arg === 'string' && parseInt(port_arg, 10) !== port_arg) {
+  if (typeof port_arg === 'object') {
+    cnxOptions = port_arg;
+  } else if (typeof port_arg === 'string' && parseInt(port_arg, 10) !== port_arg) {
     cnxOptions = {
       path: port_arg
     };


### PR DESCRIPTION
Trying to address issue #632, I believe this commit https://github.com/mranney/node_redis/commit/9c68a286b1b0be913bbbca112ea4d241eda96d91 broke the ability to connect to a redis instance listening on a unix socket in this fashion:

```
var redis = require("redis"),
     redisClient = redis.createClient("/tmp/redisTest.sock");
```

as well as being able to connect to redis when passing in the cnxOptions directly as:

```
var config = {
   port: 6379, 
   host: '127.0.0.1',
   options: {}
};

var redis = require("redis"),
     redisClient = redis.createClient(config);
```

my pull request attempts to check if you are sending a unix path or connection options in port_arg and set the cnxOptions correctly to net.createConnection

this should fix some, if not all of the connection regressions described in #632
