### PR TITLE
Added timestamp to debug traces

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -4,7 +4,9 @@ var index = require('../');
 
 function debug () {
     if (index.debug_mode) {
-        console.error.apply(null, arguments);
+        var data = Array.from(arguments);
+        data.unshift(new Date());
+        console.error.apply(null, data);
     }
 }
 

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -4,7 +4,7 @@ var index = require('../');
 
 function debug () {
     if (index.debug_mode) {
-        var data = Array.from(arguments);
+        var data = Array.prototype.slice.call(arguments);
         data.unshift(new Date().toISOString());
         console.error.apply(null, data);
     }

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -5,7 +5,7 @@ var index = require('../');
 function debug () {
     if (index.debug_mode) {
         var data = Array.from(arguments);
-        data.unshift(new Date());
+        data.unshift(new Date().toISOString());
         console.error.apply(null, data);
     }
 }

--- a/test/commands/blpop.spec.js
+++ b/test/commands/blpop.spec.js
@@ -31,7 +31,7 @@ describe("The 'blpop' method", function () {
                 });
                 client.rpush('blocking list', 'initial value', helper.isNumber(1));
                 unhookIntercept();
-                assert(/^Send 127\.0\.0\.1:6379 id [0-9]+: \*3\r\n\$5\r\nrpush\r\n\$13\r\nblocking list\r\n\$13\r\ninitial value\r\n\n$/.test(text));
+                assert(/Send 127\.0\.0\.1:6379 id [0-9]+: \*3\r\n\$5\r\nrpush\r\n\$13\r\nblocking list\r\n\$13\r\ninitial value\r\n\n$/.test(text));
                 redis.debug_mode = false;
                 bclient.blpop('blocking list', 0, function (err, value) {
                     assert.strictEqual(value[0], 'blocking list');


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **No need for docs here**

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Trying to follow connection spikes with debug traces was a bit cumbersome so I've added timestamp to them so it becomes easier to follow the events through the time.

You can see a sample of the logs here:
```
2019-04-03T15:35:45.224Z Stream connected localhost:6379 id 0
2019-04-03T15:35:45.226Z Checking server ready state...
2019-04-03T15:35:45.227Z Send localhost:6379 id 0: *1\r\n$4\r\ninfo\r\n
2019-04-03T15:35:45.229Z Net read localhost:6379 id 0
2019-04-03T15:35:45.231Z Redis server ready.
2019-04-03T15:35:45.231Z on_ready called localhost:6379 id 0'
```