### PR TITLE
Let v8 inline instead of doing in manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .nyc_output
 coverage
 npm-debug.log
+*.rdb


### PR DESCRIPTION
v8 is inlining those variables since a long time.
This is cleaner to read and I also optimized .auth not to use .to_array.
And the redis version is always there when calling .info without arguments