### PR TITLE
Flush queue when .end() is called

### DIFF
--- a/index.js
+++ b/index.js
@@ -854,6 +854,9 @@ RedisClient.prototype.end = function () {
     }
     this.stream.on("error", function(){});
 
+    // Flush queue
+    this.flush_and_error("Redis connection ended.");
+
     this.connected = false;
     this.ready = false;
     this.closing = true;


### PR DESCRIPTION
Flushes the queue when `.end()` is called to avoid pending callbacks not getting called, as mentioned in #572 .