### PR TITLE
Fixing bug where constructor was not using the options object to set …

### DIFF
--- a/index.js
+++ b/index.js
@@ -1229,8 +1229,8 @@ var createClient_unix = function (path, options){
 
 var createClient_tcp = function (port_arg, host_arg, options) {
     var cnxOptions = {
-        port : port_arg || default_port,
-        host : host_arg || default_host,
+        port : port_arg || options.port || default_port,
+        host : host_arg || options.host || default_host,
         family : options.family === 'IPv6' ? 6 : 4
     };
     var net_client = net.createConnection(cnxOptions);


### PR DESCRIPTION
…host and port

According to the [documentation](https://github.com/NodeRedis/node_redis#options-is-an-object-with-the-following-possible-properties) you should be able to specify the host and port in the options object.

Before it would default to the Redis defaults instead of reading from the options object.

```
> var client = redis.createClient({host:'myhost.com', port: 6379});
    undefined
> client.address
    '127.0.0.1'
```

With this fix, you will successfully be able to specify the host and port in the options object.

```
> var client = redis.createClient({host:'myhost.com', port: 6379});
    undefined
> client.address
    'myhost.com'
```
