### PR TITLE
I think it would be cool if we added a logo to this organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,3 +807,13 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
+
+## Other Legal Stuff
+
+Redis, and the Redis logo are the trademarks of Salvatore Sanfilippo in the U.S. and other countries:
+
+http://redis.io/topics/trademark
+
+Node.js is a trademark of Joyent:
+
+https://nodejs.org/trademark-policy.pdf


### PR DESCRIPTION
I read the trademark guidelines of [Joyent](https://nodejs.org/about/trademark/) and [Redis](http://redis.io/topics/trademark), and I think it would be fine to add a logo like this to the organization:

![node-redis-logo](https://cloud.githubusercontent.com/assets/194609/8640072/3475a47a-28a0-11e5-8e62-975035507932.png)

1. it leaves both logos in their original form.
2. there's a registered trademark symbol on both logos.
3. this project is open-source and non-profit.
4. I've added attribution to the README.md.

thoughts, cc: @erinspice, @raydog, @mranney?