### PR TITLE
[tests] fix broken utils tests

### DIFF
--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -131,17 +131,22 @@ describe('utils.js', function () {
         });
 
         it('elements in the offline queue. Reply after the offline queue is empty and respect the command_obj callback', function (done) {
-            clientMock.offline_queue.push(create_command_obj(), create_command_obj());
+            clientMock.offline_queue.push(create_command_obj());
+            clientMock.offline_queue.push(create_command_obj());
             utils.reply_in_order(clientMock, function () {
                 assert.strictEqual(clientMock.offline_queue.length, 0);
                 assert.strictEqual(res_count, 2);
                 done();
             }, null, null);
-            while (clientMock.offline_queue.length) clientMock.offline_queue.shift().callback(null, 'foo');
+            while (clientMock.offline_queue.length) {
+                clientMock.offline_queue.shift().callback(null, 'foo');
+            }
         });
 
         it('elements in the offline queue. Reply after the offline queue is empty and respect the command_obj error emit', function (done) {
-            clientMock.command_queue.push({}, create_command_obj(), {});
+            clientMock.command_queue.push({});
+            clientMock.command_queue.push(create_command_obj());
+            clientMock.command_queue.push({});
             utils.reply_in_order(clientMock, function () {
                 assert.strictEqual(clientMock.command_queue.length, 0);
                 assert(emitted);
@@ -158,8 +163,10 @@ describe('utils.js', function () {
         });
 
         it('elements in the offline queue and the command_queue. Reply all other commands got handled respect the command_obj', function (done) {
-            clientMock.command_queue.push(create_command_obj(), create_command_obj());
-            clientMock.offline_queue.push(create_command_obj(), {});
+            clientMock.command_queue.push(create_command_obj());
+            clientMock.command_queue.push(create_command_obj());
+            clientMock.command_queue.push(create_command_obj());
+            clientMock.offline_queue.push({});
             utils.reply_in_order(clientMock, function (err, res) {
                 assert.strictEqual(clientMock.command_queue.length, 0);
                 assert.strictEqual(clientMock.offline_queue.length, 0);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Patched utils.spec queue tests to support denque's singular `push()`, not sure how these slipped passed me on the last PR sorry. Singular item `.push()` is ok as this is how it's used in the library by pushing singular `Command` instances to the queue.

Will merge after CI confirms ok.