### PR TITLE
Testing in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ environment:
   matrix:
     - nodejs_version: "0.10"
     - nodejs_version: "0.12"
-    - nodejs_version: "3.0"
-    - nodejs_version: "4.0"
+    - nodejs_version: "3"
+    - nodejs_version: "4"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
This is how to always test against latest io.js 3.x and Node.js 4.x