### PR TITLE
emit event "ready" when disable_resubscribing is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,6 +382,7 @@ RedisClient.prototype.on_ready = function () {
             }
         };
         if (this.options.disable_resubscribing) {
+            this.emit('ready');
             return;
         }
         Object.keys(this.subscription_set).forEach(function (key) {


### PR DESCRIPTION
I have two connections to redis, one for subscribe() and the second one for other commands. If I set `disable_resubscribing` to true and redis goes down, when it goes back up, the `ready` event is triggered for the query connection but not for the subscribe connection, and I want to do something when the connection is available again.