### PR TITLE
Clarify reconnecting delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ emitted.
 
 `client` will emit `reconnecting` when trying to reconnect to the Redis server
 after losing the connection. Listeners are passed an object containing `delay`
-(in ms) and `attempt` (the attempt #) attributes.
+(in ms from the previous try) and `attempt` (the attempt #) attributes.
 
 ### "error"
 


### PR DESCRIPTION
Without clarification `delay` can mean two things: time to the next attempt (wrong) or time passed from the previous attempt (correct). The wrong interpretation is tempting because it makes easy to print "Trying to reconnect in {delay} ms."

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Only a minor change in main documentation.