### PR TITLE
Repurpose retry_strategy + add connection_strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 stunnel.conf
 stunnel.pid
 *.out
+.idea/

--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ __Tip:__ If the Redis server runs on the same machine as the client consider usi
 | socket_keepalive | true | If set to `true`, the keep-alive functionality is enabled on the underlying socket. |
 | no_ready_check | false |  When a connection is established to the Redis server, the server might still be loading the database from disk. While loading, the server will not respond to any commands. To work around this, `node_redis` has a "ready check" which sends the `INFO` command to the server. The response from the `INFO` command indicates whether the server is ready for more commands. When ready, `node_redis` emits a `ready` event. Setting `no_ready_check` to `true` will inhibit this check. |
 | enable_offline_queue |  true | By default, if there is no active connection to the Redis server, commands are added to a queue and are executed once the connection has been established. Setting `enable_offline_queue` to `false` will disable this feature and the callback will be executed immediately with an error, or an error will be emitted if no callback is specified. |
-| retry_max_delay | null | __Deprecated__ _Please use `retry_strategy` instead._ By default, every time the client tries to connect and fails, the reconnection delay almost doubles. This delay normally grows infinitely, but setting `retry_max_delay` limits it to the maximum value provided in milliseconds. |
-| connect_timeout | 3600000 | __Deprecated__ _Please use `retry_strategy` instead._ Setting `connect_timeout` limits the total time for the client to connect and reconnect. The value is provided in milliseconds and is counted from the moment a new client is created or from the time the connection is lost. The last retry is going to happen exactly at the timeout time. Default is to try connecting until the default system socket timeout has been exceeded and to try reconnecting until 1h has elapsed. |
-| max_attempts | 0 | __Deprecated__ _Please use `retry_strategy` instead._ By default, a client will try reconnecting until connected. Setting `max_attempts` limits total amount of connection attempts. Setting this to 1 will prevent any reconnect attempt. |
+| retry_max_delay | null | __Deprecated__ _Please use `connection_strategy` instead._ By default, every time the client tries to connect and fails, the reconnection delay almost doubles. This delay normally grows infinitely, but setting `retry_max_delay` limits it to the maximum value provided in milliseconds. |
+| connect_timeout | 3600000 | __Deprecated__ _Please use `connection_strategy` instead._ Setting `connect_timeout` limits the total time for the client to connect and reconnect. The value is provided in milliseconds and is counted from the moment a new client is created or from the time the connection is lost. The last retry is going to happen exactly at the timeout time. Default is to try connecting until the default system socket timeout has been exceeded and to try reconnecting until 1h has elapsed. |
+| max_attempts | 0 | __Deprecated__ _Please use `connection_strategy` instead._ By default, a client will try reconnecting until connected. Setting `max_attempts` limits total amount of connection attempts. Setting this to 1 will prevent any reconnect attempt. |
 | retry_unfulfilled_commands | false | If set to `true`, all commands that were unfulfilled while the connection is lost will be retried after the connection has been reestablished. Use this with caution if you use state altering commands (e.g. `incr`). This is especially useful if you use blocking commands. |
 | password | null | If set, client will run Redis auth command on connect. Alias `auth_pass` __Note__ `node_redis` < 2.5 must use `auth_pass` |
 | db | null | If set, client will run Redis `select` command on connect. |
