### PR TITLE
Fix "therefor" vs. "therefore" typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ In combination this can be used to implement backpressure by checking the buffer
 ## client.quit()
 
 This sends the quit command to the redis server and ends cleanly right after all running commands were properly handled.
-If this is called while reconnecting (and therefor no connection to the redis server exists) it is going to end the connection right away instead of
+If this is called while reconnecting (and therefore no connection to the redis server exists) it is going to end the connection right away instead of
 resulting in further reconnections! All offline commands are going to be flushed with an error in that case.
 
 ## client.end(flush)


### PR DESCRIPTION
Hi there,

This is just a single character change to the documentation so I'll skip the PR template.

I've changed "therefor" in `README.md` to "therefor**e**" since I believe that must've been the author's intention and it seems more appropriate given the context. Both are valid English words, but their meanings differ. [See this stackexchange answer for a nice, succinct explanation of how](https://english.stackexchange.com/a/58617).

Thanks for `node_redis`!