### PR TITLE
Simpler bluebird promisifyAll usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ You can also use node_redis with promises by promisifying node_redis with
 
 ```js
 const redis = require('redis');
-bluebird.promisifyAll(redis.RedisClient.prototype);
-bluebird.promisifyAll(redis.Multi.prototype);
+bluebird.promisifyAll(redis);
 ```
 
 It'll add a *Async* to all node_redis functions (e.g. return client.getAsync().then())


### PR DESCRIPTION
In the README section about bluebird promisifyAll, it is shown that you need to promisifyAll both the client prototype and the multi prototype.
However, the redis object returned from the redis lib is enough to be promisified.
This is what bluebird suggest in their own documentation for promistAll:
[bluebird promisifyAll page](http://bluebirdjs.com/docs/api/promise.promisifyall.html)

I also use this way and it works great.
I believe the readme should include the simpler and shorter way as well.
