### PR TITLE
Make it possible to test node_redis in a Docker environment

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 /*global require console setTimeout process Buffer */
-var PORT = 6379;
-var HOST = '127.0.0.1';
+var PORT = process.env.REDIS_1_PORT_6379_TCP_PORT || 6379;
+var HOST = process.env.REDIS_1_PORT_6379_TCP_ADDR || '127.0.0.1';
 var parser = process.argv[3];
 
 var redis = require("../index"),
@@ -116,7 +116,8 @@ next = function next(name) {
 // Tests are run in the order they are defined, so FLUSHDB should always be first.
 
 tests.IPV4 = function () {
-    var ipv4Client = redis.createClient( PORT, "127.0.0.1", { family : "IPv4", parser: parser } );
+    var ipv4addr = process.env.REDIS_1_PORT_6379_TCP_ADDR || "127.0.0.1";
+    var ipv4Client = redis.createClient( PORT, ipv4addr, { family : "IPv4", parser: parser } );
 
     ipv4Client.once("ready", function start_tests() {
         console.log("Connected to " + ipv4Client.address + ", Redis server version " + ipv4Client.server_info.redis_version + "\n");
@@ -142,7 +143,8 @@ tests.IPV6 = function () {
         console.log("Skipping IPV6 for old Redis server version < 2.8.0");
         return run_next_test();
     }
-    var ipv6Client = redis.createClient( PORT, "::1", { family: "IPv6", parser: parser } );
+    var ipv6addr = process.env.REDIS_1_PORT_6379_TCP_ADDR || "::1";
+    var ipv6Client = redis.createClient( PORT, ipv6addr, { family: "IPv6", parser: parser } );
 
     ipv6Client.once("ready", function start_tests() {
         console.log("Connected to " + ipv6Client.address + ", Redis server version " + ipv6Client.server_info.redis_version + "\n");

--- a/test/test.js
+++ b/test/test.js
@@ -739,7 +739,7 @@ tests.WATCH_TRANSACTION = function () {
 
 
 tests.detect_buffers = function () {
-    var name = "detect_buffers", detect_client = redis.createClient({ detect_buffers: true, parser: parser });
+    var name = "detect_buffers", detect_client = redis.createClient(PORT, HOST, { detect_buffers: true, parser: parser });
 
     detect_client.on("ready", function () {
         // single Buffer or String
@@ -804,7 +804,7 @@ tests.detect_buffers = function () {
 };
 
 tests.detect_buffers_multi = function () {
-    var name = "detect_buffers_multi", detect_client = redis.createClient({detect_buffers: true});
+    var name = "detect_buffers_multi", detect_client = redis.createClient(PORT, HOST, {detect_buffers: true});
 
     detect_client.on("ready", function () {
         // single Buffer or String
@@ -895,9 +895,9 @@ tests.detect_buffers_multi = function () {
 tests.socket_nodelay = function () {
     var name = "socket_nodelay", c1, c2, c3, ready_count = 0, quit_count = 0;
 
-    c1 = redis.createClient({ socket_nodelay: true, parser: parser });
-    c2 = redis.createClient({ socket_nodelay: false, parser: parser });
-    c3 = redis.createClient({ parser: parser });
+    c1 = redis.createClient(PORT, HOST, { socket_nodelay: true, parser: parser });
+    c2 = redis.createClient(PORT, HOST, { socket_nodelay: false, parser: parser });
+    c3 = redis.createClient(PORT, HOST, { parser: parser });
 
     function quit_check() {
         quit_count++;
@@ -1258,8 +1258,8 @@ tests.SUBSCRIBE_QUIT = function () {
 
 tests.SUBSCRIBE_CLOSE_RESUBSCRIBE = function () {
     var name = "SUBSCRIBE_CLOSE_RESUBSCRIBE";
-    var c1 = redis.createClient({ parser: parser });
-    var c2 = redis.createClient({ parser: parser });
+    var c1 = redis.createClient(PORT, HOST, { parser: parser });
+    var c2 = redis.createClient(PORT, HOST, { parser: parser });
     var count = 0;
 
     /* Create two clients. c1 subscribes to two channels, c2 will publish to them.
@@ -2055,7 +2055,7 @@ tests.MONITOR = function () {
         return next(name);
     }
 
-    monitor_client = redis.createClient({ parser: parser });
+    monitor_client = redis.createClient(PORT, HOST, { parser: parser });
     monitor_client.monitor(function (err, res) {
         client.mget("some", "keys", "foo", "bar");
         client.set("json", JSON.stringify({
@@ -2329,7 +2329,7 @@ tests.reconnectRetryMaxDelay = function() {
 
 tests.unref = function () {
     var name = "unref";
-    var external = fork("./test/test-unref.js");
+    var external = fork("./test/test-unref.js", [PORT, HOST]);
     var done = false;
     external.on("close", function (code) {
         assert(code == 0, "test-unref.js failed");

--- a/test/test.js
+++ b/test/test.js
@@ -166,6 +166,15 @@ tests.IPV6 = function () {
 }
 
 tests.UNIX_SOCKET = function () {
+    try {
+      var stat = require('fs').accessSync('/tmp/redis.sock');
+    } catch(err) {
+      if (err.code === 'ENOENT') {
+        console.log("Skipping SOCKET since none exists");
+        return run_next_test();
+      }
+    }
+
     var unixClient = redis.createClient('/tmp/redis.sock', { parser: parser });
 
     // if this fails, check the permission of unix socket.

--- a/test/test.js
+++ b/test/test.js
@@ -166,15 +166,6 @@ tests.IPV6 = function () {
 }
 
 tests.UNIX_SOCKET = function () {
-    try {
-      var stat = require('fs').accessSync('/tmp/redis.sock');
-    } catch(err) {
-      if (err.code === 'ENOENT') {
-        console.log("Skipping SOCKET since none exists");
-        return run_next_test();
-      }
-    }
-
     var unixClient = redis.createClient('/tmp/redis.sock', { parser: parser });
 
     // if this fails, check the permission of unix socket.

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 /*global require console setTimeout process Buffer */
-var PORT = process.env.REDIS_1_PORT_6379_TCP_PORT || 6379;
-var HOST = process.env.REDIS_1_PORT_6379_TCP_ADDR || '127.0.0.1';
+var PORT = process.env.REDIS_PORT_6379_TCP_PORT || 6379;
+var HOST = process.env.REDIS_PORT_6379_TCP_ADDR || '127.0.0.1';
 var parser = process.argv[3];
 
 var redis = require("../index"),
@@ -116,7 +116,7 @@ next = function next(name) {
 // Tests are run in the order they are defined, so FLUSHDB should always be first.
 
 tests.IPV4 = function () {
-    var ipv4addr = process.env.REDIS_1_PORT_6379_TCP_ADDR || "127.0.0.1";
+    var ipv4addr = process.env.REDIS_PORT_6379_TCP_ADDR || "127.0.0.1";
     var ipv4Client = redis.createClient( PORT, ipv4addr, { family : "IPv4", parser: parser } );
 
     ipv4Client.once("ready", function start_tests() {
@@ -143,7 +143,7 @@ tests.IPV6 = function () {
         console.log("Skipping IPV6 for old Redis server version < 2.8.0");
         return run_next_test();
     }
-    var ipv6addr = process.env.REDIS_1_PORT_6379_TCP_ADDR || "::1";
+    var ipv6addr = process.env.REDIS_PORT_6379_TCP_ADDR || "::1";
     var ipv6Client = redis.createClient( PORT, ipv6addr, { family: "IPv6", parser: parser } );
 
     ipv6Client.once("ready", function start_tests() {


### PR DESCRIPTION
There is an ongoing effort in the official Node.JS Build and Test Working Group nodejs/smoke-test#1 to be able to test popular NPM packages as a part of the official test suite and continuous integration for Node.JS. The goal here is to more quickly identify what breaks when, giving core developers important feedback on new features, and package authors an early warning and time to roll out new compatible versions with new Node.JS releases. We believe this effort will contribute to make the overall experience of using Node.JS better. 

Testing drivers are particularly challenging; but equally important, since they rely on external dependencies that Node.JS does not control. We are proposing a test infrastructure composed of Docker containers which allows us to create all the different external dependencies in a easy, reproducible, and secure way; you can follow that effort here nodejs/smoke-test#3.

What we need from the drivers is that they 1) do not assume that the test suite is running on the same machine as the services they are dependent upon; 2) that we can in some way configure host and corresponding port variables to point to the external service.

When we run the `node_redis` test suite in the following way:

```
docker run --link redis node:latest npm test
```

… Docker creates two environment variables to the linked Redis service:

* `REDIS_PORT_6379_TCP_ADDR` - address of the linked redis service
* `REDIS_PORT_6379_TCP_PORT` - port of the linked redis service

----

I have made three modifications to the test suite to get it working with the Docker setup described above:

1. Checking for `REDIS_PORT_6379_TCP_ADDR` and `REDIS_PORT_6379_TCP_PORT` before setting default values to `HOST` and `PORT` variables (d34dcc8) (da535a6)
2. ~~~Skip the SOCKET test if no socket exists (I have an idea on how to do this though Docker, just needs some more configuration) but for the time being this would suffice (e646b4e)~~~
3. Always pass `HOST` and `PORT` variables when creating new redis clients in the test suite to prevent clients from connecting to `127.0.0.1` which seams to be the default if no host is provided (8b5ce10)