### PR TITLE
Batch and atomicBatch functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -1187,7 +1187,8 @@ Batch.prototype.exec = Batch.prototype.EXEC = function (callback) {
     var resp = new Array(todo);
     var errors = null;
 
-    if (!todo) return setImmediate(function() { callback && callback(null); });
+    // what do we want to do if there's nothing queued?
+    if (!todo) return callback && callback(null, []);
 
     var isDone = function() {
         if (!--todo) return callback && callback(errors, resp);


### PR DESCRIPTION
Implements #806 

Needs tests (ahh!) but it functionally works.

## Batch
### All cases
```js
var b = redis.batch();
b.set('test', '1');
b.get('test', function(err, res) {
  //= null, '1'
});
b.exec(function(err, res) {
  //= null, [ 'OK', '1' ]
});
```
```
"set" "test" "1"
"get" "test"
```

## Atomic Batch
### Multiple commands

```js
var b = redis.atomicBatch();
b.set('test', '1');
b.get('test', function(err, res) {
  //= null, '1'
});
b.exec(function(err, res) {
  //= null, [ 'OK', '1' ]
});
```
```
"multi"
"set" "test" "1"
"get" "test"
"exec"
```

### Single command

```js
var b = redis.atomicBatch();
b.set('test', '1');
b.exec(function(err, res) {
  //= null, [ 'OK' ]
});
```
```
"set" "test" "1"
```
Note: no multi/exec wrapper as it's unnecessary for a single command

