### PR TITLE
Revert to old behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,16 +13,13 @@ var net = require("net"),
     connection_id = 0,
     default_port = 6379,
     default_host = "127.0.0.1",
-    debug;
+    debug = function(msg) {
+        if (exports.debug_mode) {
+            console.error(msg);
+        }
+    };
 
-/* istanbul ignore next */
-if (util.debuglog) {
-    debug = util.debuglog('redis');
-} else if (/\bredis\b/i.test(process.env.NODE_DEBUG)) {
-    debug = console.error;
-} else {
-    debug = function() {};
-}
+exports.debug_mode = /\bredis\b/i.test(process.env.NODE_DEBUG);
 
 // hiredis might not be installed
 try {


### PR DESCRIPTION
I thought it is probably best to revert the debug behavior to be in line with the old one until be release a new major version. It is still possible to pass the NODE_DEBUG env though, so the readme is up to date. Just no code is going to break at all (even though it is unlikely that someone read our stderr stream and relied on our debug messages in real code).