### PR TITLE
trigger `connect`&`ready` event even the client is ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ limits total amount of connection tries. Setting this to 1 will prevent any reco
 * `auth_pass` defaults to `null`. By default client will try connecting without auth. If set, client will run redis auth command on connect.
 * `family` defaults to `IPv4`. The client connects in IPv4 if not specified or if the DNS resolution returns an IPv4 address.
 You can force an IPv6 if you set the family to 'IPv6'. See nodejs net or dns modules how to use the family type.
+* `always_trigger_ready`: defaults to `false`. By default if try listen `connect` or `ready` event on a ready client, the listeners will not triggered. Set this option to `true`, both `connect`&`ready` will triggered at this situation. However, if `no_ready_check` is `true`, only `connect` will triggered.
 
 ```js
 var redis = require("redis"),

--- a/index.js
+++ b/index.js
@@ -83,11 +83,22 @@ function RedisClient(stream, options) {
     this.install_stream_listeners();
 
     events.EventEmitter.call(this);
+
+    if (options.always_trigger_ready) {
+      this.on("newListener", function (name, func) {
+        if (this.connected && name === "connect") {
+          func.call(this);
+        }
+        if (this.ready && !this.no_ready_check && name === "ready") {
+          func.call(this);
+        }
+      });
+    }
 }
 util.inherits(RedisClient, events.EventEmitter);
 exports.RedisClient = RedisClient;
 
-RedisClient.prototype.install_stream_listeners = function() {
+RedisClient.prototype.install_stream_listeners = function () {
     var self = this;
 
     this.stream.on("connect", function () {

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function RedisClient(stream, options) {
         if (this.connected && name === "connect") {
           func.call(this);
         }
-        if (this.ready && !this.no_ready_check && name === "ready") {
+        if (this.ready && !this.options.no_ready_check && name === "ready") {
           func.call(this);
         }
       });

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -859,6 +859,34 @@ describe("The node_redis client", function () {
                       always_trigger_ready: true
                   });
 
+                  it("fires client.on('connect') after clietn.ready is true", function (done) {
+                      client = redis.createClient.apply(redis.createClient, args);
+                      client.on("connect", function () {
+                          client.on("connect", function () {
+                              client.quit();
+
+                              client.once('end', function () {
+                                  return done();
+                              });
+                          });
+                      });
+                  });
+
+                  it("fires client.on('connect') after clietn.ready is true and 'no_ready_check' is true", function (done) {
+                      client = redis.createClient.apply(redis.createClient, args);
+                      client.on("connect", function () {
+                          client.options.no_ready_check = true;
+                          client.on("connect", function () {
+                              client.quit();
+
+                              client.once('end', function () {
+                                  delete client.options.no_ready_check;
+                                  return done();
+                              });
+                          });
+                      });
+                  });
+
                   it("fires client.on('ready') after clietn.ready is true", function (done) {
                       client = redis.createClient.apply(redis.createClient, args);
                       client.on("ready", function () {
@@ -869,6 +897,24 @@ describe("The node_redis client", function () {
                                   return done();
                               });
                           });
+                      });
+                  });
+
+                  it("not fires client.on('ready') after clietn.ready is true and 'no_ready_check' is true", function (done) {
+                      client = redis.createClient.apply(redis.createClient, args);
+                      client.on("ready", function () {
+                          client.options.no_ready_check = true;
+                          client.on("ready", function () {
+                              assert(null);
+                          });
+                          setTimeout(function () {
+                              client.quit();
+
+                              client.once('end', function () {
+                                  delete client.options.no_ready_check;
+                                  return done();
+                              });
+                          }, 1100);
                       });
                   });
                 });
@@ -885,7 +931,13 @@ describe("The node_redis client", function () {
                             client.on("ready", function () {
                                 assert(null);
                             });
-                            setTimeout(done, 1100);
+                            setTimeout(function () {
+                                client.quit();
+
+                                client.once('end', function () {
+                                    return done();
+                                });
+                            }, 1100);
                         });
                     });
                 });

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -852,6 +852,44 @@ describe("The node_redis client", function () {
                 });
             });
 
+            describe('always_trigger_ready', function () {
+                describe('true', function () {
+                  var client;
+                  var args = config.configureClient(parser, ip, {
+                      always_trigger_ready: true
+                  });
+
+                  it("fires client.on('ready') after clietn.ready is true", function (done) {
+                      client = redis.createClient.apply(redis.createClient, args);
+                      client.on("ready", function () {
+                          client.on("ready", function () {
+                              client.quit();
+
+                              client.once('end', function () {
+                                  return done();
+                              });
+                          });
+                      });
+                  });
+                });
+
+                describe('false', function () {
+                    var client;
+                    var args = config.configureClient(parser, ip, {
+                        always_trigger_ready: false
+                    });
+
+                    it("not fires client.on('ready') after clietn.ready is true", function (done) {
+                        client = redis.createClient.apply(redis.createClient, args);
+                        client.on("ready", function () {
+                            client.on("ready", function () {
+                                assert(null);
+                            });
+                            setTimeout(done, 1100);
+                        });
+                    });
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
When we try listen `connect` or `ready` event on a ready client, our `listener` would not triggered.

````
// redisClient.js
module.exports = redis.createClient();
````
````
// clientA.js
var client = require('./redisClient');
client.on('ready', function() {
  // normally, we will go here once the client is ready
});
````
````
// clientB.js
var client = require('./redisClient');
client.on('ready', function() {
  // but there possibility that we cannot go here if the client.ready is `true` before we try to listen `ready`
});
````
I add a option called `always_trigger_ready` (the option name looks not good~~) for above situation.
By default, the option is `false` to be compatible.
If set the option to `true`, when we try to listen a `ready` or `connect` event on a ready client, our `listener` would triggered immediately.
If `no_ready_check` is `true`, only `connect` event will triggered.