### PR TITLE
Channel names with spaces + test

### DIFF
--- a/index.js
+++ b/index.js
@@ -357,7 +357,8 @@ RedisClient.prototype.on_ready = function () {
             }
         };
         Object.keys(this.subscription_set).forEach(function (key) {
-            var parts = key.split(" ");
+            var space_index = key.indexOf(" ");
+            var parts = [key.slice(0,space_index), key.slice(space_index+1)];
             if (exports.debug_mode) {
                 console.warn("sending pub/sub on_ready " + parts[0] + ", " + parts[1]);
             }

--- a/test.js
+++ b/test.js
@@ -1216,6 +1216,29 @@ tests.SUBSCRIBE_CLOSE_RESUBSCRIBE = function () {
     });
 };
 
+tests.RESUBSCRIBE_CHANNEL_NAMES = function () {
+    var name = "RESUBSCRIBE_CHANNEL_NAMES", channel_name = "RESUBSCRIBE CHANNEL NAMES";
+    var c1 = redis.createClient();
+    var c2 = redis.createClient();
+    // Force a retry and make sure the client resubscribes to the same channel name
+    c1.on("subscribe", function (channel, count) {
+        assert.strictEqual(channel, channel_name);
+    });
+
+    c1.subscribe(channel_name);
+
+    c2.once("ready", function(err, results) {
+        c1.once("ready", function(err, results) {
+            c1.quit(function() {
+                c2.quit(function() {
+                    next(name);
+                });
+            });
+        });
+        c1.stream.end();
+    });
+};
+
 tests.EXISTS = function () {
     var name = "EXISTS";
     client.del("foo", "foo2", require_number_any(name));


### PR DESCRIPTION
(Let's try this again without the extraneous space.)
#692 #691

Added a test for pbihler/node_redis@a1a7abd as requested in #692.
Fails under the current code because c1 resubscribes on the wrong channel name.

I'm happy to squash these two commits into one if you prefer, but I figured I would leave it so pbihler gets credit where it's due.