### PR TITLE
Issue #512 send_command("monitoring") is doomed to fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,7 +369,7 @@ RedisClient.prototype.on_ready = function () {
         });
         return;
     } else if (this.monitoring) {
-        this.send_command("monitor");
+        this.send_command("monitor", []);
     } else {
         this.send_offline_queue();
     }


### PR DESCRIPTION
I tried to work out how to add a test case for this condition but it was challenging since the current
tests don't really deal with disconnects/reconnects/etc.  I have run some of my own tests with
this change in place and it seems to work but additional validation would be welcomed.