### PR TITLE
Don't assume port_arg is a string

### DIFF
--- a/lib/createClient.js
+++ b/lib/createClient.js
@@ -23,7 +23,8 @@ module.exports = function createClient (port_arg, host_arg, options) {
     } else if (typeof port_arg === 'string' || port_arg && port_arg.url) {
 
         options = utils.clone(port_arg.url ? port_arg : host_arg || options);
-        var parsed = URL.parse(port_arg.url || port_arg, true, true);
+        var url = port_arg.url || port_arg;
+        var parsed = URL.parse(url, true, true);
 
         // [redis:]//[[user][:password]@][host][:port][/db-number][?db=db-number[&password=bar[&option=value]]]
         if (parsed.slashes) { // We require slashes
@@ -59,7 +60,7 @@ module.exports = function createClient (port_arg, host_arg, options) {
         } else if (parsed.hostname) {
             throw new RangeError('The redis url must begin with slashes "//" or contain slashes after the redis protocol');
         } else {
-            options.path = port_arg;
+            options.path = url;
         }
 
     } else if (typeof port_arg === 'object' || port_arg === undefined) {


### PR DESCRIPTION
Fixes https://github.com/NodeRedis/node_redis/issues/1257

Don't assume `port_arg` is a string, the url string could of been passed in as a string or as the `url` property in an object.