### PR TITLE
Fix error message relating to connection family

### DIFF
--- a/index.js
+++ b/index.js
@@ -1264,7 +1264,7 @@ var createClient_tcp = function (port_arg, host_arg, options) {
     var cnxOptions = {
         'port' : port_arg || default_port,
         'host' : host_arg || default_host,
-        'family' : (options && options.family === 'IPv6') ? 'IPv6' : 'IPv4' 
+        'family' : (options && options.family === 'IPv6') ? '6' : '4' 
     };
     var net_client = net.createConnection(cnxOptions);
     var redis_client = new RedisClient(net_client, options || {});


### PR DESCRIPTION
This fixes an error that causes `Error: invalid argument: `family` must be 4 or 6` when attempting to create a remote connection.
