### PR TITLE
Add option to return es6 Map from hgetall

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ limits total amount of reconnects.
 * `auth_pass` defaults to `null`. By default client will try connecting without auth. If set, client will run redis auth command on connect.
 * `family` defaults to `IPv4`. The client connects in IPv4 if not specified or if the DNS resolution returns an IPv4 address. 
 You can force an IPv6 if you set the family to 'IPv6'. See nodejs net or dns modules how to use the family type. 
+* `use_es6_map` defaults to `false`. By default `hgetall` returns a plain object. Set `use_es6_map` to `true` to make `hgetall` return an es6 `Map` object instead.
 
 ```js
     var redis = require("redis"),

--- a/index.js
+++ b/index.js
@@ -1183,7 +1183,12 @@ Multi.prototype.exec = function (callback) {
 
                 // TODO - confusing and error-prone that hgetall is special cased in two places
                 if (reply && args[0].toLowerCase() === "hgetall") {
-                    replies[i - 1] = reply = reply_to_object(reply);
+                    if (self.options.use_es6_map) {
+                        replies[i - 1] = reply = reply_to_map(reply);
+                    }
+                    else {
+                        replies[i - 1] = reply = reply_to_object(reply);
+                    }
                 }
 
                 if (typeof args[args.length - 1] === "function") {

--- a/test.js
+++ b/test.js
@@ -1467,6 +1467,30 @@ tests.HGETALL_NULL = function () {
     });
 };
 
+tests.HGETALL_MAP = function () {
+    var name = "HGETALL_MAP";
+
+    if (typeof Map === 'undefined') {
+        console.log("Skipping", name, "since es6 Map is not available.");
+        return next(name);
+    }
+
+    client.options.use_es6_map = true;
+
+    client.hmset(["map_test", "key1", "val1", "key2", "val2"], require_string("OK", name));
+    client.hgetall("map_test", function (err, obj) {
+        assert.strictEqual(null, err);
+        assert.strictEqual(obj instanceof Map, true);
+        assert.strictEqual(obj.size, 2);
+        assert.strictEqual(obj.get("key1"), "val1");
+        assert.strictEqual(obj.get("key2"), "val2");
+
+        client.options.use_es6_map = false;
+
+        next(name);
+    });
+};
+
 tests.UTF8 = function () {
     var name = "UTF8",
         utf8_sample = "ಠ_ಠ";


### PR DESCRIPTION
`hgetall` currently returns a plain object, which can be problematic for certain keys (e.g. `'hasOwnProperty'`, `'__proto__'`, etc.). Adding the option to return a `Map` would avoid these key problems.