### PR TITLE
Feature: Emit an event when the maximum number of connection attempts has been reached

### DIFF
--- a/index.js
+++ b/index.js
@@ -507,8 +507,8 @@ RedisClient.prototype.connection_gone = function (why) {
 
     if (this.max_attempts && this.attempts >= this.max_attempts) {
         this.retry_timer = null;
-        // TODO - some people need a "Redis is Broken mode" for future commands that errors immediately, and others
-        // want the program to exit.  Right now, we just log, which doesn't really help in either case.
+        // TODO - some people want the program to exit.
+        this.emit("max attempts");
         console.error("node_redis: Couldn't get Redis connection after " + this.max_attempts + " attempts.");
         return;
     }


### PR DESCRIPTION
I followed the lead of the TODO comment, though I think my preferred solution would be that an error event is raised, similar to when a connection cannot be established in the first place, or when the redis server disappears completely.

Anyway, we wanted this for our own purposes, and it was easy to add. :) 