### PR TITLE
Adds config variable `enable_offline_queue_until_first_ready`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ connection to the redis server, commands are added to a queue and are executed
 once the connection has been established. Setting `enable_offline_queue` to
 `false` will disable this feature and the callback will be executed immediately
 with an error, or an error will be emitted if no callback is specified.
+* `enable_offline_queue_until_first_ready`: *false*; To be used in conjunction with `enable_offline_queue`,
+if you would like to turn off offline queue (by setting `enable_offline_queue` to false) however you still want
+to queue commands that occur before the connection becomes ready then you can set this variable to `true`. Commands
+executed while the connection becomes ready will be queued but once the connection first becomes ready, if you have
+`enable_offline_queue` set to `false`, you will no longer have offline queuing. This helps handle redis timeouts or
+connection drops that occur post initial connection by not queuing commands and failing immediately (helpful when you
+are using redis as a cache so you can immediately go to the primary source of the data).
 * `retry_max_delay`: *null*; By default every time the client tries to connect and fails the reconnection delay almost doubles.
 This delay normally grows infinitely, but setting `retry_max_delay` limits it to the maximum value, provided in milliseconds.
 * `connect_timeout`: *3600000*; Setting `connect_timeout` limits total time for client to connect and reconnect.

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -550,6 +550,40 @@ describe("The node_redis client", function () {
                 });
             });
 
+            describe.only('offline_queue_enabled', function () {
+                describe('true', function () {
+                    // @TODO: Add more tests
+
+                    it("does not return an error and enqueues operation", function (done) {
+                        client = redis.createClient({
+                            max_attempts: 0,
+                            enable_offline_queue: false,
+                            enable_offline_queue_until_first_ready: true,
+                        });
+                        client.set('foo', 'bar', function(err, result) {
+                          assert.equal(result, 'OK');
+                          return done();
+                        });
+                    });
+                });
+
+                describe('false', function () {
+                    // @TODO: Add more tests
+
+                    it("return an error because offline queues disabled", function (done) {
+                        client = redis.createClient({
+                            max_attempts: 0,
+                            enable_offline_queue: false,
+                            enable_offline_queue_until_first_ready: false,
+                        });
+                        client.set('foo', 'bar', function(err, result) {
+                          assert.equal(err.message, 'SET can\'t be processed. The connection is not yet established and the offline queue is deactivated.');
+                          return done();
+                        });
+                    });
+                });
+            });
+
             describe('enable_offline_queue', function () {
                 describe('true', function () {
                     it("should emit drain if offline queue is flushed and nothing to buffer", function (done) {


### PR DESCRIPTION
Configuration variable added that allows you to enable the offline queue only while the connection is being opened, before it first becomes ready. After it is ready, if you have `enable_offline_queue` set to false then it will stop queuing. Useful for when you don’t want an offline queue during normal operation (ie, you are using redis as a cache that has a fallback to a primary data source) but you do want it to queue requests initially when loading the connection without havingto listen to the ‘ready’ event being emitted.