### PR TITLE
Add socket_connect_timeout option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ every command on a client.
 Nagle algorithm on the underlying socket. Setting this option to `false` can result in additional throughput at the
 cost of more latency. Most applications will want this set to `true`.
 * `socket_keepalive` defaults to `true`. Whether the keep-alive functionality is enabled on the underlying socket.
+* `socket_connect_timeout` defaults to `null`. By default a connection attempts use the operating system's timeout, but 
+setting `socket_connect_timeout` will time-out the connection attempt after this many milliseconds instead.
 * `no_ready_check`: defaults to `false`. When a connection is established to the Redis server, the server might still
 be loading the database from disk. While loading, the server not respond to any commands. To work around this,
 `node_redis` has a "ready check" which sends the `INFO` command to the server. The response from the `INFO` command

--- a/index.js
+++ b/index.js
@@ -81,6 +81,12 @@ exports.RedisClient = RedisClient;
 RedisClient.prototype.install_stream_listeners = function() {
     var self = this;
 
+    if (this.options.socket_connect_timeout > 0) {
+        this.stream.setTimeout(this.options.socket_connect_timeout, function () {
+            self.on_timeout();
+        });
+    }
+
     this.stream.on("connect", function () {
         self.on_connect();
     });
@@ -216,6 +222,18 @@ RedisClient.prototype.do_auth = function () {
         }
     });
     self.send_anyway = false;
+};
+
+RedisClient.prototype.on_timeout = function () {
+    if (this.connected || this.closing) {
+        // Only handle connection timeouts.
+        return;
+    }
+
+    debug("Stream timeout " + this.address + " id " + this.connection_id);
+
+    this.stream.end();
+    this.connection_gone("timeout");
 };
 
 RedisClient.prototype.on_connect = function () {


### PR DESCRIPTION
This allows you to specify the connection timeout for the stream; note that once the stream is connected the existing code performs `stream.setTimeout(0)` thereby preventing this patch triggering an idle timeout on an established connection. (This is also why I called it `socket_connect_timeout` rather than simply `socket_timeout`.)

I added `this.stream.setTimeout` to `install_stream_listeners` as it seemed the DRY-est place to put it since it is called for all streams just after they're created. If this is not the right place, please let me know.
