### PR TITLE
allow reading from a disconnected read-only slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ __Note:__ Using `'rediss://...` for the protocol in a `redis_url` will enable a 
 | tls | null | An object containing options to pass to [tls.connect](http://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback) to set up a TLS connection to Redis (if, for example, it is set up to be accessible via a tunnel). |
 | prefix | null | A string used to prefix all used keys (e.g. `namespace:test`). Please be aware that the `keys` command will not be prefixed. The `keys` command has a "pattern" as argument and no key and it would be impossible to determine the existing keys in Redis if this would be prefixed. |
 | retry_strategy | function | A function that receives an options object as parameter including the retry `attempt`, the `total_retry_time` indicating how much time passed since the last time connected, the `error` why the connection was lost and the number of `times_connected` in total. If you return a number from this function, the retry will happen exactly after that time in milliseconds. If you return a non-number, no further retry will happen and all offline commands are flushed with errors. Return an error to return that specific error to all offline commands. Example below. |
+| allow_disconnected_slaves | null | If set to `true` and the redis server is configured as `slave-read-only` then connections to a disconnected slave are allowed. Otherwise connections will be retried until the master connection is restored. |
 
 ```js
 var redis = require("redis");

--- a/index.js
+++ b/index.js
@@ -504,7 +504,9 @@ RedisClient.prototype.on_info_cmd = function (err, res) {
 
     if (!this.server_info.loading || this.server_info.loading === '0') {
         // If the master_link_status exists but the link is not up, try again after 50 ms
-        if (this.server_info.master_link_status && this.server_info.master_link_status !== 'up') {
+        var disconnected = this.server_info.master_link_status && this.server_info.master_link_status !== 'up';
+        var allow_disconnected = this.options.allow_disconnected_slaves && this.server_info.slave_read_only === "1";
+        if (disconnected && ! allow_disconnected) {
             this.server_info.loading_eta_seconds = 0.05;
         } else {
             // Eta loading should change


### PR DESCRIPTION
### Pull Request check-list
- [ ] Does `npm test` pass with this change (including linting)?
The list of failing tests is unchanged / pull request does not cause new failures
- [ ] Is the new or changed code fully tested?
Tested, but not covered by test files
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

My company has local read-only redis slaves that are allowed to cache stale data; so we needed a new option to "allow_disconnected_slaves":
If set to `true` and the redis server is configured as `slave-read-only` then connections to a disconnected slave are allowed. Otherwise connections will be retried until the master connection is restored.