### PR TITLE
Return Error object for errors in reply to EXEC

### DIFF
--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -57,6 +57,11 @@ ReplyParser.prototype._parseResult = function (type) {
             throw new IncompleteReadBuffer("Wait for more data.");
         }
 
+        if (type === 45) {
+            var result = this._buffer.toString(this._encoding, start, end);
+            return new Error(result);
+        }
+
         if (this.options.return_buffers) {
             return this._buffer.slice(start, end);
         } else {

--- a/test.js
+++ b/test.js
@@ -413,6 +413,24 @@ tests.MULTI_EXCEPTION_1 = function() {
     });
 };
 
+tests.MULTI_EXCEPTION_2 = function() {
+    var name = "MULTI_EXCEPTION_2";
+
+    if (!server_version_at_least(client, [2, 6, 5])) {
+        console.log("Skipping " + name + " for old Redis server version < 2.6.5");
+        return next(name);
+    }
+
+    client.multi().set("foo", "bar").lpop("foo").exec(function(err, reply) {
+        assert.strictEqual(null, err);
+        assert(Array.isArray(reply));
+        assert.strictEqual(2, reply.length);
+        assert.strictEqual("OK", reply[0]);
+        assert(reply[1] instanceof Error);
+        next(name);
+    });
+};
+
 tests.MULTI_8 = function () {
     var name = "MULTI_8", multi1, multi2;
 


### PR DESCRIPTION
The javascript reply parser does produces strings instead of `Error`
objects for errors in replies to EXEC. Return `Error` objects to be
consistent with hiredis.