### PR TITLE
Consistent commands arguments

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,6 +16,9 @@
     "node": true, // Enable globals available when code is running inside of the NodeJS runtime environment.
     "mocha": true,
 
+    // Relaxing options
+    "boss": true, // Accept things like `while (command = keys.shift()) { ... }`
+
     "overrides": {
         "examples/*.js": {
             "unused": false

--- a/test/commands/blpop.spec.js
+++ b/test/commands/blpop.spec.js
@@ -33,6 +33,16 @@ describe("The 'blpop' method", function () {
                 });
             });
 
+            it('pops value immediately if list contains values using array notation', function (done) {
+                bclient = redis.createClient.apply(redis.createClient, args);
+                client.rpush(["blocking list", "initial value"], helper.isNumber(1));
+                bclient.blpop(["blocking list", 0], function (err, value) {
+                    assert.strictEqual(value[0], "blocking list");
+                    assert.strictEqual(value[1], "initial value");
+                    return done(err);
+                });
+            });
+
             it('waits for value if list is not yet populated', function (done) {
                 bclient = redis.createClient.apply(redis.createClient, args);
                 bclient.blpop("blocking list 2", 5, function (err, value) {

--- a/test/commands/client.spec.js
+++ b/test/commands/client.spec.js
@@ -37,8 +37,17 @@ describe("The 'client' method", function () {
                     });
                 });
 
+                it("lists connected clients when invoked with array syntax on client", function (done) {
+                    client.multi().client(["list"]).exec(function(err, results) {
+                        assert(pattern.test(results[0]), "expected string '" + results + "' to match " + pattern.toString());
+                        return done();
+                    });
+                });
+
                 it("lists connected clients when invoked with multi's array syntax", function (done) {
-                    client.multi().client("list").exec(function(err, results) {
+                    client.multi([
+                        ['client', 'list']
+                    ]).exec(function(err, results) {
                         assert(pattern.test(results[0]), "expected string '" + results + "' to match " + pattern.toString());
                         return done();
                     });

--- a/test/commands/dbsize.spec.js
+++ b/test/commands/dbsize.spec.js
@@ -71,7 +71,7 @@ describe("The 'dbsize' method", function () {
                     var oldSize;
 
                     beforeEach(function (done) {
-                        client.dbsize([], function (err, res) {
+                        client.dbsize(function (err, res) {
                             helper.isType.number()(err, res);
                             assert.strictEqual(res, 0, "Initial db size should be 0");
 

--- a/test/commands/del.spec.js
+++ b/test/commands/del.spec.js
@@ -36,6 +36,20 @@ describe("The 'del' method", function () {
                 client.get('apple', helper.isNull(done));
             });
 
+            it('allows multiple keys to be deleted with the array syntax', function (done) {
+                client.mset('foo', 'bar', 'apple', 'banana');
+                client.del(['foo', 'apple'], helper.isNumber(2));
+                client.get('foo', helper.isNull());
+                client.get('apple', helper.isNull(done));
+            });
+
+            it('allows multiple keys to be deleted with the array syntax and no callback', function (done) {
+                client.mset('foo', 'bar', 'apple', 'banana');
+                client.del(['foo', 'apple']);
+                client.get('foo', helper.isNull());
+                client.get('apple', helper.isNull(done));
+            });
+
             afterEach(function () {
                 client.end();
             });

--- a/test/commands/exits.spec.js
+++ b/test/commands/exits.spec.js
@@ -24,6 +24,11 @@ describe("The 'exits' method", function () {
                 client.EXISTS('foo', helper.isNumber(1, done));
             });
 
+            it('returns 1 if the key exists with array syntax', function (done) {
+                client.set('foo', 'bar');
+                client.EXISTS(['foo'], helper.isNumber(1, done));
+            });
+
             it('returns 0 if the key does not exist', function (done) {
                 client.exists('bar', helper.isNumber(0, done));
             });

--- a/test/commands/expire.spec.js
+++ b/test/commands/expire.spec.js
@@ -21,6 +21,14 @@ describe("The 'expire' method", function () {
 
             it('expires key after timeout', function (done) {
                 client.set(['expiry key', 'bar'], helper.isString("OK"));
+                client.EXPIRE("expiry key", "1", helper.isNumber(1));
+                setTimeout(function () {
+                    client.exists(["expiry key"], helper.isNumber(0, done));
+                }, 1100);
+            });
+
+            it('expires key after timeout with array syntax', function (done) {
+                client.set(['expiry key', 'bar'], helper.isString("OK"));
                 client.EXPIRE(["expiry key", "1"], helper.isNumber(1));
                 setTimeout(function () {
                     client.exists(["expiry key"], helper.isNumber(0, done));

--- a/test/commands/flushdb.spec.js
+++ b/test/commands/flushdb.spec.js
@@ -58,35 +58,49 @@ describe("The 'flushdb' method", function () {
                 describe("when there is data in Redis", function () {
 
                     beforeEach(function (done) {
-                        var end = helper.callFuncAfter(function () {
-                            client.flushdb(helper.isString("OK", done));
-                        }, 2);
-                        client.mset(key, uuid.v4(), key2, uuid.v4(), helper.isNotError(end));
+                        client.mset(key, uuid.v4(), key2, uuid.v4(), helper.isNotError());
                         client.dbsize([], function (err, res) {
                             helper.isType.positiveNumber()(err, res);
                             assert.equal(res, 2, 'Two keys should have been inserted');
-                            end();
+                            done();
                         });
                     });
 
                     it("deletes all the keys", function (done) {
-                        client.mget(key, key2, function (err, res) {
-                            assert.strictEqual(null, err, "Unexpected error returned");
-                            assert.strictEqual(true, Array.isArray(res), "Results object should be an array.");
-                            assert.strictEqual(2, res.length, "Results array should have length 2.");
-                            assert.strictEqual(null, res[0], "Redis key should have been flushed.");
-                            assert.strictEqual(null, res[1], "Redis key should have been flushed.");
-                            done(err);
+                        client.flushdb(function(err, res) {
+                            assert.equal(res, 'OK');
+                            client.mget(key, key2, function (err, res) {
+                                assert.strictEqual(null, err, "Unexpected error returned");
+                                assert.strictEqual(true, Array.isArray(res), "Results object should be an array.");
+                                assert.strictEqual(2, res.length, "Results array should have length 2.");
+                                assert.strictEqual(null, res[0], "Redis key should have been flushed.");
+                                assert.strictEqual(null, res[1], "Redis key should have been flushed.");
+                                done(err);
+                            });
                         });
                     });
 
                     it("results in a db size of zero", function (done) {
-                        client.dbsize([], function (err, res) {
-                            helper.isNotError()(err, res);
-                            helper.isType.number()(err, res);
-                            assert.strictEqual(0, res, "Flushing db should result in db size 0");
-                            done();
+                        client.flushdb(function(err, res) {
+                            client.dbsize([], function (err, res) {
+                                helper.isNotError()(err, res);
+                                helper.isType.number()(err, res);
+                                assert.strictEqual(0, res, "Flushing db should result in db size 0");
+                                done();
+                            });
                         });
+                    });
+
+                    it("results in a db size of zero without a callback", function (done) {
+                        client.flushdb();
+                        setTimeout(function(err, res) {
+                            client.dbsize([], function (err, res) {
+                                helper.isNotError()(err, res);
+                                helper.isType.number()(err, res);
+                                assert.strictEqual(0, res, "Flushing db should result in db size 0");
+                                done();
+                            });
+                        }, 25);
                     });
                 });
             });

--- a/test/commands/get.spec.js
+++ b/test/commands/get.spec.js
@@ -70,6 +70,21 @@ describe("The 'get' method", function () {
                             done(err);
                         });
                     });
+
+                    it("gets the value correctly with array syntax and the callback being in the array", function (done) {
+                        client.GET([key, function (err, res) {
+                            helper.isString(value)(err, res);
+                            done(err);
+                        }]);
+                    });
+
+                    it("should not throw on a get without callback (even if it's not useful", function (done) {
+                        client.GET(key);
+                        client.on('error', function(err) {
+                            throw err;
+                        });
+                        setTimeout(done, 50);
+                    });
                 });
 
                 describe("when the key does not exist in Redis", function () {

--- a/test/commands/getset.spec.js
+++ b/test/commands/getset.spec.js
@@ -74,6 +74,26 @@ describe("The 'getset' method", function () {
                             });
                         });
                     });
+
+                    it("gets the value correctly with array syntax", function (done) {
+                        client.GETSET([key, value2], function (err, res) {
+                            helper.isString(value)(err, res);
+                            client.get(key, function (err, res) {
+                                helper.isString(value2)(err, res);
+                                done(err);
+                            });
+                        });
+                    });
+
+                    it("gets the value correctly with array syntax style 2", function (done) {
+                        client.GETSET(key, [value2], function (err, res) {
+                            helper.isString(value)(err, res);
+                            client.get(key, function (err, res) {
+                                helper.isString(value2)(err, res);
+                                done(err);
+                            });
+                        });
+                    });
                 });
 
                 describe("when the key does not exist in Redis", function () {

--- a/test/commands/hgetall.spec.js
+++ b/test/commands/hgetall.spec.js
@@ -67,7 +67,7 @@ describe("The 'hgetall' method", function () {
 
                 it('returns binary results', function (done) {
                     client.hmset(["bhosts", "mjr", "1", "another", "23", "home", "1234", new Buffer([0xAA, 0xBB, 0x00, 0xF0]), new Buffer([0xCC, 0xDD, 0x00, 0xF0])], helper.isString("OK"));
-                    client.HGETALL(["bhosts"], function (err, obj) {
+                    client.HGETALL(["bhosts", function (err, obj) {
                         assert.strictEqual(4, Object.keys(obj).length);
                         assert.strictEqual("1", obj.mjr.toString());
                         assert.strictEqual("23", obj.another.toString());
@@ -75,7 +75,7 @@ describe("The 'hgetall' method", function () {
                         assert.strictEqual((new Buffer([0xAA, 0xBB, 0x00, 0xF0])).toString('binary'), Object.keys(obj)[3]);
                         assert.strictEqual((new Buffer([0xCC, 0xDD, 0x00, 0xF0])).toString('binary'), obj[(new Buffer([0xAA, 0xBB, 0x00, 0xF0])).toString('binary')].toString('binary'));
                         return done(err);
-                    });
+                    }]);
                 });
             });
 

--- a/test/commands/hmset.spec.js
+++ b/test/commands/hmset.spec.js
@@ -83,6 +83,24 @@ describe("The 'hmset' method", function () {
                 });
             });
 
+            it('allows a key plus array without callback', function (done) {
+                client.HMSET(hash, [99, 'banana', 'test', 25]);
+                client.HGETALL(hash, function (err, obj) {
+                    assert.equal(obj['99'], 'banana');
+                    assert.equal(obj.test, '25');
+                    return done(err);
+                });
+            });
+
+            it('allows a key plus array and a callback', function (done) {
+                client.HMSET(hash, [99, 'banana', 'test', 25], helper.isString('OK'));
+                client.HGETALL(hash, function (err, obj) {
+                    assert.equal(obj['99'], 'banana');
+                    assert.equal(obj.test, '25');
+                    return done(err);
+                });
+            });
+
             it('handles object-style syntax without callback', function (done) {
                 client.HMSET(hash, {"0123456789": "abcdefghij", "some manner of key": "a type of value"});
                 client.HGETALL(hash, function (err, obj) {

--- a/test/commands/keys.spec.js
+++ b/test/commands/keys.spec.js
@@ -23,7 +23,7 @@ describe("The 'keys' method", function () {
 
             it('returns matching keys', function (done) {
                 client.mset(["test keys 1", "test val 1", "test keys 2", "test val 2"], helper.isString("OK"));
-                client.KEYS(["test keys*"], function (err, results) {
+                client.KEYS("test keys*", function (err, results) {
                     assert.strictEqual(2, results.length);
                     assert.ok(~results.indexOf("test keys 1"));
                     assert.ok(~results.indexOf("test keys 2"));

--- a/test/commands/mget.spec.js
+++ b/test/commands/mget.spec.js
@@ -42,7 +42,7 @@ describe("The 'mget' method", function () {
             });
 
             it('handles fetching multiple keys, when some keys do not exist', function (done) {
-                client.MGET(["mget keys 1", "some random shit", "mget keys 2", "mget keys 3"], function (err, results) {
+                client.MGET("mget keys 1", ["some random shit", "mget keys 2", "mget keys 3"], function (err, results) {
                     assert.strictEqual(4, results.length);
                     assert.strictEqual("mget val 1", results[0].toString());
                     assert.strictEqual(null, results[1]);

--- a/test/commands/mset.spec.js
+++ b/test/commands/mset.spec.js
@@ -88,6 +88,12 @@ describe("The 'mset' method", function () {
                             client.get(key, helper.isString(value2));
                             client.get(key2, helper.isString(value, done));
                         });
+
+                        it("sets the value correctly with array syntax", function (done) {
+                            client.mset([key, value2, key2, value]);
+                            client.get([key, helper.isString(value2)]);
+                            client.get(key2, helper.isString(value, done));
+                        });
                     });
 
                     describe("with undefined 'key' and missing 'value'  parameter", function () {

--- a/test/commands/multi.spec.js
+++ b/test/commands/multi.spec.js
@@ -165,6 +165,23 @@ describe("The 'multi' method", function () {
                         });
                 });
 
+                it('allows multiple commands to work the same as normal to be performed using a chaining API', function (done) {
+                    client.multi()
+                        .mset(['some', '10', 'keys', '20'])
+                        .incr('some')
+                        .incr('keys')
+                        .mget('some', 'keys')
+                        .exec(function (err, replies) {
+                            assert.strictEqual(null, err);
+                            assert.equal('OK', replies[0]);
+                            assert.equal(11, replies[1]);
+                            assert.equal(21, replies[2]);
+                            assert.equal(11, replies[3][0].toString());
+                            assert.equal(21, replies[3][1].toString());
+                            return done();
+                        });
+                });
+
                 it('allows an array to be provided indicating multiple operations to perform', function (done) {
                     // test nested multi-bulk replies with nulls.
                     client.multi([

--- a/test/commands/rpush.spec.js
+++ b/test/commands/rpush.spec.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var config = require("../lib/config");
+var helper = require("../helper");
+var redis = config.redis;
+var assert = require('assert');
+
+describe("The 'rpush' command", function () {
+
+    helper.allTests(function(parser, ip, args) {
+
+        describe("using " + parser + " and " + ip, function () {
+            var client;
+
+            beforeEach(function (done) {
+                client = redis.createClient.apply(redis.createClient, args);
+                client.once("error", done);
+                client.once("connect", function () {
+                    client.flushdb(done);
+                });
+            });
+
+            it('inserts multiple values at a time into a list', function (done) {
+                client.rpush('test', ['list key', 'should be a list']);
+                client.lrange('test', 0, -1, function(err, res) {
+                    assert.equal(res[0], 'list key');
+                    assert.equal(res[1], 'should be a list');
+                    done(err);
+                });
+            });
+
+            afterEach(function () {
+                client.end();
+            });
+        });
+    });
+});

--- a/test/commands/sadd.spec.js
+++ b/test/commands/sadd.spec.js
@@ -44,6 +44,17 @@ describe("The 'sadd' method", function () {
                 });
             });
 
+            it('allows multiple values to be added to the set with a different syntax', function (done) {
+                client.sadd(["set0", "member0", "member1", "member2"], helper.isNumber(3));
+                client.smembers("set0", function (err, res) {
+                    assert.strictEqual(res.length, 3);
+                    assert.ok(~res.indexOf("member0"));
+                    assert.ok(~res.indexOf("member1"));
+                    assert.ok(~res.indexOf("member2"));
+                    return done(err);
+                });
+            });
+
             afterEach(function () {
                 client.end();
             });

--- a/test/commands/sdiff.spec.js
+++ b/test/commands/sdiff.spec.js
@@ -22,11 +22,11 @@ describe("The 'sdiff' method", function () {
 
             it('returns set difference', function (done) {
                 client.sadd('foo', 'x', helper.isNumber(1));
-                client.sadd('foo', 'a', helper.isNumber(1));
+                client.sadd('foo', ['a'], helper.isNumber(1));
                 client.sadd('foo', 'b', helper.isNumber(1));
-                client.sadd('foo', 'c', helper.isNumber(1));
+                client.sadd(['foo', 'c'], helper.isNumber(1));
 
-                client.sadd('bar', 'c', helper.isNumber(1));
+                client.sadd(['bar', 'c', helper.isNumber(1)]);
 
                 client.sadd('baz', 'a', helper.isNumber(1));
                 client.sadd('baz', 'd', helper.isNumber(1));

--- a/test/commands/sort.spec.js
+++ b/test/commands/sort.spec.js
@@ -75,6 +75,13 @@ describe("The 'sort' method", function () {
                     });
                 });
 
+                it("handles sorting with a 'by' pattern and 2 'get' patterns with the array syntax", function (done) {
+                    client.sort(['x', 'by', 'w*', 'asc', 'get', 'o*', 'get', 'p*'], function (err, sorted) {
+                        assert.deepEqual(sorted, ['foo', 'bux', 'bar', 'tux', 'baz', 'lux', 'buz', 'qux']);
+                        return done(err);
+                    });
+                });
+
                 it("sorting with a 'by' pattern and 2 'get' patterns and stores results", function (done) {
                     client.sort('x', 'by', 'w*', 'asc', 'get', 'o*', 'get', 'p*', 'store', 'bacon', function (err) {
                         if (err) return done(err);

--- a/test/commands/srem.spec.js
+++ b/test/commands/srem.spec.js
@@ -41,8 +41,8 @@ describe("The 'srem' method", function () {
             });
 
             it('handles a value missing from the set of values being removed', function (done) {
-                client.sadd("set0", ["member0", "member1", "member2"], helper.isNumber(3));
-                client.SREM("set0", ["member3", "member4"], helper.isNumber(0));
+                client.sadd(["set0", "member0", "member1", "member2"], helper.isNumber(3));
+                client.SREM(["set0", "member3", "member4"], helper.isNumber(0));
                 client.smembers("set0", function (err, res) {
                     assert.strictEqual(res.length, 3);
                     assert.ok(~res.indexOf("member0"));

--- a/test/commands/type.spec.js
+++ b/test/commands/type.spec.js
@@ -35,12 +35,12 @@ describe("The 'type' method", function () {
             });
 
             it('reports zset type', function (done) {
-                client.zadd(["zset key", "10.0", "should be a zset"], helper.isNumber(1));
+                client.zadd("zset key", ["10.0", "should be a zset"], helper.isNumber(1));
                 client.TYPE(["zset key"], helper.isString("zset", done));
             });
 
             it('reports hash type', function (done) {
-                client.hset(["hash key", "hashtest", "should be a hash"], helper.isNumber(1));
+                client.hset("hash key", "hashtest", "should be a hash", helper.isNumber(1));
                 client.TYPE(["hash key"], helper.isString("hash", done));
             });
 


### PR DESCRIPTION
This fixes #686, #369, #422 and #390 and closes #634 and very likely more.

Earlier quite some commands were handled different. Now all commands take the same arguments, no matter if they are on multi or not.