### PR TITLE
Fix parsing huge replies by JavascriptReplyParser

### DIFF
--- a/lib/parsers/javascript.js
+++ b/lib/parsers/javascript.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var util   = require('util');
+var util = require('util');
+var BufferList = require('bl');
 
 function JavascriptReplyParser() {
     this.name = exports.name;
-    this._buffer            = new Buffer(0);
-    this._offset            = 0;
+    this._bufferList = new BufferList();
+    this._offset = 0;
 }
 
 function IncompleteReadBuffer(message) {
@@ -25,7 +26,7 @@ JavascriptReplyParser.prototype._parseResult = function (type) {
         end = this._packetEndOffset() - 1;
         start = this._offset;
 
-        if (end > this._buffer.length) {
+        if (end > this._bufferList.length) {
             throw new IncompleteReadBuffer('Wait for more data.');
         }
 
@@ -33,12 +34,12 @@ JavascriptReplyParser.prototype._parseResult = function (type) {
         this._offset = end + 2;
 
         if (type === 43) {
-            return this._buffer.slice(start, end);
+            return this._bufferList.slice(start, end);
         } else if (type === 58) {
             // return the coerced numeric value
-            return +this._buffer.toString('ascii', start, end);
+            return +this._bufferList.toString('ascii', start, end);
         }
-        return new Error(this._buffer.toString('utf-8', start, end));
+        return new Error(this._bufferList.toString('utf-8', start, end));
     } else if (type === 36) { // $
         // set a rewind point, as the packet could be larger than the
         // buffer in memory
@@ -54,14 +55,14 @@ JavascriptReplyParser.prototype._parseResult = function (type) {
         end = this._offset + packetHeader;
         start = this._offset;
 
-        if (end > this._buffer.length) {
+        if (end > this._bufferList.length) {
             throw new IncompleteReadBuffer('Wait for more data.');
         }
 
         // set the offset to after the delimiter
         this._offset = end + 2;
 
-        return this._buffer.slice(start, end);
+        return this._bufferList.slice(start, end);
     } else if (type === 42) { // *
         offset = this._offset;
         packetHeader = this.parseHeader();
@@ -81,9 +82,9 @@ JavascriptReplyParser.prototype._parseResult = function (type) {
         offset = this._offset - 1;
 
         for (i = 0; i < packetHeader; i++) {
-            ntype = this._buffer[this._offset++];
+            ntype = this._bufferList.get(this._offset++);
 
-            if (this._offset > this._buffer.length) {
+            if (this._offset > this._bufferList.length) {
                 throw new IncompleteReadBuffer('Wait for more data.');
             }
             res = this._parseResult(ntype);
@@ -107,7 +108,7 @@ JavascriptReplyParser.prototype.execute = function (buffer) {
         }
 
         try {
-            type = this._buffer[this._offset++];
+            type = this._bufferList.get(this._offset++);
 
             if (type === 43) { // Strings +
                 ret = this._parseResult(type);
@@ -149,21 +150,19 @@ JavascriptReplyParser.prototype.execute = function (buffer) {
 };
 
 JavascriptReplyParser.prototype.append = function (newBuffer) {
-
-    // out of data
-    if (this._offset >= this._buffer.length) {
-        this._buffer = newBuffer;
-        this._offset = 0;
-        return;
+    if (this._offset >= this._bufferList.length) { // Out of data
+        this._bufferList = new BufferList();
+    } else if (this._offset > 0) {
+        this._bufferList.consume(this._offset);
     }
 
-    this._buffer = Buffer.concat([this._buffer.slice(this._offset), newBuffer]);
+    this._bufferList.append(newBuffer);
     this._offset = 0;
 };
 
 JavascriptReplyParser.prototype.parseHeader = function () {
     var end   = this._packetEndOffset(),
-        value = this._buffer.toString('ascii', this._offset, end - 1) | 0;
+        value = this._bufferList.toString('ascii', this._offset, end - 1) | 0;
 
     this._offset = end + 1;
 
@@ -173,12 +172,12 @@ JavascriptReplyParser.prototype.parseHeader = function () {
 JavascriptReplyParser.prototype._packetEndOffset = function () {
     var offset = this._offset;
 
-    while (this._buffer[offset] !== 0x0d && this._buffer[offset + 1] !== 0x0a) {
+    while (this._bufferList.get(offset) !== 0x0d && this._bufferList.get(offset + 1) !== 0x0a) {
         offset++;
 
         /* istanbul ignore if: activate the js parser out of memory test to test this */
-        if (offset >= this._buffer.length) {
-            throw new IncompleteReadBuffer('Did not see LF after NL reading multi bulk count (' + offset + ' => ' + this._buffer.length + ', ' + this._offset + ')');
+        if (offset >= this._bufferList.length) {
+            throw new IncompleteReadBuffer('Did not see LF after NL reading multi bulk count (' + offset + ' => ' + this._bufferList.length + ', ' + this._offset + ')');
         }
     }
 
@@ -187,7 +186,7 @@ JavascriptReplyParser.prototype._packetEndOffset = function () {
 };
 
 JavascriptReplyParser.prototype._bytesRemaining = function () {
-    return (this._buffer.length - this._offset) < 0 ? 0 : (this._buffer.length - this._offset);
+    return (this._bufferList.length - this._offset) < 0 ? 0 : (this._bufferList.length - this._offset);
 };
 
 exports.Parser = JavascriptReplyParser;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "posttest": "jshint ."
   },
   "dependencies": {
-    "double-ended-queue": "^2.1.0-0"
+    "double-ended-queue": "^2.1.0-0",
+    "bl": "^1.0.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
This pull request fixes issue #678. Instead of parsing whole buffer when new chunk arrives I'm adding it to BufferList and converting it to regular Buffer only when it's necessary.