### PR TITLE
Tiny speedup by removing command.toLowerCase()

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,9 +551,9 @@ the second word as first parameter:
 
 ## client.send_command(command_name, args, callback)
 
-Used internally to send commands to Redis. For convenience, nearly all commands that are published on the Redis
-Wiki have been added to the `client` object. However, if I missed any, or if new commands are introduced before
-this library is updated, you can use `send_command()` to send arbitrary commands to Redis.
+Used internally to send commands to Redis. Nearly all Redis commands have been added to the `client` object.
+However, if new commands are introduced before this library is updated, you can use `send_command()` to send arbitrary commands to Redis.
+The command has to be lower case.
 
 All commands are sent as multi-bulk commands. `args` can either be an Array of arguments, or omitted.
 

--- a/index.js
+++ b/index.js
@@ -624,14 +624,14 @@ RedisClient.prototype.return_reply = function (reply) {
 
     if (command_obj && !command_obj.sub_command) {
         if (typeof command_obj.callback === "function") {
-            if (this.options.detect_buffers && command_obj.buffer_args === false && 'exec' !== command_obj.command.toLowerCase()) {
+            if (this.options.detect_buffers && command_obj.buffer_args === false && 'exec' !== command_obj.command) {
                 // If detect_buffers option was specified, then the reply from the parser will be Buffers.
                 // If this command did not use Buffer arguments, then convert the reply to Strings here.
                 reply = reply_to_strings(reply);
             }
 
             // TODO - confusing and error-prone that hgetall is special cased in two places
-            if (reply && 'hgetall' === command_obj.command.toLowerCase()) {
+            if (reply && 'hgetall' === command_obj.command) {
                 reply = reply_to_object(reply);
             }
 
@@ -730,8 +730,7 @@ RedisClient.prototype.send_command = function (command, args, callback) {
     //     client.sadd(arg1, [arg2, arg3, arg4], cb);
     //  converts to:
     //     client.sadd(arg1, arg2, arg3, arg4, cb);
-    lcaseCommand = command.toLowerCase();
-    if ((lcaseCommand === 'sadd' || lcaseCommand === 'srem') && args.length > 0 && Array.isArray(args[args.length - 1])) {
+    if ((command === 'sadd' || command === 'srem') && args.length > 0 && Array.isArray(args[args.length - 1])) {
         args = args.slice(0, -1).concat(args[args.length - 1]);
     }
 
@@ -885,7 +884,7 @@ RedisClient.prototype.end = function () {
 
 function Multi(client, args) {
     this._client = client;
-    this.queue = [["MULTI"]];
+    this.queue = [["multi"]];
     if (Array.isArray(args)) {
         this.queue = this.queue.concat(args);
     }
@@ -1061,7 +1060,7 @@ Multi.prototype.exec = function (callback) {
         if (args.length === 1 && Array.isArray(args[0])) {
             args = args[0];
         }
-        if (command.toLowerCase() === 'hmset' && typeof args[1] === 'object') {
+        if (command === 'hmset' && typeof args[1] === 'object') {
             obj = args.pop();
             Object.keys(obj).forEach(function (key) {
                 args.push(key);
@@ -1081,7 +1080,7 @@ Multi.prototype.exec = function (callback) {
     }, this);
 
     // TODO - make this callback part of Multi.prototype instead of creating it each time
-    return this._client.send_command("EXEC", [], function (err, replies) {
+    return this._client.send_command("exec", [], function (err, replies) {
         if (err) {
             if (callback) {
                 errors.push(new Error(err));
@@ -1106,7 +1105,7 @@ Multi.prototype.exec = function (callback) {
                 }
 
                 // TODO - confusing and error-prone that hgetall is special cased in two places
-                if (reply && args[0].toLowerCase() === "hgetall") {
+                if (reply && args[0] === "hgetall") {
                     replies[i - 1] = reply = reply_to_object(reply);
                 }
 

--- a/index.js
+++ b/index.js
@@ -692,7 +692,7 @@ function Command(command, args, sub_command, buffer_args, callback) {
 }
 
 RedisClient.prototype.send_command = function (command, args, callback) {
-    var arg, command_obj, i, il, elem_count, buffer_args, stream = this.stream, command_str = "", buffered_writes = 0, last_arg_type, lcaseCommand;
+    var arg, command_obj, i, il, elem_count, buffer_args, stream = this.stream, command_str = "", buffered_writes = 0, last_arg_type;
 
     if (typeof command !== "string") {
         throw new Error("First argument to send_command must be the command name string, not " + typeof command);

--- a/test/commands/client.spec.js
+++ b/test/commands/client.spec.js
@@ -32,7 +32,7 @@ describe("The 'client' method", function () {
 
             describe('list', function () {
                 it('lists connected clients', function (done) {
-                    client.client("list", helper.match(pattern, done));
+                    client.client("LIST", helper.match(pattern, done));
                 });
 
                 it("lists connected clients when invoked with multi's chaining syntax", function (done) {

--- a/test/commands/dbsize.spec.js
+++ b/test/commands/dbsize.spec.js
@@ -59,7 +59,7 @@ describe("The 'dbsize' method", function () {
                 });
 
                 it("returns a zero db size", function (done) {
-                    client.dbsize([], function (err, res) {
+                    client.DBSIZE([], function (err, res) {
                         helper.isNotError()(err, res);
                         helper.isType.number()(err, res);
                         assert.strictEqual(res, 0, "Initial db size should be 0");

--- a/test/commands/del.spec.js
+++ b/test/commands/del.spec.js
@@ -21,7 +21,7 @@ describe("The 'del' method", function () {
 
             it('allows a single key to be deleted', function (done) {
                 client.set('foo', 'bar');
-                client.del('foo', helper.isNumber(1));
+                client.DEL('foo', helper.isNumber(1));
                 client.get('foo', helper.isNull(done));
             });
 

--- a/test/commands/eval.spec.js
+++ b/test/commands/eval.spec.js
@@ -35,7 +35,7 @@ describe("The 'eval' method", function () {
             });
 
             it('returns a string', function (done) {
-                client.eval("return 'hello world'", 0, helper.isString('hello world', done));
+                client.EVAL("return 'hello world'", 0, helper.isString('hello world', done));
             });
 
             it('converts boolean true to integer 1', function (done) {

--- a/test/commands/exits.spec.js
+++ b/test/commands/exits.spec.js
@@ -21,7 +21,7 @@ describe("The 'exits' method", function () {
 
             it('returns 1 if the key exists', function (done) {
                 client.set('foo', 'bar');
-                client.exists('foo', helper.isNumber(1, done));
+                client.EXISTS('foo', helper.isNumber(1, done));
             });
 
             it('returns 0 if the key does not exist', function (done) {

--- a/test/commands/flushdb.spec.js
+++ b/test/commands/flushdb.spec.js
@@ -76,7 +76,7 @@ describe("The 'flushdb' method", function () {
                                 return done(err);
                             }
 
-                            client.flushdb(function (err, res) {
+                            client.FLUSHDB(function (err, res) {
                                 helper.isString("OK")(err, res);
                                 done(err);
                             });

--- a/test/commands/get.spec.js
+++ b/test/commands/get.spec.js
@@ -64,7 +64,7 @@ describe("The 'get' method", function () {
                     });
 
                     it("gets the value correctly", function (done) {
-                        client.get(key, function (err, res) {
+                        client.GET(key, function (err, res) {
                             helper.isString(value)(err, res);
                             done(err);
                         });

--- a/test/commands/getset.spec.js
+++ b/test/commands/getset.spec.js
@@ -65,7 +65,7 @@ describe("The 'getset' method", function () {
                     });
 
                     it("gets the value correctly", function (done) {
-                        client.getset(key, value2, function (err, res) {
+                        client.GETSET(key, value2, function (err, res) {
                             helper.isString(value)(err, res);
                             client.get(key, function (err, res) {
                                 helper.isString(value2)(err, res);

--- a/test/commands/hgetall.spec.js
+++ b/test/commands/hgetall.spec.js
@@ -35,7 +35,7 @@ describe("The 'hgetall' method", function () {
                 });
 
                 it('handles fetching keys set using an object', function (done) {
-                    client.hmset("msg_test", {message: "hello"}, helper.isString("OK"));
+                    client.HMSET("msg_test", {message: "hello"}, helper.isString("OK"));
                     client.hgetall("msg_test", function (err, obj) {
                         assert.strictEqual(1, Object.keys(obj).length);
                         assert.strictEqual(obj.message, "hello");

--- a/test/commands/hincrby.spec.js
+++ b/test/commands/hincrby.spec.js
@@ -24,7 +24,7 @@ describe("The 'hincrby' method", function () {
                 var field = "field 1";
 
                 client.HSET(hash, field, 33);
-                client.HINCRBY(hash, field, 10, helper.isNumber(43, done));
+                client.hincrby(hash, field, 10, helper.isNumber(43, done));
             });
 
             it('increments a key that has not been set', function (done) {

--- a/test/commands/hmget.spec.js
+++ b/test/commands/hmget.spec.js
@@ -23,7 +23,7 @@ describe("The 'hmget' method", function () {
             });
 
             it('allows keys to be specified using multiple arguments', function (done) {
-                client.HMGET(hash, "0123456789", "some manner of key", function (err, reply) {
+                client.hmget(hash, "0123456789", "some manner of key", function (err, reply) {
                     assert.strictEqual("abcdefghij", reply[0].toString());
                     assert.strictEqual("a type of value", reply[1].toString());
                     return done(err);

--- a/test/commands/hmset.spec.js
+++ b/test/commands/hmset.spec.js
@@ -31,7 +31,7 @@ describe("The 'hmset' method", function () {
             });
 
             it('handles object-style syntax', function (done) {
-                client.HMSET(hash, {"0123456789": "abcdefghij", "some manner of key": "a type of value", "otherTypes": 555}, helper.isString('OK'));
+                client.hmset(hash, {"0123456789": "abcdefghij", "some manner of key": "a type of value", "otherTypes": 555}, helper.isString('OK'));
                 client.HGETALL(hash, function (err, obj) {
                     assert.equal(obj['0123456789'], 'abcdefghij');
                     assert.equal(obj['some manner of key'], 'a type of value');

--- a/test/commands/hset.spec.js
+++ b/test/commands/hset.spec.js
@@ -25,7 +25,7 @@ describe("The 'hset' method", function () {
                 var field = new Buffer("0123456789");
                 var value = new Buffer("abcdefghij");
 
-                client.HSET(hash, field, value, helper.isNumber(1));
+                client.hset(hash, field, value, helper.isNumber(1));
                 client.HGET(hash, field, helper.isString(value.toString(), done));
             });
 

--- a/test/commands/incr.spec.js
+++ b/test/commands/incr.spec.js
@@ -69,7 +69,7 @@ describe("The 'incr' method", function () {
                 });
 
                 it("changes the last digit from 2 to 3", function (done) {
-                    client.incr(key, function (err, res) {
+                    client.INCR(key, function (err, res) {
                         helper.isString("9007199254740993")(err, res);
                         done(err);
                     });

--- a/test/commands/keys.spec.js
+++ b/test/commands/keys.spec.js
@@ -46,7 +46,7 @@ describe("The 'keys' method", function () {
                     return a.concat(b);
                 }), helper.isString("OK"));
 
-                client.KEYS("multibulk:*", function(err, results) {
+                client.keys("multibulk:*", function(err, results) {
                     assert.deepEqual(keys_values.map(function(val) {
                         return val[0];
                     }).sort(), results.sort());

--- a/test/commands/mget.spec.js
+++ b/test/commands/mget.spec.js
@@ -33,7 +33,7 @@ describe("The 'mget' method", function () {
             });
 
             it('handles fetching multiple keys via an array', function (done) {
-                client.MGET(["mget keys 1", "mget keys 2", "mget keys 3"], function (err, results) {
+                client.mget(["mget keys 1", "mget keys 2", "mget keys 3"], function (err, results) {
                     assert.strictEqual("mget val 1", results[0].toString());
                     assert.strictEqual("mget val 2", results[1].toString());
                     assert.strictEqual("mget val 3", results[2].toString());

--- a/test/commands/msetnx.spec.js
+++ b/test/commands/msetnx.spec.js
@@ -26,7 +26,7 @@ describe("The 'msetnx' method", function () {
             });
 
             it('sets multiple keys if all keys are not set', function (done) {
-                client.MSETNX(["mset3", "val3", "mset4", "val4"], helper.isNumber(1));
+                client.msetnx(["mset3", "val3", "mset4", "val4"], helper.isNumber(1));
                 client.exists(["mset3"], helper.isNumber(1));
                 client.exists(["mset3"], helper.isNumber(1, done));
             });

--- a/test/commands/multi.spec.js
+++ b/test/commands/multi.spec.js
@@ -62,7 +62,7 @@ describe("The 'multi' method", function () {
                     var multi1, multi2;
 
                     // Provoke an error at queue time
-                    multi1 = client.multi();
+                    multi1 = client.MULTI();
                     multi1.mset("multifoo", "10", "multibar", "20", helper.isString("OK"));
                     multi1.set("foo2", helper.isError());
                     multi1.incr("multifoo", helper.isNumber(11));

--- a/test/commands/rename.spec.js
+++ b/test/commands/rename.spec.js
@@ -21,7 +21,7 @@ describe("The 'rename' method", function () {
 
             it('populates the new key', function (done) {
                 client.set(['foo', 'bar'], helper.isString("OK"));
-                client.RENAME(["foo", "new foo"], helper.isString("OK"));
+                client.rename(["foo", "new foo"], helper.isString("OK"));
                 client.exists(["new foo"], helper.isNumber(1, done));
             });
 

--- a/test/commands/renamenx.spec.js
+++ b/test/commands/renamenx.spec.js
@@ -21,7 +21,7 @@ describe("The 'renamenx' method", function () {
 
             it('renames the key if target does not yet exist', function (done) {
                 client.set('foo', 'bar', helper.isString('OK'));
-                client.renamenx('foo', 'foo2', helper.isNumber(1));
+                client.RENAMENX('foo', 'foo2', helper.isNumber(1));
                 client.exists('foo', helper.isNumber(0));
                 client.exists(['foo2'], helper.isNumber(1, done));
             });

--- a/test/commands/script.spec.js
+++ b/test/commands/script.spec.js
@@ -33,7 +33,7 @@ describe("The 'script' method", function () {
             });
 
             it("loads script with client.script('load')", function (done) {
-                client.script("load", command, function(err, result) {
+                client.SCRIPT("load", command, function(err, result) {
                     assert.strictEqual(result, commandSha);
                     return done();
                 });

--- a/test/commands/select.spec.js
+++ b/test/commands/select.spec.js
@@ -48,7 +48,7 @@ describe("The 'select' method", function () {
                 it("changes the database and calls the callback", function (done) {
                     // default value of null means database 0 will be used.
                     assert.strictEqual(client.selected_db, null, "default db should be null");
-                    client.select(1, function (err, res) {
+                    client.SELECT(1, function (err, res) {
                         helper.isNotError()(err, res);
                         assert.strictEqual(client.selected_db, 1, "db should be 1 after select");
                         done();

--- a/test/commands/set.spec.js
+++ b/test/commands/set.spec.js
@@ -58,7 +58,7 @@ describe("The 'set' method", function () {
                 describe("and a callback is specified", function () {
                     describe("with valid parameters", function () {
                         it("sets the value correctly", function (done) {
-                            client.set(key, value, function (err, res) {
+                            client.SET(key, value, function (err, res) {
                                 helper.isNotError()(err, res);
                                 client.get(key, function (err, res) {
                                     helper.isString(value)(err, res);

--- a/test/commands/setex.spec.js
+++ b/test/commands/setex.spec.js
@@ -21,7 +21,7 @@ describe("The 'setex' method", function () {
             });
 
             it('sets a key with an expiry', function (done) {
-                client.SETEX(["setex key", "100", "setex val"], helper.isString("OK"));
+                client.setex(["setex key", "100", "setex val"], helper.isString("OK"));
                 client.exists(["setex key"], helper.isNumber(1));
                 client.ttl(['setex key'], function (err, ttl) {
                     assert.ok(ttl > 0);

--- a/test/commands/setnx.spec.js
+++ b/test/commands/setnx.spec.js
@@ -20,7 +20,7 @@ describe("The 'setnx' method", function () {
             });
 
             it('sets key if it does not have a value', function (done) {
-                client.setnx('foo', 'banana', helper.isNumber(1));
+                client.SETNX('foo', 'banana', helper.isNumber(1));
                 client.get('foo', helper.isString('banana', done));
             });
 

--- a/test/commands/sinter.spec.js
+++ b/test/commands/sinter.spec.js
@@ -29,7 +29,7 @@ describe("The 'sinter' method", function () {
                 client.sadd('sb', 'c', helper.isNumber(1));
                 client.sadd('sb', 'd', helper.isNumber(1));
 
-                client.sinter('sa', 'sb', function (err, intersection) {
+                client.SINTER('sa', 'sb', function (err, intersection) {
                     assert.equal(intersection.length, 2);
                     assert.deepEqual(intersection.sort(), [ 'b', 'c' ]);
                     return done(err);

--- a/test/commands/sismember.spec.js
+++ b/test/commands/sismember.spec.js
@@ -25,7 +25,7 @@ describe("The 'sismember' method", function () {
 
             it('returns 1 if the value is in the set', function (done) {
                 client.sadd('foo', 'banana', helper.isNumber(1));
-                client.sismember('foo', 'banana', helper.isNumber(1, done));
+                client.SISMEMBER('foo', 'banana', helper.isNumber(1, done));
             });
 
             afterEach(function () {

--- a/test/commands/slowlog.spec.js
+++ b/test/commands/slowlog.spec.js
@@ -25,7 +25,7 @@ describe("The 'slowlog' method", function () {
                 client.slowlog("reset", helper.isString("OK"));
                 client.set("foo", "bar", helper.isString("OK"));
                 client.get("foo", helper.isString("bar"));
-                client.slowlog("get", function (err, res) {
+                client.SLOWLOG("get", function (err, res) {
                     assert.equal(res.length, 3);
                     assert.equal(res[0][3].length, 2);
                     assert.deepEqual(res[1][3], ["set", "foo", "bar"]);

--- a/test/commands/smove.spec.js
+++ b/test/commands/smove.spec.js
@@ -28,7 +28,7 @@ describe("The 'smove' method", function () {
 
             it("does not move a value if it does not exist in the first set", function (done) {
                 client.sadd('foo', 'x', helper.isNumber(1));
-                client.smove('foo', 'bar', 'y', helper.isNumber(0));
+                client.SMOVE('foo', 'bar', 'y', helper.isNumber(0));
                 client.sismember('foo', 'y', helper.isNumber(0));
                 client.sismember('bar', 'y', helper.isNumber(0, done));
             });

--- a/test/commands/sort.spec.js
+++ b/test/commands/sort.spec.js
@@ -30,7 +30,7 @@ describe("The 'sort' method", function () {
                 });
 
                 it('sorts in descending alphabetical order', function (done) {
-                    client.sort('y', 'desc', 'alpha', function (err, sorted) {
+                    client.SORT('y', 'desc', 'alpha', function (err, sorted) {
                         assert.deepEqual(sorted, ['d', 'c', 'b', 'a']);
                         return done(err);
                     });

--- a/test/commands/srem.spec.js
+++ b/test/commands/srem.spec.js
@@ -27,7 +27,7 @@ describe("The 'srem' method", function () {
             });
 
             it('handles attempting to remove a missing value', function (done) {
-                client.srem('set0', 'member0', helper.isNumber(0, done));
+                client.SREM('set0', 'member0', helper.isNumber(0, done));
             });
 
             it('allows multiple values to be removed', function (done) {

--- a/test/commands/type.spec.js
+++ b/test/commands/type.spec.js
@@ -26,7 +26,7 @@ describe("The 'type' method", function () {
 
             it('reports list type', function (done) {
                 client.rpush(["list key", "should be a list"], helper.isNumber(1));
-                client.TYPE(["list key"], helper.isString("list", done));
+                client.type(["list key"], helper.isString("list", done));
             });
 
             it('reports set type', function (done) {

--- a/test/commands/watch.spec.js
+++ b/test/commands/watch.spec.js
@@ -32,7 +32,7 @@ describe("The 'watch' method", function () {
             });
 
             it('does not execute transaction if watched key was modified prior to execution', function (done) {
-                client.watch(watched);
+                client.WATCH(watched);
                 client.incr(watched);
                 var multi = client.multi();
                 multi.incr(watched);


### PR DESCRIPTION
This is not necessary as the command itself is only used from inside the code and as they are (now) all lower case it is safe to remove the toLowerCase.