### PR TITLE
Fix multi error handling

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ generate_commands.js
 multi_bench.js
 test-unref.js
 changelog.md
+*.log

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -77,6 +77,21 @@ describe("The node_redis client", function () {
                     });
                 });
 
+                it("connects correctly to localhost and no ready check", function (done) {
+                    client = redis.createClient(undefined, undefined, {
+                        no_ready_check: true
+                    });
+                    client.on("error", done);
+
+                    client.once("ready", function () {
+                        client.set('foo', 'bar');
+                        client.get('foo', function(err, res) {
+                            assert.strictEqual(res, 'bar');
+                            done(err);
+                        });
+                    });
+                });
+
                 it("throws on strange connection info", function () {
                     try {
                         redis.createClient(true);


### PR DESCRIPTION
This is only optimizing the error handling to be consistent as mentioned in #689. It would be great to get some replies about the behavior as I implemented it here, as there might be room for further optimizations.

<s>It seems like the js parser is not in line with the redis parser though (errors are returned as replies) and therefor one test is going to fail with the js parser. I did not dig into fixing this yet.</s>