### PR TITLE
Remove redundant check

### DIFF
--- a/index.js
+++ b/index.js
@@ -402,7 +402,7 @@ RedisClient.prototype.on_info_cmd = function (err, res) {
     // expose info key/vals to users
     this.server_info = obj;
 
-    if (!obj.loading || (obj.loading && obj.loading === "0")) {
+    if (!obj.loading || obj.loading === "0") {
         if (exports.debug_mode) {
             console.log("Redis server ready.");
         }


### PR DESCRIPTION
If the first operand of the disjunction (`!obj.loading`) is false, `obj.loading` is truthy.
Thus there is no need to test it again in second operand.