### PR TITLE
add support for disable_flush option

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,9 @@ RedisClient.prototype.on_error = function (msg) {
         console.warn(message);
     }
 
-    this.flush_and_error(message);
+    if(!this.options.disable_flush === true){
+      this.flush_and_error(message);
+    }
 
     this.connected = false;
     this.ready = false;


### PR DESCRIPTION
When my connection fails I would like for it to keep its offline queue.
This would also allow better failover in the redis-sentinel-client module.