### PR TITLE
Attach command_obj to return error

### DIFF
--- a/index.js
+++ b/index.js
@@ -556,6 +556,7 @@ RedisClient.prototype.on_data = function (data) {
 
 RedisClient.prototype.return_error = function (err) {
     var command_obj = this.command_queue.shift(), queue_len = this.command_queue.getLength();
+    err.redis_command = command_obj
 
     if (this.pub_sub_mode === false && queue_len === 0) {
         this.command_queue = new Queue();


### PR DESCRIPTION
Base on the error reply, we can't know where the error real happens, and what command relative it, if there are multiple command executing at the same time.

So we have to trace what command occurs the error, we need attach the command_obj to the error.