### PR TITLE
Remove clientError handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,12 +279,6 @@ RedisClient.prototype.create_stream = function () {
         self.on_error(err);
     });
 
-    /* istanbul ignore next: difficult to test and not important as long as we keep this listener */
-    this.stream.on('clientError', function (err) {
-        debug('clientError occured');
-        self.on_error(err);
-    });
-
     this.stream.once('close', function (hadError) {
         self.connection_gone('close');
     });


### PR DESCRIPTION
This event is never emitted on `net.Socket` or `tls.TLSSocket` streams in
any of the supported versions of Node.js.

### Pull Request check-list

- [x] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
  - Not applicable.
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? 
  - Not applicable.

### Description of change

It seems that this handler was added in eae5596, as part of adding support for TLS. While `tls.TLSServer` instances can emit `'clientError'` (prior to Node 6), `tls.TLSSocket` cannot.