@@ -200,7 +200,7 @@ __Tip:__ If the Redis server runs on the same machine as the client consider usi
 | rename_commands | null | Passing an object with renamed commands to use instead of the original functions. See the [Redis security topics](http://redis.io/topics/security) for more info. |
 | tls | null | An object containing options to pass to [tls.connect](http://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback) to set up a TLS connection to Redis (if, for example, it is set up to be accessible via a tunnel). |
 | prefix | null | A string used to prefix all used keys (e.g. `namespace:test`). Please be aware that the `keys` command will not be prefixed. The `keys` command has a "pattern" as argument and no key and it would be impossible to determine the existing keys in Redis if this would be prefixed. |
-| retry_strategy | function | A function that receives an options object as parameter including the retry `attempt`, the `total_retry_time` indicating how much time passed since the last time connected, the `error` why the connection was lost and the number of `times_connected` in total. If you return a number from this function, the retry will happen exactly after that time in milliseconds. If you return a non-number, no further retry will happen and all offline commands are flushed with errors. Return an error to return that specific error to all offline commands. Example below. |
+| connection_strategy | function | A function that receives an options object as parameter including the retry `attempt`, the `total_retry_time` indicating how much time passed since the last time connected, the `error` why the connection was lost and the number of `times_connected` in total. If you return a number from this function, the retry will happen exactly after that time in milliseconds. If you return a non-number, no further retry will happen and all offline commands are flushed with errors. Return an error to return that specific error to all offline commands. Example below. |
 
 ```js
 var redis = require("redis");
@@ -220,10 +220,10 @@ client.get(new Buffer("foo_rand000000000000"), function (err, reply) {
 client.quit();
 ```
 
-retry_strategy example
+connection_strategy example
 ```js
 var client = redis.createClient({
-    retry_strategy: function (options) {
+    connection_strategy: function (options) {
         if (options.error && options.error.code === 'ECONNREFUSED') {
             // End reconnecting on a specific error and flush all commands with a individual error
             return new Error('The server refused the connection');

--- a/changelog.md
+++ b/changelog.md
@@ -174,7 +174,7 @@ Features
 -  The client.server_info is from now on updated while using the info command
 -  Gracefuly handle redis protocol errors from now on
 -  Added a `warning` emitter that receives node_redis warnings like auth not required and deprecation messages
--  Added a `retry_strategy` option that replaces all reconnect options
+-  Added a `connection_strategy` option that replaces all reconnect options
 -  The reconnecting event from now on also receives:
  -  The error message why the reconnect happend (params.error)
  -  The amount of times the client was connected (params.times_connected)
@@ -212,8 +212,8 @@ Deprecations
 -  The `socket_nodelay` option is deprecated and will be removed in v.3.0.0
  -  If you want to buffer commands you should use [.batch or .multi](./README.md) instead. This is necessary to reduce the amount of different options and this is very likely reducing your throughput if set to false.
  -  If you are sure you want to activate the NAGLE algorithm you can still activate it by using client.stream.setNoDelay(false)
--  The `max_attempts` option is deprecated and will be removed in v.3.0.0. Please use the `retry_strategy` instead
--  The `retry_max_delay` option is deprecated and will be removed in v.3.0.0. Please use the `retry_strategy` instead
+-  The `max_attempts` option is deprecated and will be removed in v.3.0.0. Please use the `connection_strategy` instead
+-  The `retry_max_delay` option is deprecated and will be removed in v.3.0.0. Please use the `connection_strategy` instead
 -  The drain event is deprecated and will be removed in v.3.0.0. Please listen to the stream drain event instead
 -  The idle event is deprecated and will likely be removed in v.3.0.0. If you rely on this feature please open a new ticket in node_redis with your use case
 -  Redis < v. 2.6 is not officially supported anymore and might not work in all cases. Please update to a newer redis version as it is not possible to test for these old versions

--- a/index.js
+++ b/index.js
@@ -345,7 +345,7 @@ RedisClient.prototype.flush_and_error = function (error_attributes, options) {
     options = options || {};
     var aggregated_errors = [];
     var queue_names = options.queues || ['command_queue', 'offline_queue']; // Flush the command_queue first to keep the order intakt
-    debug("flushing queues " + queue_names.toString());
+    debug('flushing queues ' + queue_names.toString());
     for (var i = 0; i < queue_names.length; i++) {
         // If the command was fired it might have been processed so far
         if (queue_names[i] === 'command_queue') {

--- a/index.js
+++ b/index.js
@@ -345,6 +345,7 @@ RedisClient.prototype.flush_and_error = function (error_attributes, options) {
     options = options || {};
     var aggregated_errors = [];
     var queue_names = options.queues || ['command_queue', 'offline_queue']; // Flush the command_queue first to keep the order intakt
+    debug("flushing queues " + queue_names.toString());
     for (var i = 0; i < queue_names.length; i++) {
         // If the command was fired it might have been processed so far
         if (queue_names[i] === 'command_queue') {
@@ -556,7 +557,6 @@ var retry_connection = function (self, error) {
         reconnect_params.times_connected = self.times_connected;
     }
     self.emit('reconnecting', reconnect_params);
-
     self.retry_totaltime += self.retry_delay;
     self.attempts += 1;
     self.retry_delay = Math.round(self.retry_delay * self.retry_backoff);

--- a/test/conect.slave.spec.js
+++ b/test/conect.slave.spec.js
@@ -45,7 +45,7 @@ describe('master slave sync', function () {
         var firstInfo;
         slave = redis.createClient({
             port: port,
-            retry_strategy: function (options) {
+            connection_strategy: function (options) {
                 // Try to reconnect in very small intervals to catch the master_link_status down before the sync completes
                 return 10;
             }

--- a/test/connection.spec.js
+++ b/test/connection.spec.js
@@ -349,12 +349,12 @@ describe('connection tests', function () {
                     var offlineQueueLengthTotal = 0;
                     client = redis.createClient({
                         connection_strategy: function (options) {
-                            offlineQueueLengthTotal += client.offlineQueueLength
+                            offlineQueueLengthTotal += client.offlineQueueLength;
                             return Math.min(options.attempt * 25, 200);
                         },
                         retry_strategy: function (options) {
-                            if (options.total_retry_time == 150) {
-                                return new Error("Redis unavailable.");
+                            if (options.total_retry_time === 150) {
+                                return new Error('Redis unavailable.');
                             }
                             if (options.total_retry_time > 150) {
                                 var isLessThanBefore = (client.offlineQueueLength < offlineQueueLengthTotal);
@@ -371,7 +371,7 @@ describe('connection tests', function () {
                     }, 50);
                     var attemptTimeout = null;
                     function attemptSet () {
-                        client.set("foo", new Date().toString());
+                        client.set('foo', new Date().toString());
                         attemptTimeout = setTimeout(attemptSet, 25);
                     }
                     attemptSet();

--- a/test/connection.spec.js
+++ b/test/connection.spec.js
@@ -40,7 +40,7 @@ describe('connection tests', function () {
             var called = 0;
             client = redis.createClient({
                 port: 9999,
-                retry_strategy: function (options) {
+                connection_strategy: function (options) {
                     var bool = client.quit(function (err, res) {
                         assert.strictEqual(res, 'OK');
                         assert.strictEqual(err, null);
@@ -270,14 +270,14 @@ describe('connection tests', function () {
                     });
                 });
 
-                it('retryStrategy used to reconnect with individual error', function (done) {
+                it('connectionStrategy used to reconnect with individual error', function (done) {
                     var text = '';
                     var unhookIntercept = intercept(function (data) {
                         text += data;
                         return '';
                     });
                     client = redis.createClient({
-                        retryStrategy: function (options) {
+                        connectionStrategy: function (options) {
                             if (options.totalRetryTime > 150) {
                                 client.set('foo', 'bar', function (err, res) {
                                     assert.strictEqual(err.message, 'Stream connection ended and command aborted.');
@@ -296,16 +296,16 @@ describe('connection tests', function () {
                     process.nextTick(function () {
                         assert.strictEqual(
                             text,
-                            'node_redis: WARNING: You activated the retry_strategy and max_attempts at the same time. This is not possible and max_attempts will be ignored.\n' +
-                            'node_redis: WARNING: You activated the retry_strategy and retry_max_delay at the same time. This is not possible and retry_max_delay will be ignored.\n'
+                            'node_redis: WARNING: You activated the connection_strategy and max_attempts at the same time. This is not possible and max_attempts will be ignored.\n' +
+                            'node_redis: WARNING: You activated the connection_strategy and retry_max_delay at the same time. This is not possible and retry_max_delay will be ignored.\n'
                         );
                         unhookIntercept();
                     });
                 });
 
-                it('retry_strategy used to reconnect', function (done) {
+                it('connection_strategy used to reconnect', function (done) {
                     client = redis.createClient({
-                        retry_strategy: function (options) {
+                        connection_strategy: function (options) {
                             if (options.total_retry_time > 150) {
                                 client.set('foo', 'bar', function (err, res) {
                                     assert.strictEqual(err.message, 'Stream connection ended and command aborted.');
@@ -321,13 +321,13 @@ describe('connection tests', function () {
                     });
                 });
 
-                it('retryStrategy used to reconnect with defaults', function (done) {
+                it('connectionStrategy used to reconnect with defaults', function (done) {
                     var unhookIntercept = intercept(function () {
                         return '';
                     });
                     redis.debugMode = true;
                     client = redis.createClient({
-                        retryStrategy: function (options) {
+                        connectionStrategy: function (options) {
                             client.set('foo', 'bar');
                             assert(redis.debugMode);
                             return null;

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -40,7 +40,7 @@ describe('The node_redis client', function () {
 
     it('reset the parser while reconnecting (See #1190)', function (done) {
         var client = redis.createClient({
-            retryStrategy: function () {
+            connectionStrategy: function () {
                 return 5;
             }
         });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -32,7 +32,7 @@ describe('utils.js', function () {
         it('transform camelCase options to snake_case and add the camel_case option', function () {
             var a = utils.clone({
                 optionOneTwo: true,
-                retryStrategy: false,
+                connectionStrategy: false,
                 nested: {
                     onlyContainCamelCaseOnce: true
                 },
@@ -42,7 +42,7 @@ describe('utils.js', function () {
             });
             assert.strictEqual(Object.keys(a).length, 5);
             assert.strictEqual(a.option_one_two, true);
-            assert.strictEqual(a.retry_strategy, false);
+            assert.strictEqual(a.connection_strategy, false);
             assert.strictEqual(a.camel_case, true);
             assert.strictEqual(a.tls.rejectUnauthorized, true);
             assert.strictEqual(Object.keys(a.nested).length, 1);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

Addresses #1198 as an alternative to #1200 .

This change adds `options.connection_strategy` which intends to replace the existing `options.retry_strategy`, as the existing `retry_strategy` is mostly concerned with handling re-connection efforts, and this change aims to add additional control regarding queue'd commands. In that aim, this change changes the purpose of `options.retry_strategy` to handle allow for control of queue'd commands. The `retry_strategy` now accepts the same arguments as it did before, however if it returns an instance of an `Error`, then the queues will be flushed with that error. This allows for queue flushing and connection attempt handling to be decoupled.

I can understand why re-purposing the existing `retry_strategy` and renaming to `connection_strategy` may not be preferred and would cause a breaking change / major version bump, so if that is an obstacle please let me know and I would be happy to rename `connection_strategy` back to `retry_strategy` and come-up with a new name for `retry_strategy` in the context of this PR.