### PR TITLE
added URL support to createClient

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 /*global Buffer require exports console setTimeout */
 
 var net = require("net"),
+    URL = require("url"),
     util = require("./lib/util"),
     Queue = require("./lib/queue"),
     to_array = require("./lib/to_array"),
@@ -1227,9 +1228,19 @@ exports.createClient = function(arg0, arg1, arg2){
         return createClient_tcp(arg0, arg1, arg2);
 
     } else if( typeof arg0 === 'string' ){
+        var parsed = URL.parse(arg0, true, true),
+            options = (arg1 || {});
 
-        // createClient( '/tmp/redis.sock', options)
-        return createClient_unix(arg0,arg1);
+        if (parsed.hostname) {
+            if (parsed.auth) {
+                options.auth_pass = parsed.auth.split(':')[1];
+            }
+            // createClient(3000, host, options)
+            return createClient_tcp((parsed.port || default_port), parsed.hostname, options);
+        } else {
+            // createClient( '/tmp/redis.sock', options)
+            return createClient_unix(arg0,options);
+        }
 
     } else if( arg0 !== null && typeof arg0 === 'object' ){
 

--- a/test.js
+++ b/test.js
@@ -2169,6 +2169,25 @@ tests.auth2 = function () {
     });
 };
 
+// auth password specified by URL string.
+tests.auth3 = function () {
+    var name = "AUTH3", client4, ready_count = 0;
+
+    client4 = redis.createClient('redis://redistogo:664b1b6aaf134e1ec281945a8de702a9@filefish.redistogo.com:9006/');
+
+    // test auth, then kill the connection so it'll auto-reconnect and auto-re-auth
+    client4.on("ready", function () {
+        ready_count++;
+        if (ready_count === 1) {
+            client4.stream.destroy();
+        } else {
+            client4.quit(function (err, res) {
+                next(name);
+            });
+        }
+    });
+};
+
 tests.reconnectRetryMaxDelay = function() {
     var time = new Date().getTime(),
         name = 'reconnectRetryMaxDelay',


### PR DESCRIPTION
Hi,

I thought it would be useful if we could specify redis server with URL string, like below:

```javascript
// specify remote redis service.
require('redis').createClient('redis://user:password@redis-service.com:6379/');

// or we can also specify localhost.
require('redis').createClient('//localhost:6379');
```

This overloaded interface would be useful especially for node apps hosted on heroku, on which redis add-ons is usually provided via ENV variable.

```javascript
require('redis').createClient(process.env.REDISTOGO_URL);
```