### PR TITLE
Support retry after flush

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 stunnel.conf
 stunnel.pid
 *.out
+.idea

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ var client = redis.createClient({
         // attempt reconnect after retry_delay, and flush any pending commands
         return {
             retry_delay: Math.min(options.attempt * 100, 3000),
-            error: error
+            error: new Error('Your custom error.');
         }
     }
 });

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ client.get(new Buffer("foo_rand000000000000"), function (err, reply) {
 client.quit();
 ```
 
-retry_strategy example
+####retry_strategy example
+
 ```js
 var client = redis.createClient({
     retry_strategy: function (options) {

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ __Tip:__ If the Redis server runs on the same machine as the client consider usi
 | rename_commands | null | Passing an object with renamed commands to use instead of the original functions. See the [Redis security topics](http://redis.io/topics/security) for more info. |
 | tls | null | An object containing options to pass to [tls.connect](http://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback) to set up a TLS connection to Redis (if, for example, it is set up to be accessible via a tunnel). |
 | prefix | null | A string used to prefix all used keys (e.g. `namespace:test`). Please be aware that the `keys` command will not be prefixed. The `keys` command has a "pattern" as argument and no key and it would be impossible to determine the existing keys in Redis if this would be prefixed. |
-| retry_strategy | function | A function that receives an options object as parameter including the retry `attempt`, the `total_retry_time` indicating how much time passed since the last time connected, the `error` why the connection was lost and the number of `times_connected` in total. If you return a number from this function, the retry will happen exactly after that time in milliseconds. If you return a non-number, no further retry will happen and all offline commands are flushed with errors. Return an error to return that specific error to all offline commands. Example below. |
+| retry_strategy | function | A function that receives an options object as parameter including the retry `attempt`, the `total_retry_time` indicating how much time passed since the last time connected, the `error` why the connection was lost and the number of `times_connected` in total. If you return a number from this function, the retry will happen exactly after that time in milliseconds. If you return a non-number, no further retry will happen and all offline commands are flushed with errors. Return an error to return that specific error to all offline commands. Return a object with an error and retry_delay for the commands to be flushed and connection retry to be attempted after `retry_delay`. Examples below. |
 
 ```js
 var redis = require("redis");
@@ -238,6 +238,26 @@ var client = redis.createClient({
         }
         // reconnect after
         return Math.min(options.attempt * 100, 3000);
+    }
+});
+```
+
+```js
+var client = redis.createClient({
+    retry_strategy: function (options) {
+        if (options.error && options.error.code === 'ECONNREFUSED') {
+            // End reconnecting on a specific error and flush all commands with a individual error
+            return new Error('The server refused the connection');
+        }
+        if (options.total_retry_time > 1000 * 60 * 60) {
+            // End reconnecting after a specific timeout and flush all commands with a individual error
+            return new Error('Retry time exhausted');
+        }
+        // attempt reconnect after retry_delay, and flush any pending commands
+        return {
+            retry_delay: Math.min(options.attempt * 100, 3000),
+            error: error
+        }
     }
 });
 ```

--- a/index.js
+++ b/index.js
@@ -83,10 +83,6 @@ function RedisClient (options, stream) {
             // Do not print deprecation warnings twice
             delete options.retry_max_delay;
         }
-        this.retry_on_flush = false;
-        if (options.retry_on_flush) {
-            this.retry_on_flush = options.retry_on_flush;
-        }
     }
 
     this.connection_options = cnx_options;

--- a/index.js
+++ b/index.js
@@ -617,7 +617,7 @@ RedisClient.prototype.connection_gone = function (why, error) {
                 error = this.retry_delay;
             }
             // Handle object pattern
-            if (typeof this.retry_delay === 'object' && !(this.retry_delay instanceof Error) && this.retry_delay !== null) {
+            else if (typeof this.retry_delay === 'object' && this.retry_delay !== null) {
                 if (this.retry_delay.error && this.retry_delay.error instanceof Error) {
                     error = this.retry_delay.error;
                 }

--- a/index.js
+++ b/index.js
@@ -617,11 +617,11 @@ RedisClient.prototype.connection_gone = function (why, error) {
                 error = this.retry_delay;
             }
             // Handle object pattern
-            if (typeof this.retry_delay == 'object' && !(this.retry_delay instanceof Error) && this.retry_delay != null) {
+            if (typeof this.retry_delay === 'object' && !(this.retry_delay instanceof Error) && this.retry_delay !== null) {
                 if (this.retry_delay.error && this.retry_delay.error instanceof Error) {
                     error = this.retry_delay.error;
                 }
-                if (typeof this.retry_delay.retry_delay == 'number') {
+                if (typeof this.retry_delay.retry_delay === 'number') {
                     this.retry_delay = this.retry_delay.retry_delay;
                 }
             }

--- a/test/connection.spec.js
+++ b/test/connection.spec.js
@@ -303,6 +303,26 @@ describe('connection tests', function () {
                     });
                 });
 
+                // it('retry_strategy used to reconnect with object', function (done) {
+                //     client = redis.createClient({
+                //         retry_strategy: function (options) {
+                //             if (options.total_retry_time > 150) {
+                //                 client.set('foo', 'bar', function (err, res) {
+                //                     assert.strictEqual(err.message, 'Stream connection ended and command aborted.');
+                //                     assert.strictEqual(err.code, 'NR_CLOSED');
+                //                     assert.strictEqual(err.origin.code, 'ECONNREFUSED');
+                //                     done();
+                //                 });
+                //             }
+                //             return {
+                //                 retry_delay: Math.min(options.attempt * 25, 200),
+                //                 error: options.error
+                //             };
+                //         },
+                //         port: 9999
+                //     });
+                // });
+
                 it('retry_strategy used to reconnect', function (done) {
                     client = redis.createClient({
                         retry_strategy: function (options) {
@@ -322,8 +342,8 @@ describe('connection tests', function () {
                 });
 
                 it('retryStrategy used to reconnect with defaults', function (done) {
-                    var unhookIntercept = intercept(function () {
-                        return '';
+                    var unhookIntercept = intercept(function (text) {
+                        return text;
                     });
                     redis.debugMode = true;
                     client = redis.createClient({

--- a/test/connection.spec.js
+++ b/test/connection.spec.js
@@ -342,8 +342,8 @@ describe('connection tests', function () {
                 });
 
                 it('retryStrategy used to reconnect with defaults', function (done) {
-                    var unhookIntercept = intercept(function (text) {
-                        return "";
+                    var unhookIntercept = intercept(function () {
+                        return '';
                     });
                     redis.debugMode = true;
                     client = redis.createClient({

--- a/test/connection.spec.js
+++ b/test/connection.spec.js
@@ -303,25 +303,25 @@ describe('connection tests', function () {
                     });
                 });
 
-                // it('retry_strategy used to reconnect with object', function (done) {
-                //     client = redis.createClient({
-                //         retry_strategy: function (options) {
-                //             if (options.total_retry_time > 150) {
-                //                 client.set('foo', 'bar', function (err, res) {
-                //                     assert.strictEqual(err.message, 'Stream connection ended and command aborted.');
-                //                     assert.strictEqual(err.code, 'NR_CLOSED');
-                //                     assert.strictEqual(err.origin.code, 'ECONNREFUSED');
-                //                     done();
-                //                 });
-                //             }
-                //             return {
-                //                 retry_delay: Math.min(options.attempt * 25, 200),
-                //                 error: options.error
-                //             };
-                //         },
-                //         port: 9999
-                //     });
-                // });
+                it('retry_strategy used to reconnect with object', function (done) {
+                    client = redis.createClient({
+                        retry_strategy: function (options) {
+                            if (options.total_retry_time > 150) {
+                                client.set('foo', 'bar', function (err, res) {
+                                    assert.strictEqual(err.message, 'Stream connection ended and command aborted.');
+                                    assert.strictEqual(err.code, 'NR_CLOSED');
+                                    assert.strictEqual(err.origin.code, 'ECONNREFUSED');
+                                    done();
+                                });
+                            }
+                            return {
+                                retry_delay: Math.min(options.attempt * 25, 200),
+                                error: options.error
+                            };
+                        },
+                        port: 9999
+                    });
+                });
 
                 it('retry_strategy used to reconnect', function (done) {
                     client = redis.createClient({

--- a/test/connection.spec.js
+++ b/test/connection.spec.js
@@ -343,7 +343,7 @@ describe('connection tests', function () {
 
                 it('retryStrategy used to reconnect with defaults', function (done) {
                     var unhookIntercept = intercept(function (text) {
-                        return text;
+                        return "";
                     });
                     redis.debugMode = true;
                     client = redis.createClient({


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

Allows for the retry_strategy to return a object which results in the command queue being flushed but also for a connection retry attempt to occur. This change is in response to #1198  .