### PR TITLE
Fix for multi/exec logic with detect_buffers enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -610,7 +610,7 @@ function try_callback(callback, reply) {
 function reply_to_object(reply) {
     var obj = {}, j, jl, key, val;
 
-    if (reply.length === 0) {
+    if (reply.length === 0 || !Array.isArray(reply)) {
         return null;
     }
 

--- a/index.js
+++ b/index.js
@@ -672,7 +672,7 @@ RedisClient.prototype.return_reply = function (reply) {
 
     if (command_obj && !command_obj.sub_command) {
         if (typeof command_obj.callback === "function") {
-            if (this.options.detect_buffers && command_obj.buffer_args === false) {
+            if (this.options.detect_buffers && command_obj.buffer_args === false && 'exec' !== command_obj.command.toLowerCase()) {
                 // If detect_buffers option was specified, then the reply from the parser will be Buffers.
                 // If this command did not use Buffer arguments, then convert the reply to Strings here.
                 reply = reply_to_strings(reply);

--- a/index.js
+++ b/index.js
@@ -648,7 +648,7 @@ RedisClient.prototype.return_reply = function (reply) {
     // If the "reply" here is actually a message received asynchronously due to a
     // pubsub subscription, don't pop the command queue as we'll only be consuming
     // the head command prematurely.
-    if (Array.isArray(reply) && reply.length > 0 && reply[0]) {
+    if (this.pub_sub_mode && Array.isArray(reply) && reply.length > 0 && reply[0]) {
         type = reply[0].toString();
     }
 


### PR DESCRIPTION
Fixes #732 and #263.

Basically, fixes the bugs where:
- Doing a `.hgetall` in a multi with detect_buffers while asking for strings mangles the data.
- Doing a `.hgetall` in a multi with detect_buffers while asking for buffers throws an exception.
- Asking for a mix of string/buffer responses will get you all string responses.

Thanks!