### PR TITLE
various fixes to tests, along with groundwork for adding travis and coveralls support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 examples/
 benches/
-test.js
+test/
 diff_multi_bench_output.js
 generate_commands.js
 multi_bench.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+sudo: false
+node_js:
+  - "0.10"
+  - "0.12"
+  - "iojs"
+after_success: npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,8 @@ node_js:
   - "0.10"
   - "0.12"
   - "iojs"
+before_install:
+  - 'printf ''bind ::1 127.0.0.1\nunixsocket /tmp/redis.sock'' >> /tmp/redis.conf'
+before_script:
+  - sudo redis-server /tmp/redis.conf
 after_success: npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "0.12"
   - "iojs"
 before_install:
-  - 'printf ''bind ::1 127.0.0.1\nunixsocket /tmp/redis.sock\ndaemonize yes'' >> /tmp/redis.conf'
+  - 'printf ''bind ::1 127.0.0.1\nunixsocket /tmp/redis.sock\ndaemonize yes\nunixsocketperm 777'' >> /tmp/redis.conf'
 before_script:
   - sudo redis-server /tmp/redis.conf
 after_success: npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-sudo: false
+sudo: true
 node_js:
   - "0.10"
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "0.12"
   - "iojs"
 before_install:
-  - 'printf ''bind ::1 127.0.0.1\nunixsocket /tmp/redis.sock'' >> /tmp/redis.conf'
+  - 'printf ''bind ::1 127.0.0.1\nunixsocket /tmp/redis.sock\ndaemonize yes'' >> /tmp/redis.conf'
 before_script:
   - sudo redis-server /tmp/redis.conf
 after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 redis - a node.js redis client
 ===========================
 
+[![Build Status](https://travis-ci.org/NodeRedis/node_redis.png)](https://travis-ci.org/NodeRedis/node_redis)
+[![Coverage Status](https://coveralls.io/reposNodeRedis/node_redisbadge.svg?branch=)](https://coveralls.io/r/NodeRedis/node_redis?branch=)
+
 This is a complete Redis client for node.js.  It supports all Redis commands,
 including many recently added commands like EVAL from experimental Redis server
 branches.
@@ -162,7 +165,7 @@ every command on a client.
 * `socket_nodelay`: defaults to `true`. Whether to call setNoDelay() on the TCP stream, which disables the
 Nagle algorithm on the underlying socket.  Setting this option to `false` can result in additional throughput at the
 cost of more latency.  Most applications will want this set to `true`.
-* `socket_keepalive` defaults to `true`. Whether the keep-alive functionality is enabled on the underlying socket. 
+* `socket_keepalive` defaults to `true`. Whether the keep-alive functionality is enabled on the underlying socket.
 * `no_ready_check`: defaults to `false`. When a connection is established to the Redis server, the server might still
 be loading the database from disk.  While loading, the server not respond to any commands.  To work around this,
 `node_redis` has a "ready check" which sends the `INFO` command to the server.  The response from the `INFO` command
@@ -181,8 +184,8 @@ limits total time for client to reconnect. Value is provided in milliseconds and
 * `max_attempts` defaults to `null`. By default client will try reconnecting until connected. Setting `max_attempts`
 limits total amount of reconnects.
 * `auth_pass` defaults to `null`. By default client will try connecting without auth. If set, client will run redis auth command on connect.
-* `family` defaults to `IPv4`. The client connects in IPv4 if not specified or if the DNS resolution returns an IPv4 address. 
-You can force an IPv6 if you set the family to 'IPv6'. See nodejs net or dns modules how to use the family type. 
+* `family` defaults to `IPv4`. The client connects in IPv4 if not specified or if the DNS resolution returns an IPv4 address.
+You can force an IPv6 if you set the family to 'IPv6'. See nodejs net or dns modules how to use the family type.
 
 ```js
     var redis = require("redis"),

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* Refactor tests, and improve test coverage (Ben Coe)
 * Fix extraneous error output due to pubsub tests (Mikael Kohlmyr)
 
 ## v0.12.1 - Aug 10, 2014

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -46,7 +46,7 @@ Queue.prototype.forEach = function (fn, thisv) {
 Queue.prototype.getLength = function () {
     return this.head.length - this.offset + this.tail.length;
 };
-    
+
 Object.defineProperty(Queue.prototype, "length", {
     get: function () {
         return this.getLength();

--- a/package.json
+++ b/package.json
@@ -3,20 +3,22 @@
   "version": "0.12.1",
   "description": "Redis client library",
   "keywords": [
-    "redis",
-    "database"
+    "database",
+    "redis"
   ],
   "author": "Matt Ranney <mjr@ranney.com>",
   "license": "MIT",
   "main": "./index.js",
   "scripts": {
-    "test": "node ./test.js",
-    "coverage": "nyc npm test && nyc report"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "test": "nyc ./test/run.sh"
   },
   "devDependencies": {
     "colors": "~0.6.0-1",
+    "coveralls": "^2.11.2",
+    "hiredis": "^0.4.0",
     "metrics": ">=0.1.5",
-    "nyc": "^2.2.0",
+    "nyc": "^3.0.0",
     "underscore": "~1.4.4"
   },
   "repository": {

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -1,0 +1,35 @@
+var assert = require("assert");
+var Queue = require('../lib/queue');
+
+module.exports = function (tests, next) {
+  var q = new Queue();
+
+  tests.push = function () {
+    q.push('a');
+    q.push(3);
+    assert.equal(q.length, 2);
+    return next();
+  }
+
+  tests.shift = function () {
+    assert.equal(q.shift(), 'a');
+    return next();
+  }
+
+  tests.forEach = function () {
+    q.forEach(function (v) {
+      assert.equal(v, 3);
+    });
+
+    return next();
+  }
+
+  tests.forEachWithScope = function () {
+    q.forEach(function (v) {
+      assert.equal(this.foo, 'bar');
+      assert.equal(v, 3);
+    }, {foo: 'bar'});
+
+    return next();
+  }
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+node ./test/test.js false hiredis
+node ./test/test.js false javascript

--- a/test/test-unref.js
+++ b/test/test-unref.js
@@ -1,4 +1,4 @@
-var redis = require("./")
+var redis = require("../")
 //redis.debug_mode = true
 var PORT = process.argv[2] || 6379;
 var HOST = process.argv[3] || '127.0.0.1';


### PR DESCRIPTION
* upgraded `nyc` to the newest release, it has much nicer test output:

<img width="588" alt="screen shot 2015-07-11 at 4 17 10 pm" src="https://cloud.githubusercontent.com/assets/194609/8635716/5098d608-27e8-11e5-8c98-57d4dc8ad698.png">

* added .travis.yml, so that as soon as soon as (@brycebaril, or @mranney configure Coveralls, and Travis we can add some badges).
* added a test for queue.js (which had poor coverage), in the process refactored the tests so that it's easier to split them into multiple files.
* made it so tests are run with both the `hiredis` and the `javascript` parser -- this raised coverage significantly.
* fixed a major bug with the test suite, once you hit the domains test all tests afterwords did not properly bubble errors.

Doing all this brought test coverage up to `86%` not too shabby.

reviewers: @raydog @erinspice 
