### PR TITLE
Remove bad .eval implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var net = require("net"),
     Queue = require("./lib/queue"),
     to_array = require("./lib/to_array"),
     events = require("events"),
-    crypto = require("crypto"),
     parsers = [],
     // This static list of commands is updated from time to time.
     // ./lib/commands.js can be updated with generate_commands.js
@@ -1081,37 +1080,6 @@ Multi.prototype.execute_callback = function (err, replies) {
 
 RedisClient.prototype.multi = RedisClient.prototype.MULTI = function (args) {
     return new Multi(this, args);
-};
-
-// stash original eval method
-var eval_orig = RedisClient.prototype.eval;
-// hook eval with an attempt to evalsha for cached scripts
-RedisClient.prototype.eval = RedisClient.prototype.EVAL = function () {
-    var self = this,
-        args = to_array(arguments),
-        callback;
-
-    if (typeof args[args.length - 1] === "function") {
-        callback = args.pop();
-    }
-
-    if (Array.isArray(args[0])) {
-        args = args[0];
-    }
-
-    // replace script source with sha value
-    var source = args[0];
-    args[0] = crypto.createHash("sha1").update(source).digest("hex");
-
-    self.evalsha(args, function (err, reply) {
-        if (err && /NOSCRIPT/.test(err.message)) {
-            args[0] = source;
-            eval_orig.call(self, args, callback);
-
-        } else if (callback) {
-            callback(err, reply);
-        }
-    });
 };
 
 var createClient_unix = function(path, options){


### PR DESCRIPTION
The implementation is not really good as mentioned in #722 and we pipeline our commands.
That way we can't just replace the eval function as it was. This could result in violating the order of execution!

If we want to include a function like this we should not break the order of execution and also not recalculate the sha1 hash each time.