### PR TITLE
Redis 2.4 support

### DIFF
--- a/lib/individualCommands.js
+++ b/lib/individualCommands.js
@@ -4,6 +4,7 @@ var utils = require('./utils');
 var debug = require('./debug');
 var Multi = require('./multi');
 var no_password_is_set = /no password is set/;
+var loading = /LOADING/;
 var RedisClient = require('../').RedisClient;
 
 /********************************
@@ -91,12 +92,20 @@ RedisClient.prototype.auth = RedisClient.prototype.AUTH = function auth (pass, c
     this.auth_pass = pass;
     this.ready = this.offline_queue.length === 0; // keep the execution order intakt
     var tmp = this.send_command('auth', [pass], function (err, res) {
-        if (err && no_password_is_set.test(err.message)) {
-            self.warn('Warning: Redis server does not require a password, but a password was supplied.');
-            err = null;
-            res = 'OK';
+        if (err) {
+            if (no_password_is_set.test(err.message)) {
+                self.warn('Warning: Redis server does not require a password, but a password was supplied.');
+                err = null;
+                res = 'OK';
+            } else if (loading.test(err.message)) {
+                // If redis is still loading the db, it will not authenticate and everything else will fail
+                debug('Redis still loading, trying to authenticate later');
+                setTimeout(function () {
+                    self.auth(pass, callback);
+                }, 200);
+                return;
+            }
         }
-
         utils.callback_or_emit(self, callback, err, res);
     });
     this.ready = ready;

--- a/lib/individualCommands.js
+++ b/lib/individualCommands.js
@@ -37,14 +37,14 @@ RedisClient.prototype.select = RedisClient.prototype.SELECT = function select (d
 RedisClient.prototype.info = RedisClient.prototype.INFO = function info (section, callback) {
     var self = this;
     var ready = this.ready;
+    var args = [];
     if (typeof section === 'function') {
         callback = section;
-        section = 'default';
-    } else if (section === undefined) {
-        section = 'default';
+    } else if (section !== undefined) {
+        args = Array.isArray(section) ? section : [section];
     }
     this.ready = ready || this.offline_queue.length === 0; // keep the execution order intakt
-    var tmp = this.send_command('info', [section], function (err, res) {
+    var tmp = this.send_command('info', args, function (err, res) {
         if (res) {
             var obj = {};
             var lines = res.toString().split('\r\n');

--- a/test/commands/info.spec.js
+++ b/test/commands/info.spec.js
@@ -12,14 +12,14 @@ describe("The 'info' method", function () {
         describe("using " + parser + " and " + ip, function () {
             var client;
 
-            before(function (done) {
+            beforeEach(function (done) {
                 client = redis.createClient.apply(null, args);
                 client.once("ready", function () {
                     client.flushall(done);
                 });
             });
 
-            after(function () {
+            afterEach(function () {
                 client.end(true);
             });
 
@@ -41,9 +41,10 @@ describe("The 'info' method", function () {
                 client.set('foo', 'bar');
                 client.info('keyspace');
                 client.select(2, function () {
-                    assert.strictEqual(Object.keys(client.server_info).length, 3, 'Key length should be three');
-                    assert(typeof client.server_info.db2 === 'object', 'db2 keyspace should be an object');
+                    assert.strictEqual(Object.keys(client.server_info).length, 2, 'Key length should be three');
+                    assert.strictEqual(typeof client.server_info.db0, 'object', 'db0 keyspace should be an object');
                 });
+                client.info(['keyspace']);
                 client.set('foo', 'bar');
                 client.info('all', function (err, res) {
                     assert(Object.keys(client.server_info).length > 3, 'Key length should be way above three');
@@ -51,6 +52,17 @@ describe("The 'info' method", function () {
                     assert.strictEqual(typeof client.server_info.db2, 'object');
                     done();
                 });
+            });
+
+            it('check redis v.2.4 support', function (done) {
+                var end = helper.callFuncAfter(done, 2);
+                client.send_command = function (command, args, callback) {
+                    assert.strictEqual(args.length, 0);
+                    assert.strictEqual(command, 'info');
+                    end();
+                };
+                client.info();
+                client.info(function () {});
             });
 
             it("emit error after a failure", function (done) {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?

### Description of change

node_redis v.2.5.0 should not have broken support for Redis 2.4, so this should fix all issues with that version. 