### PR TITLE
Fix monitor mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,22 +545,20 @@ If you fire many commands at once this is going to **boost the execution speed b
 Redis supports the `MONITOR` command, which lets you see all commands received by the Redis server
 across all client connections, including from other client libraries and other computers.
 
-After you send the `MONITOR` command, no other commands are valid on that connection. `node_redis`
-will emit a `monitor` event for every new monitor message that comes across. The callback for the
-`monitor` event takes a timestamp from the Redis server and an array of command arguments.
+A `monitor` event is going to be emitted for every command fired from any client connected to the server including the monitoring client itself.
+The callback for the `monitor` event takes a timestamp from the Redis server, an array of command arguments and the raw monitoring string.
 
 Here is a simple example:
 
 ```js
-var client  = require("redis").createClient(),
-    util = require("util");
-
+var client  = require("redis").createClient();
 client.monitor(function (err, res) {
     console.log("Entering monitoring mode.");
 });
+client.set('foo', 'bar');
 
-client.on("monitor", function (time, args) {
-    console.log(time + ": " + util.inspect(args));
+client.on("monitor", function (time, args, raw_reply) {
+    console.log(time + ": " + args); // 1458910076.446514:['set', 'foo', 'bar']
 });
 ```
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+## v.2.6.0 - XX Mar, 2016
+
+Features
+
+-  Monitor now works together with the offline queue
+ -  All commands that were send after a connection loss are now going to be send after reconnecting
+-  Activating monitor mode does now work together with arbitrary commands including pub sub mode
+
+Bugfixes
+
+-  Fixed calling monitor command while other commands are still running
+-  Fixed monitor and pub sub mode not working together
+-  Fixed monitor mode not working in combination with the offline queue
+
 ## v.2.5.3 - 21 Mar, 2016
 
 Bugfixes

--- a/lib/individualCommands.js
+++ b/lib/individualCommands.js
@@ -33,6 +33,41 @@ RedisClient.prototype.select = RedisClient.prototype.SELECT = function select (d
     });
 };
 
+RedisClient.prototype.monitor = RedisClient.prototype.MONITOR = function (callback) {
+    // Use a individual command, as this is a special case that does not has to be checked for any other command
+    var self = this;
+    return this.send_command('monitor', [], function (err, res) {
+        if (err === null) {
+            self.reply_parser.returnReply = function (reply) {
+                // If in monitor mode, all normal commands are still working and we only want to emit the streamlined commands
+                // As this is not the average use case and monitor is expensive anyway, let's change the code here, to improve
+                // the average performance of all other commands in case of no monitor mode
+                if (self.monitoring) {
+                    var replyStr;
+                    if (self.buffers && Buffer.isBuffer(reply)) {
+                        replyStr = reply.toString();
+                    } else {
+                        replyStr = reply;
+                    }
+                    // While reconnecting the redis server does not recognize the client as in monitor mode anymore
+                    // Therefor the monitor command has to finish before it catches further commands
+                    if (typeof replyStr === 'string' && utils.monitor_regex.test(replyStr)) {
+                        var timestamp = replyStr.slice(0, replyStr.indexOf(' '));
+                        var args = replyStr.slice(replyStr.indexOf('"') + 1, -1).split('" "').map(function (elem) {
+                            return elem.replace(/\\"/g, '"');
+                        });
+                        self.emit('monitor', timestamp, args, replyStr);
+                        return;
+                    }
+                }
+                self.return_reply(reply);
+            };
+            self.monitoring = true;
+        }
+        utils.callback_or_emit(self, callback, err, res);
+    });
+};
+
 // Store info in this.server_info after each call
 RedisClient.prototype.info = RedisClient.prototype.INFO = function info (section, callback) {
     var self = this;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,8 +39,6 @@ function print (err, reply) {
     }
 }
 
-var redisErrCode = /^([A-Z]+)\s+(.+)$/;
-
 // Deep clone arbitrary objects with arrays. Can't handle cyclic structures (results in a range error)
 // Any attribute with a non primitive value besides object and array will be passed by reference (e.g. Buffers, Maps, Functions)
 function clone (obj) {
@@ -102,7 +100,8 @@ module.exports = {
     reply_to_strings: replyToStrings,
     reply_to_object: replyToObject,
     print: print,
-    err_code: redisErrCode,
+    err_code: /^([A-Z]+)\s+(.+)$/,
+    monitor_regex: /^[0-9]{10,11}\.[0-9]+ \[[0-9]{1,3} [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:[0-9]{1,5}\].*/,
     clone: convenienceClone,
     callback_or_emit: callbackOrEmit,
     reply_in_order: replyInOrder


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `npm test` pass with this change (including linting)?
- [X] Is the new or changed code fully tested?

### Description of change

<s>A couple of persons ran into the issue that an error was thrown, when they used monitor and fired commands with that very same client instead of using another client to fire the commands from.</s>

<s>This helps in that situation by not only not throwing the error and instead emitting it (and therefor making it easy to catch, as the error listener should be attached all the time), it also links to redis.io to give detailed information how to use this. 

@NodeRedis/contributors I guess it might actually be reasonable to warn if a user did not attach a error listener to a client. What do you think?</s>

After digging deeper I realized that monitor was just broken and a single client is actually able to handle normal commands and monitor everything too.

So this fixes that.

Fixes #1005