### PR TITLE
removing use of function.prototype.apply which internally uses queuin…

### DIFF
--- a/lib/multi.js
+++ b/lib/multi.js
@@ -13,9 +13,9 @@ function Multi (client, args) {
             command = args[i][0];
             tmp_args = args[i].slice(1);
             if (Array.isArray(command)) {
-                this[command[0]].apply(this, command.slice(1).concat(tmp_args));
+                this[command[0]](command.slice(1).concat(tmp_args));
             } else {
-                this[command].apply(this, tmp_args);
+                this[command](tmp_args);
             }
         }
     }


### PR DESCRIPTION
…g causing stack limit to be reached on large number of arguments

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Earlier MULTI function was calling the commands using function.prototype.apply which has a hardcoded argument limit of [65536](https://bugs.webkit.org/show_bug.cgi?id=80797). 
for eg. If I wanted to add 1 mil keys in a set using a SADD command running REDIS transaction it throws a Maximum call stack size exceeded error.
```
client.multi(
['sadd',keyName,1,2,3,4,.......999999,1000000]
['expire',keyName,30000]
)
```
So, I have changed the function invocation which is not using function.prototype.apply.