### PR TITLE
adds coverage reporting using nyc bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .tern-port
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
   "author": "Matt Ranney <mjr@ranney.com>",
   "main": "./index.js",
   "scripts": {
-    "test": "node ./test.js"
+    "test": "node ./test.js",
+    "coverage": "nyc npm test && nyc report"
   },
   "devDependencies": {
-    "metrics": ">=0.1.5",
     "colors": "~0.6.0-1",
+    "metrics": ">=0.1.5",
+    "nyc": "^2.2.0",
     "underscore": "~1.4.4"
   },
   "repository": {


### PR DESCRIPTION
This pull request adds coverage reporting using [nyc](https://www.npmjs.com/package/nyc):

* run `npm run coverage` to get a human readable coverage report.
* run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.

Here's what the output looks like:

```shell
--------------------|-----------|-----------|-----------|-----------|
File                |   % Stmts |% Branches |   % Funcs |   % Lines |
--------------------|-----------|-----------|-----------|-----------|
   ./               |     82.34 |     75.97 |        80 |     82.52 |
      index.js      |     82.77 |     76.42 |     81.01 |     82.72 |
      test-unref.js |     54.55 |        50 |         0 |     66.67 |
   ./lib/           |     79.07 |        70 |     85.71 |     79.07 |
      commands.js   |       100 |       100 |       100 |       100 |
      queue.js      |     74.19 |        70 |     83.33 |     74.19 |
      to_array.js   |       100 |       100 |       100 |       100 |
      util.js       |        80 |       100 |       100 |        80 |
   ./lib/parser/    |     78.26 |     72.62 |        75 |     78.26 |
      hiredis.js    |         8 |         0 |         0 |         8 |
      javascript.js |     89.31 |     82.43 |     92.31 |     89.31 |
--------------------|-----------|-----------|-----------|-----------|
All files           |      81.4 |     75.36 |     79.61 |     81.53 |
--------------------|-----------|-----------|-----------|-----------|
```