### PR TITLE
Generalise monitor_regex

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -127,7 +127,7 @@ module.exports = {
     reply_to_object: replyToObject,
     print: print,
     err_code: /^([A-Z]+)\s+(.+)$/,
-    monitor_regex: /^[0-9]{10,11}\.[0-9]+ \[[0-9]{1,3} (.(?!\]))+.\]( ".+?")+$/,
+    monitor_regex: /^[0-9]{10,11}\.[0-9]+ \[[0-9]+ .+\]( ".+?")+$/,
     clone: convenienceClone,
     callback_or_emit: callbackOrEmit,
     reply_in_order: replyInOrder


### PR DESCRIPTION
* **Version**: master
* **Platform**: all
* **Description**:

The regular expression for detecting a monitor line is not all inclusive.

An example line that my local redis (3.0.6) outputs:
1489434066.308193 [0 [::ffff:172.17.0.1]:43346] "get" "..."

See issue #1208

[gitter]: https://gitter.im/NodeRedis/node_redis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge