### PR TITLE
fix: client duplicate function now allows db param to be passed

### DIFF
--- a/lib/extendedApi.js
+++ b/lib/extendedApi.js
@@ -95,7 +95,7 @@ RedisClient.prototype.duplicate = function (options, callback) {
         existing_options[elem] = options[elem];
     }
     var client = new RedisClient(existing_options);
-    client.selected_db = this.selected_db;
+    client.selected_db = options.db || this.selected_db;
     if (typeof callback === 'function') {
         var ready_listener = function () {
             callback(null, client);

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -120,11 +120,14 @@ describe('The node_redis client', function () {
                     });
 
                     it('check if all new options replaced the old ones', function (done) {
+                        client.selected_db = 1;
                         var client2 = client.duplicate({
+                            db: 2, 
                             no_ready_check: true
                         });
                         assert(client.connected);
                         assert(!client2.connected);
+                        assert.notEqual(client.selected_db, client2.selected_db);
                         assert.strictEqual(client.options.no_ready_check, undefined);
                         assert.strictEqual(client2.options.no_ready_check, true);
                         assert.notDeepEqual(client.options, client2.options);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm test` pass with this change (including linting)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

When invoking the redis client duplicate function the new client will respect a new selected_db target if the db option param is passed.

Thoughts?

fixes #1281 