### PR TITLE
Add redis error codes to the errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1060,7 +1060,6 @@ Multi.prototype.execute_callback = function (err, replies) {
 
     if (err) {
         if (err.code !== 'CONNECTION_BROKEN') {
-            err.code = 'EXECABORT';
             err.errors = this.errors;
             if (this.callback) {
                 this.callback(err);

--- a/index.js
+++ b/index.js
@@ -1077,7 +1077,13 @@ Multi.prototype.execute_callback = function (err, replies) {
             args = this.queue[i];
 
             // If we asked for strings, even in detect_buffers mode, then return strings:
-            if (reply) {
+            if (reply instanceof Error) {
+                var match = reply.message.match(err_code);
+                // LUA script could return user errors that don't behave like all other errors!
+                if (match) {
+                    reply.code = match[1];
+                }
+            } else if (reply) {
                 if (this._client.options.detect_buffers && this.wants_buffers[i] === false) {
                     replies[i - 1] = reply = reply_to_strings(reply);
                 }

--- a/test/commands/eval.spec.js
+++ b/test/commands/eval.spec.js
@@ -128,6 +128,7 @@ describe("The 'eval' method", function () {
                     helper.serverVersionAtLeast.call(this, client, [2, 5, 0]);
                     client.evalsha('ffffffffffffffffffffffffffffffffffffffff', 0);
                     client.on('error', function(err) {
+                        assert.equal(err.code, 'NOSCRIPT');
                         assert(/NOSCRIPT No matching script. Please use EVAL./.test(err.message));
                         done();
                     });

--- a/test/commands/eval.spec.js
+++ b/test/commands/eval.spec.js
@@ -52,7 +52,11 @@ describe("The 'eval' method", function () {
 
             it('converts lua error to an error response', function (done) {
                 helper.serverVersionAtLeast.call(this, client, [2, 5, 0]);
-                client.eval("return {err='this is an error'}", 0, helper.isError(done));
+                client.eval("return {err='this is an error'}", 0, function(err) {
+                    assert(err.code === undefined);
+                    helper.isError()(err);
+                    done();
+                });
             });
 
             it('represents a lua table appropritely', function (done) {

--- a/test/commands/keys.spec.js
+++ b/test/commands/keys.spec.js
@@ -14,6 +14,9 @@ describe("The 'keys' method", function () {
             var client;
 
             beforeEach(function (done) {
+                args = args || {};
+                // This is going to test if the high water is also respected
+                args.command_queue_high_water = 100;
                 client = redis.createClient.apply(redis.createClient, args);
                 client.once("connect", function () {
                     client.flushdb(done);

--- a/test/commands/multi.spec.js
+++ b/test/commands/multi.spec.js
@@ -254,6 +254,7 @@ describe("The 'multi' method", function () {
                         assert(err.message.match(/^EXECABORT/), "Error message should begin with EXECABORT");
                         assert.equal(err.errors.length, 2, "err.errors should have 2 items");
                         assert.strictEqual(err.errors[0].command_used, 'SET');
+                        assert.strictEqual(err.errors[0].code, 'ERR');
                         assert.strictEqual(err.errors[0].position, 1);
                         assert(/^ERR/.test(err.errors[0].message), "Actuall error message should begin with ERR");
                         return done();
@@ -261,9 +262,11 @@ describe("The 'multi' method", function () {
                 });
 
                 it('reports multiple exceptions when they occur (while EXEC is running)', function (done) {
-                    client.multi().config("bar").debug("foo").exec(function (err, reply) {
-                        assert.strictEqual(reply.length, 2);
+                    client.multi().config("bar").debug("foo").eval("return {err='this is an error'}", 0).exec(function (err, reply) {
+                        assert.strictEqual(reply.length, 3);
                         assert.equal(reply[0].code, 'ERR');
+                        assert.equal(reply[2].code, undefined);
+                        assert(/^this is an error/.test(reply[2].message));
                         assert(/^ERR/.test(reply[0].message), "Error message should begin with ERR");
                         assert(/^ERR/.test(reply[1].message), "Error message should begin with ERR");
                         return done();
@@ -276,6 +279,7 @@ describe("The 'multi' method", function () {
                     multi.set('foo', 'bar', helper.isString('OK'));
                     multi.debug("foo").exec(function (err, reply) {
                         assert.strictEqual(reply.length, 3);
+                        assert.strictEqual(reply[0].code, 'ERR');
                         assert(/^ERR/.test(reply[0].message), "Error message should begin with ERR");
                         assert(/^ERR/.test(reply[2].message), "Error message should begin with ERR");
                         assert.strictEqual(reply[1], "OK");

--- a/test/commands/multi.spec.js
+++ b/test/commands/multi.spec.js
@@ -263,6 +263,7 @@ describe("The 'multi' method", function () {
                 it('reports multiple exceptions when they occur (while EXEC is running)', function (done) {
                     client.multi().config("bar").debug("foo").exec(function (err, reply) {
                         assert.strictEqual(reply.length, 2);
+                        assert.equal(reply[0].code, 'ERR');
                         assert(/^ERR/.test(reply[0].message), "Error message should begin with ERR");
                         assert(/^ERR/.test(reply[1].message), "Error message should begin with ERR");
                         return done();

--- a/test/commands/select.spec.js
+++ b/test/commands/select.spec.js
@@ -57,7 +57,8 @@ describe("The 'select' method", function () {
                     describe("with a valid db index", function () {
                         it("selects the appropriate database", function (done) {
                             assert.strictEqual(client.selected_db, null, "default db should be null");
-                            client.select(1, function () {
+                            client.select(1, function (err) {
+                                assert.equal(err, null);
                                 assert.equal(client.selected_db, 1, "we should have selected the new valid DB");
                                 return done();
                             });
@@ -68,6 +69,7 @@ describe("The 'select' method", function () {
                         it("returns an error", function (done) {
                             assert.strictEqual(client.selected_db, null, "default db should be null");
                             client.select(9999, function (err) {
+                                assert.equal(err.code, 'ERR');
                                 assert.equal(err.message, 'ERR invalid DB index');
                                 return done();
                             });


### PR DESCRIPTION
This adds redis error codes to the returned errors. We might as well add error classes like parser errors, network errors and similar (the later do not have any error codes yet).

Fixes partly #695 and closes #538