### PR TITLE
Update client.quit definition in README.md to include callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ implement backpressure by checking the buffer state before sending a command and
 listening to the stream
 [drain](https://nodejs.org/api/stream.html#stream_event_drain) event.
 
-## client.quit()
+## client.quit(callback)
 
 This sends the quit command to the redis server and ends cleanly right after all
 running commands were properly handled. If this is called while reconnecting


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

I was a bit confused by the documentation provided in the `README.md` for `client.quit`. It didn't point out that `.close` accepted a callback. I looked at the [source code](https://github.com/NodeRedis/node_redis/blob/master/lib/individualCommands.js#L105) and it sems it does. I updated `client.quit` definition in the `README.md` to include `callback`.  