### PR TITLE
minor tweaks to how we spawn tests in #815

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
-services:
-  - redis-server
 node_js:
   - "0.10"
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+services:
+  - redis-server
 node_js:
   - "0.10"
   - "0.12"

--- a/lib/parser/hiredis.js
+++ b/lib/parser/hiredis.js
@@ -8,7 +8,7 @@ exports.name = "hiredis";
 
 function HiredisReplyParser(options) {
     this.name = exports.name;
-    this.options = options || {};
+    this.options = options;
     this.reset();
     events.EventEmitter.call(this);
 }
@@ -27,12 +27,7 @@ HiredisReplyParser.prototype.execute = function (data) {
     var reply;
     this.reader.feed(data);
     while (true) {
-        try {
-            reply = this.reader.get();
-        } catch (err) {
-            this.emit("error", err);
-            break;
-        }
+        reply = this.reader.get();
 
         if (reply === undefined) {
             break;

--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -12,7 +12,7 @@ exports.name = "javascript";
 
 function ReplyParser(options) {
     this.name = exports.name;
-    this.options = options || { };
+    this.options = options;
 
     this._buffer            = null;
     this._offset            = 0;

--- a/test/commands/hmget.spec.js
+++ b/test/commands/hmget.spec.js
@@ -37,6 +37,14 @@ describe("The 'hmget' method", function () {
                 });
             });
 
+            it('allows keys to be specified by passing an array as first argument', function (done) {
+                client.HMGET([hash, "0123456789", "some manner of key"], function (err, reply) {
+                    assert.strictEqual("abcdefghij", reply[0].toString());
+                    assert.strictEqual("a type of value", reply[1].toString());
+                    return done(err);
+                });
+            });
+
             it('allows a single key to be specified in an array', function (done) {
                 client.HMGET(hash, ["0123456789"], function (err, reply) {
                     assert.strictEqual("abcdefghij", reply[0].toString());

--- a/test/commands/hmset.spec.js
+++ b/test/commands/hmset.spec.js
@@ -20,7 +20,7 @@ describe("The 'hmset' method", function () {
             });
 
             it('handles redis-style syntax', function (done) {
-                client.HMSET(hash, "0123456789", "abcdefghij", "some manner of key", "a type of value", helper.isString('OK'));
+                client.HMSET(hash, "0123456789", "abcdefghij", "some manner of key", "a type of value", "otherTypes", 555, helper.isString('OK'));
                 client.HGETALL(hash, function (err, obj) {
                     assert.equal(obj['0123456789'], 'abcdefghij');
                     assert.equal(obj['some manner of key'], 'a type of value');
@@ -29,12 +29,21 @@ describe("The 'hmset' method", function () {
             });
 
             it('handles object-style syntax', function (done) {
-                client.HMSET(hash, {"0123456789": "abcdefghij", "some manner of key": "a type of value"}, helper.isString('OK'));
+                client.HMSET(hash, {"0123456789": "abcdefghij", "some manner of key": "a type of value", "otherTypes": 555}, helper.isString('OK'));
                 client.HGETALL(hash, function (err, obj) {
                     assert.equal(obj['0123456789'], 'abcdefghij');
                     assert.equal(obj['some manner of key'], 'a type of value');
                     return done(err);
                 })
+            });
+
+            it('handles object-style syntax and the key being a number', function (done) {
+                client.HMSET(231232, {"0123456789": "abcdefghij", "some manner of key": "a type of value", "otherTypes": 555}, helper.isString('OK'));
+                client.HGETALL(231232, function (err, obj) {
+                    assert.equal(obj['0123456789'], 'abcdefghij');
+                    assert.equal(obj['some manner of key'], 'a type of value');
+                    return done(err);
+                });
             });
 
             it('allows a numeric key', function (done) {

--- a/test/commands/mset.spec.js
+++ b/test/commands/mset.spec.js
@@ -7,12 +7,6 @@ var uuid = require('uuid');
 
 describe("The 'mset' method", function () {
 
-    function removeMochaListener () {
-        var mochaListener = process.listeners('uncaughtException').pop();
-        process.removeListener('uncaughtException', mochaListener);
-        return mochaListener;
-    }
-
     helper.allTests(function(parser, ip, args) {
 
         describe("using " + parser + " and " + ip, function () {
@@ -102,7 +96,7 @@ describe("The 'mset' method", function () {
                     describe("with undefined 'key' and missing 'value'  parameter", function () {
                         // this behavior is different from the 'set' behavior.
                         it("throws an error", function (done) {
-                            var mochaListener = removeMochaListener();
+                            var mochaListener = helper.removeMochaListener();
 
                             process.once('uncaughtException', function (err) {
                                 process.on('uncaughtException', mochaListener);
@@ -116,7 +110,7 @@ describe("The 'mset' method", function () {
 
                     describe("with undefined 'key' and defined 'value' parameters", function () {
                         it("throws an error", function () {
-                            var mochaListener = removeMochaListener();
+                            var mochaListener = helper.removeMochaListener();
 
                             process.once('uncaughtException', function (err) {
                                 process.on('uncaughtException', mochaListener);

--- a/test/commands/select.spec.js
+++ b/test/commands/select.spec.js
@@ -6,12 +6,6 @@ var redis = config.redis;
 
 describe("The 'select' method", function () {
 
-    function removeMochaListener () {
-        var mochaListener = process.listeners('uncaughtException').pop();
-        process.removeListener('uncaughtException', mochaListener);
-        return mochaListener;
-    }
-
     helper.allTests(function(parser, ip, args) {
 
         describe("using " + parser + " and " + ip, function () {
@@ -96,7 +90,7 @@ describe("The 'select' method", function () {
 
                     describe("with an invalid db index", function () {
                         it("throws an error when callback not provided", function (done) {
-                            var mochaListener = removeMochaListener();
+                            var mochaListener = helper.removeMochaListener();
                             assert.strictEqual(client.selected_db, null, "default db should be null");
 
                             process.once('uncaughtException', function (err) {

--- a/test/commands/set.spec.js
+++ b/test/commands/set.spec.js
@@ -7,12 +7,6 @@ var uuid = require('uuid');
 
 describe("The 'set' method", function () {
 
-    function removeMochaListener () {
-        var mochaListener = process.listeners('uncaughtException').pop();
-        process.removeListener('uncaughtException', mochaListener);
-        return mochaListener;
-    }
-
     helper.allTests(function(parser, ip, args) {
 
         describe("using " + parser + " and " + ip, function () {
@@ -123,7 +117,7 @@ describe("The 'set' method", function () {
 
                         it("does not throw an error", function (done) {
                             this.timeout(200);
-                            var mochaListener = removeMochaListener();
+                            var mochaListener = helper.removeMochaListener();
 
                             process.once('uncaughtException', function (err) {
                                 process.on('uncaughtException', mochaListener);
@@ -140,7 +134,7 @@ describe("The 'set' method", function () {
 
                     describe("with undefined 'key' and defined 'value' parameters", function () {
                         it("throws an error", function () {
-                            var mochaListener = removeMochaListener();
+                            var mochaListener = helper.removeMochaListener();
 
                             process.once('uncaughtException', function (err) {
                                 process.on('uncaughtException', mochaListener);

--- a/test/conf/password.conf
+++ b/test/conf/password.conf
@@ -1,5 +1,5 @@
 requirepass porkchopsandwiches
-port 6378
+port 6379
 bind ::1 127.0.0.1
 unixsocket /tmp/redis.sock
 unixsocketperm 755

--- a/test/conf/redis.conf
+++ b/test/conf/redis.conf
@@ -1,4 +1,4 @@
-port 6378
+port 6379
 bind ::1 127.0.0.1
 unixsocket /tmp/redis.sock
 unixsocketperm 755

--- a/test/helper.js
+++ b/test/helper.js
@@ -92,12 +92,21 @@ module.exports = {
         return true;
     },
     allTests: function (cb) {
-        ['javascript', 'hiredis'].forEach(function (parser) {
-            cb(parser, "/tmp/redis.sock", config.configureClient(parser, "/tmp/redis.sock"));
-            ['IPv4', 'IPv6'].forEach(function (ip) {
-                cb(parser, ip, config.configureClient(parser, ip));
+        [undefined].forEach(function (options) { // add buffer option at some point
+            describe(options && options.return_buffers ? "returning buffers" : "returning strings", function () {
+                ['hiredis', 'javascript'].forEach(function (parser) {
+                    cb(parser, "/tmp/redis.sock", config.configureClient(parser, "/tmp/redis.sock", options));
+                    ['IPv4', 'IPv6'].forEach(function (ip) {
+                        cb(parser, ip, config.configureClient(parser, ip, options));
+                    });
+                });
             });
         });
+    },
+    removeMochaListener: function () {
+        var mochaListener = process.listeners('uncaughtException').pop();
+        process.removeListener('uncaughtException', mochaListener);
+        return mochaListener;
     }
 }
 

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -4,7 +4,7 @@ var redis = require('../../index');
 
 var config = {
     redis: redis,
-    PORT: 6378,
+    PORT: 6379,
     HOST: {
         IPv4: "127.0.0.1",
         IPv6: "::1"

--- a/test/lib/redis-process.js
+++ b/test/lib/redis-process.js
@@ -11,6 +11,17 @@ module.exports = {
         var confFile = conf || path.resolve(__dirname, '../conf/redis.conf');
         var rp = cp.spawn("redis-server", [confFile], {});
 
+        // capture a failure booting redis, and give
+        // the user running the test some directions.
+        rp.once("exit", function (code) {
+            if (code !== 0) {
+                console.error('failed to starting redis with exit code "' + code + '" ' +
+                  'stop any other redis processes currently running (' +
+                  'hint: lsof -i :6379)');
+                process.exit(code)
+            }
+        })
+
         // wait for redis to become available, by
         // checking the port we bind on.
         waitForRedis(true, function () {

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -9,15 +9,36 @@ describe("The node_redis client", function () {
 
     helper.allTests(function(parser, ip, args) {
 
+        if (args[2]) { // skip if options are undefined
+            describe("testing parser existence", function () {
+                it('throws on non-existence', function (done) {
+                    var mochaListener = helper.removeMochaListener();
+
+                    process.once('uncaughtException', function (err) {
+                        process.on('uncaughtException', mochaListener);
+                        assert.equal(err.message, 'Couldn\'t find named parser nonExistingParser on this system');
+                        return done();
+                    });
+
+                    // Don't pollute the args for the other connections
+                    var tmp = JSON.parse(JSON.stringify(args));
+                    tmp[2].parser = 'nonExistingParser';
+                    redis.createClient.apply(redis.createClient, tmp);
+                });
+            });
+        }
+
         describe("using " + parser + " and " + ip, function () {
             var client;
 
             describe("when not connected", function () {
                 afterEach(function () {
-                    client.end();
+                    if (client) {
+                        client.end();
+                    }
                 });
 
-                it("connects correctly", function (done) {
+                it("connects correctly with args", function (done) {
                     client = redis.createClient.apply(redis.createClient, args);
                     client.on("error", done);
 
@@ -28,6 +49,58 @@ describe("The node_redis client", function () {
                         });
                     });
                 });
+
+                it("connects correctly with defaults values", function (done) {
+                    client = redis.createClient();
+                    client.on("error", done);
+
+                    client.once("ready", function () {
+                        client.removeListener("error", done);
+                        client.get("recon 1", function (err, res) {
+                            done(err);
+                        });
+                    });
+                });
+
+                it("connects correctly to localhost", function (done) {
+                    client = redis.createClient(null, null);
+                    client.on("error", done);
+
+                    client.once("ready", function () {
+                        client.removeListener("error", done);
+                        client.get("recon 1", function (err, res) {
+                            done(err);
+                        });
+                    });
+                });
+
+                it("throws on strange connection infos", function () {
+                    try {
+                        redis.createClient(true);
+                        throw new Error('failed');
+                    } catch (err) {
+                        assert.equal(err.message, 'unknown type of connection in createClient()');
+                    }
+                });
+
+                if (ip === 'IPv4') {
+                    it('allows connecting with the redis url and the default port', function (done) {
+                        client = redis.createClient('redis://foo:porkchopsandwiches@' + config.HOST[ip]);
+                        client.on("ready", function () {
+                            return done();
+                        });
+                    });
+
+                    it('allows connecting with the redis url and no auth', function (done) {
+                        client = redis.createClient('redis://' + config.HOST[ip] + ':' + config.PORT, {
+                            detect_buffers: false
+                        });
+                        client.on("ready", function () {
+                            return done();
+                        });
+                    });
+                }
+
             });
 
             describe("when connected", function () {

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -50,7 +50,7 @@ describe("The node_redis client", function () {
                     });
                 });
 
-                it("connects correctly with defaults values", function (done) {
+                it("connects correctly with default values", function (done) {
                     client = redis.createClient();
                     client.on("error", done);
 
@@ -74,7 +74,7 @@ describe("The node_redis client", function () {
                     });
                 });
 
-                it("throws on strange connection infos", function () {
+                it("throws on strange connection info", function () {
                     try {
                         redis.createClient(true);
                         throw new Error('failed');


### PR DESCRIPTION
slight modification to https://github.com/NodeRedis/node_redis/pull/815

* we now spawn redis on the default port so that we don't need to run a second copy of redis for tests that exercise node_redis' default behavior.
* we stop the tests and warn the user if they already have a copy of redis up and running on `:6379`.
