### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -985,7 +985,7 @@ commands.forEach(function (fullCommand) {
     var command = fullCommand.split(' ')[0];
 
     RedisClient.prototype[command] = function (args, callback) {
-        if (Array.isArray(args) && typeof callback === "function") {
+        if (Array.isArray(args)) {
             return this.send_command(command, args, callback);
         } else {
             return this.send_command(command, to_array(arguments));


### PR DESCRIPTION
Half bug in the RedisClient.prototype[command] = function... (see commit)

It was almost bug: imagine args is array but callback is not defined - in this case all args (that is consists of one array) are packing to new array. That means we get this: this.send_command(command, [[...]]). Double array. It doesn't make any sense.

After I fix it we get this: this.send_command(command, [...], undefined). It's really ok because if we call for example client.hget("test", "aaa") we actually do the same: this.send_command("hget", ["test", "aaa"], undefined). No different from this.send_command(command, [...], undefined).

By the way, «this.send_command(command, [[...]])» could be a bug. Try to call client.eval(["return 1", 0]) and you should get throw because "eval" required 2 param, but program thinks it's only one param: ["return 1", 0]. There's only one reason why you don't get throw - RedisClient.prototype.eval is overridden for some optimizations, lucky. But that doesn't mean everything is ok.