### PR TITLE
Allow garbage collection of processed queue items

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -18,7 +18,10 @@ Queue.prototype.shift = function () {
             return;
         }
     }
-    return this.head[this.offset++]; // sorry, JSLint
+    var item = this.head[this.offset];
+    this.head[this.offset] = null;
+    this.offset++;
+    return item;
 };
 
 Queue.prototype.push = function (item) {


### PR DESCRIPTION
Set processed queue items to `null` to allow garbage collection of these
items. The command queue contains callbacks. They contain the stack of
the current fiber, which can be large. Allow earlier garbage collection
of these stacks by removing the reference to the queue items.