### PR TITLE
Fix option param null bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -931,7 +931,7 @@ RedisClient.prototype.internal_send_command = function (command_obj) {
             args_copy[i] = this.options.prefix + args_copy[i];
         }
     }
-    if (typeof this.options.rename_commands !== 'undefined' && this.options.rename_commands[command]) {
+    if (this.options.rename_commands && this.options.rename_commands[command]) {
         command = this.options.rename_commands[command];
     }
     // Always use 'Multi bulk commands', but if passed any Buffer args, then do multiple writes, one for each arg.


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

options.rename_commands could be null,and according to the README.md the default value is "null"

_Please provide a description of the change here._