### PR TITLE
Ensure synthetic function names conform to naming requirements

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -21,6 +21,7 @@ var changeFunctionName = (function () {
 // that provided a functionality to add new commands to the client
 
 commands.list.forEach(function (command) {
+    var commandName = command.replace(/(?:^([0-9])|[^a-zA-Z0-9_$])/g, '_$1');
 
     // Do not override existing functions
     if (!RedisClient.prototype[command]) {
@@ -59,7 +60,7 @@ commands.list.forEach(function (command) {
         };
         if (changeFunctionName) {
             Object.defineProperty(RedisClient.prototype[command], 'name', {
-                value: command
+                value: commandName
             });
         }
     }
@@ -102,7 +103,7 @@ commands.list.forEach(function (command) {
         };
         if (changeFunctionName) {
             Object.defineProperty(Multi.prototype[command], 'name', {
-                value: command
+                value: commandName
             });
         }
     }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The "restore-asking" function name is not valid and was causing co-redis (by way of its usage of thenify) to throw because thenify uses the function name to rewrite async functions with promises.

This PR will change the name of the "restore-asking" function to "restore_asking", which is valid.

This sanitation is a bit stricter than necessary, since it also sanitizes valid unicode characters, but it covers this module's potential use cases just fine.