### PR TITLE
Add "debug" instead of using different indidivudal styles for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,36 +539,6 @@ This will print:
 
 Note that this program will not exit cleanly because the client is still connected.
 
-## redis.debug_mode
-
-Boolean to enable debug mode and protocol tracing.
-
-```js
-var redis = require("redis"),
-    client = redis.createClient();
-
-redis.debug_mode = true;
-
-client.on("connect", function () {
-    client.set("foo_rand000000000000", "some fantastic value");
-});
-```
-
-This will display:
-
-    mjr:~/work/node_redis (master)$ node ~/example.js
-    send command: *3
-    $3
-    SET
-    $20
-    foo_rand000000000000
-    $20
-    some fantastic value
-
-    on_data: +OK
-
-`send command` is data sent into Redis and `on_data` is data received from Redis.
-
 ## Multi-word commands
 
 To execute redis multi-word commands like `SCRIPT LOAD` or `CLIENT LIST` pass

--- a/examples/eval.js
+++ b/examples/eval.js
@@ -3,8 +3,6 @@
 var redis = require("../index"),
     client = redis.createClient();
 
-redis.debug_mode = true;
-
 client.eval("return 100.5", 0, function (err, res) {
     console.dir(err);
     console.dir(res);

--- a/examples/psubscribe.js
+++ b/examples/psubscribe.js
@@ -7,8 +7,6 @@ var redis = require("redis"),
     client4 = redis.createClient(),
     msg_count = 0;
 
-redis.debug_mode = false;
-
 client1.on("psubscribe", function (pattern, count) {
     console.log("client1 psubscribed to " + pattern + ", " + count + " total subscriptions");
     client2.publish("channeltwo", "Me!");

--- a/examples/pub_sub.js
+++ b/examples/pub_sub.js
@@ -4,8 +4,6 @@ var redis = require("redis"),
     client1 = redis.createClient(), msg_count = 0,
     client2 = redis.createClient();
 
-redis.debug_mode = false;
-
 // Most clients probably don't do much on "subscribe".  This example uses it to coordinate things within one program.
 client1.on("subscribe", function (channel, count) {
     console.log("client1 subscribed to " + channel + ", " + count + " total subscriptions");

--- a/index.js
+++ b/index.js
@@ -13,7 +13,16 @@ var net = require("net"),
     connection_id = 0,
     default_port = 6379,
     default_host = "127.0.0.1",
+    debug;
+
+/* istanbul ignore next */
+if (util.debuglog) {
     debug = util.debuglog('redis');
+} else if (/\bredis\b/i.test(process.env.NODE_DEBUG)) {
+    debug = console.error;
+} else {
+    debug = function() {};
+}
 
 // hiredis might not be installed
 try {

--- a/lib/parser/hiredis.js
+++ b/lib/parser/hiredis.js
@@ -4,7 +4,6 @@ var events = require("events"),
     util = require("../util"),
     hiredis = require("hiredis");
 
-exports.debug_mode = false;
 exports.name = "hiredis";
 
 function HiredisReplyParser(options) {

--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -9,7 +9,6 @@ function Packet(type, size) {
 }
 
 exports.name = "javascript";
-exports.debug_mode = false;
 
 function ReplyParser(options) {
     this.name = exports.name;
@@ -18,7 +17,6 @@ function ReplyParser(options) {
     this._buffer            = null;
     this._offset            = 0;
     this._encoding          = "utf-8";
-    this._debug_mode        = options.debug_mode;
     this._reply_type        = null;
 }
 

--- a/multi_bench.js
+++ b/multi_bench.js
@@ -11,8 +11,6 @@ var redis = require("./index"),
     },
     small_str, large_str, small_buf, large_buf, very_large_str, very_large_buf;
 
-redis.debug_mode = false;
-
 function lpad(input, len, chr) {
     var str = input.toString();
     chr = chr || " ";

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -1,19 +1,15 @@
 // helpers for configuring a redis client in
 // its various modes, ipV6, ipV4, socket.
-module.exports = (function () {
-    var redis = require('../../index');
-    redis.debug_mode = process.env.DEBUG ? JSON.parse(process.env.DEBUG) : false;
+var redis = require('../../index');
 
-    var config = {
-        redis: redis,
-        PORT: 6378,
-        HOST: {
-            IPv4: "127.0.0.1",
-            IPv6: "::1"
-        }
-    };
-
-    config.configureClient = function (parser, ip, opts) {
+var config = {
+    redis: redis,
+    PORT: 6378,
+    HOST: {
+        IPv4: "127.0.0.1",
+        IPv6: "::1"
+    },
+    configureClient: function (parser, ip, opts) {
         var args = [];
         opts = opts || {};
 
@@ -29,7 +25,7 @@ module.exports = (function () {
         args.push(opts);
 
         return args;
-    };
+    }
+};
 
-    return config;
-})();
+module.exports = config;

--- a/test/lib/unref.js
+++ b/test/lib/unref.js
@@ -4,7 +4,6 @@
 'use strict';
 
 var redis = require("../../");
-//redis.debug_mode = true
 var HOST = process.argv[2] || '127.0.0.1';
 var PORT = process.argv[3]
 var args = PORT ? [PORT, HOST] : [HOST]


### PR DESCRIPTION
There were all sorts of ways to print debug statements and I moved all of those to use [debug] (https://github.com/visionmedia/debug) instead. This is handy, as it won't pollute the coverage with statements that are not necessary and debug is widespread.