### PR TITLE
Remove event emitters from the parsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,18 +302,8 @@ RedisClient.prototype.init_parser = function () {
     this.reply_parser = new this.parser_module.Parser({
         return_buffers: self.options.return_buffers || self.options.detect_buffers || false
     });
-
-    // "reply error" is an error sent back by Redis
-    this.reply_parser.on("reply error", function (reply) {
-        self.return_error(reply);
-    });
-    this.reply_parser.on("reply", function (reply) {
-        self.return_reply(reply);
-    });
-    // "error" is bad.  Somehow the parser got confused.  It'll try to reset and continue.
-    this.reply_parser.on("error", function (err) {
-        self.emit("error", new Error("Redis reply parser error: " + err.stack));
-    });
+    this.reply_parser.send_error = this.return_error.bind(self);
+    this.reply_parser.send_reply = this.return_reply.bind(self);
 };
 
 RedisClient.prototype.on_ready = function () {

--- a/lib/parser/hiredis.js
+++ b/lib/parser/hiredis.js
@@ -1,8 +1,6 @@
 'use strict';
 
-var events = require("events"),
-    util = require("util"),
-    hiredis = require("hiredis");
+var hiredis = require("hiredis");
 
 exports.name = "hiredis";
 
@@ -10,10 +8,7 @@ function HiredisReplyParser(options) {
     this.name = exports.name;
     this.options = options || {};
     this.reset();
-    events.EventEmitter.call(this);
 }
-
-util.inherits(HiredisReplyParser, events.EventEmitter);
 
 exports.Parser = HiredisReplyParser;
 
@@ -27,21 +22,16 @@ HiredisReplyParser.prototype.execute = function (data) {
     var reply;
     this.reader.feed(data);
     while (true) {
-        try {
-            reply = this.reader.get();
-        } catch (err) {
-            this.emit("error", err);
-            break;
-        }
+        reply = this.reader.get();
 
         if (reply === undefined) {
             break;
         }
 
         if (reply && reply.constructor === Error) {
-            this.emit("reply error", reply);
+            this.send_error(reply);
         } else {
-            this.emit("reply", reply);
+            this.send_reply(reply);
         }
     }
 };

--- a/lib/parser/javascript.js
+++ b/lib/parser/javascript.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var events = require("events"),
-    util   = require("util");
+var util   = require("util");
 
 function Packet(type, size) {
     this.type = type;
@@ -19,8 +18,6 @@ function ReplyParser(options) {
     this._encoding          = "utf-8";
     this._reply_type        = null;
 }
-
-util.inherits(ReplyParser, events.EventEmitter);
 
 exports.Parser = ReplyParser;
 
@@ -285,12 +282,4 @@ ReplyParser.prototype._packetEndOffset = function () {
 
 ReplyParser.prototype._bytesRemaining = function () {
     return (this._buffer.length - this._offset) < 0 ? 0 : (this._buffer.length - this._offset);
-};
-
-ReplyParser.prototype.send_error = function (reply) {
-    this.emit("reply error", reply);
-};
-
-ReplyParser.prototype.send_reply = function (reply) {
-    this.emit("reply", reply);
 };

--- a/test/parser/javascript.spec.js
+++ b/test/parser/javascript.spec.js
@@ -11,7 +11,7 @@ describe('javascript parser', function () {
             assert.deepEqual(reply, [['a']], "Expecting multi-bulk reply of [['a']]");
             reply_count++;
         }
-        parser.on("reply", check_reply);
+        parser.send_reply = check_reply;
 
         parser.execute(new Buffer('*1\r\n*1\r\n$1\r\na\r\n'));
 


### PR DESCRIPTION
 Right now the parser first emit the reply / error and the catched data is then passed to another function.

This is an unneeded overhead as it's possible to call the function without any detour.