### PR TITLE
feat(parser): update to latest Redis parser & errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ node_js:
   - "4"
   - "6"
   - "8"
+  - "12"
 after_success: npm run coveralls
 before_script:
   # Add an IPv6 config - see the corresponding Travis issue

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "12"
 
 pull_requests:
   do_not_increment_build_number: true

--- a/benchmarks/diff_multi_bench_output.js
+++ b/benchmarks/diff_multi_bench_output.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 var metrics = require('metrics');
-    // `node diff_multi_bench_output.js beforeBench.txt afterBench.txt`
+// `node diff_multi_bench_output.js beforeBench.txt afterBench.txt`
 var file1 = process.argv[2];
 var file2 = process.argv[3];
 

--- a/examples/streams.js
+++ b/examples/streams.js
@@ -5,43 +5,43 @@ var client1 = redis.createClient();
 var client2 = redis.createClient();
 var client3 = redis.createClient();
 
-client1.xadd('mystream', '*', 'field1', 'm1',  function (err) {
-	if(err){
-	    return console.error(err);	
-	}
-	client1.xgroup('CREATE', 'mystream', 'mygroup', '$',  function (err) {
-		if(err){
-		    return console.error(err);	
-		}
-	});
-	
-	client2.xreadgroup('GROUP', 'mygroup', 'consumer', 'Block', 1000, 'NOACK',
-			'STREAMS', 'mystream', '>',  function (err, stream) {
-		if(err){
-		    return console.error(err);	
-		}
-	    console.log('client2 ' + stream);
-	});
-	
-	client3.xreadgroup('GROUP', 'mygroup', 'consumer', 'Block', 1000, 'NOACK',
-			'STREAMS', 'mystream', '>',  function (err, stream) {
-		if(err){
-		    return console.error(err);	
-		}
-	    console.log('client3 ' + stream);
-	});
+client1.xadd('mystream', '*', 'field1', 'm1', function (err) {
+    if (err) {
+        return console.error(err);
+    }
+    client1.xgroup('CREATE', 'mystream', 'mygroup', '$', function (err) {
+        if (err) {
+            return console.error(err);
+        }
+    });
 
-	
-	client1.xadd('mystream', '*', 'field1', 'm2',  function (err) {
-		if(err){
-		    return console.error(err);	
-		}
-	});
-	
-	client1.xadd('mystream', '*', 'field1', 'm3',  function (err) {
-		if(err){
-		    return console.error(err);	
-		}
-	});
+    client2.xreadgroup('GROUP', 'mygroup', 'consumer', 'Block', 1000, 'NOACK',
+        'STREAMS', 'mystream', '>', function (err, stream) {
+            if (err) {
+                return console.error(err);
+            }
+            console.log('client2 ' + stream);
+        });
+
+    client3.xreadgroup('GROUP', 'mygroup', 'consumer', 'Block', 1000, 'NOACK',
+        'STREAMS', 'mystream', '>', function (err, stream) {
+            if (err) {
+                return console.error(err);
+            }
+            console.log('client3 ' + stream);
+        });
+
+
+    client1.xadd('mystream', '*', 'field1', 'm2', function (err) {
+        if (err) {
+            return console.error(err);
+        }
+    });
+
+    client1.xadd('mystream', '*', 'field1', 'm3', function (err) {
+        if (err) {
+            return console.error(err);
+        }
+    });
 
 });

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var Queue = require('denque');
 var errorClasses = require('./lib/customErrors');
 var EventEmitter = require('events');
 var Parser = require('redis-parser');
+var RedisErrors = require('redis-errors');
 var commands = require('redis-commands');
 var debug = require('./lib/debug');
 var unifyOptions = require('./lib/createClient');
@@ -1090,9 +1091,9 @@ exports.RedisClient = RedisClient;
 exports.print = utils.print;
 exports.Multi = require('./lib/multi');
 exports.AbortError = errorClasses.AbortError;
-exports.RedisError = Parser.RedisError;
-exports.ParserError = Parser.ParserError;
-exports.ReplyError = Parser.ReplyError;
+exports.RedisError = RedisErrors.RedisError;
+exports.ParserError = RedisErrors.ParserError;
+exports.ReplyError = RedisErrors.ReplyError;
 exports.AggregateError = errorClasses.AggregateError;
 
 // Add all redis commands / node_redis api to the client

--- a/lib/customErrors.js
+++ b/lib/customErrors.js
@@ -2,14 +2,13 @@
 
 var util = require('util');
 var assert = require('assert');
-var RedisError = require('redis-parser').RedisError;
+var RedisError = require('redis-errors').RedisError;
 var ADD_STACKTRACE = false;
 
 function AbortError (obj, stack) {
     assert(obj, 'The options argument is required');
     assert.strictEqual(typeof obj, 'object', 'The options argument has to be of type object');
 
-    RedisError.call(this, obj.message, ADD_STACKTRACE);
     Object.defineProperty(this, 'message', {
         value: obj.message || '',
         configurable: true,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "denque": "^1.2.3",
     "redis-commands": "^1.4.0",
-    "redis-parser": "^2.6.0"
+    "redis-errors": "^1.2.0",
+    "redis-parser": "^3.0.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -359,7 +359,7 @@ describe('The node_redis client', function () {
 
                     it('send_command with callback as args', function (done) {
                         client.send_command('abcdef', function (err, res) {
-                            assert.strictEqual(err.message, "ERR unknown command 'abcdef'");
+                            assert.strictEqual(err.message, 'ERR unknown command `abcdef`, with args beginning with: ');
                             done();
                         });
                     });

--- a/test/rename.spec.js
+++ b/test/rename.spec.js
@@ -50,7 +50,7 @@ describe('rename commands', function () {
                 });
 
                 client.get('key', function (err, reply) {
-                    assert.strictEqual(err.message, "ERR unknown command 'get'");
+                    assert.strictEqual(err.message, 'ERR unknown command `get`, with args beginning with: `key`, ');
                     assert.strictEqual(err.command, 'GET');
                     assert.strictEqual(reply, undefined);
                 });
@@ -108,7 +108,7 @@ describe('rename commands', function () {
                 multi.exec(function (err, res) {
                     assert(err);
                     assert.strictEqual(err.message, 'EXECABORT Transaction discarded because of previous errors.');
-                    assert.strictEqual(err.errors[0].message, "ERR unknown command 'get'");
+                    assert.strictEqual(err.errors[0].message, 'ERR unknown command `get`, with args beginning with: `key`, ');
                     assert.strictEqual(err.errors[0].command, 'GET');
                     assert.strictEqual(err.code, 'EXECABORT');
                     assert.strictEqual(err.errors[0].code, 'ERR');


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

- update `redis-parser` to `3.0.0` for removing `hiredis` to support node 12+.
- fix eslint errors.
- fix some of existing errors.
- add nodejs 12 to travis ci.
- add nodejs 12 to appveyor ci.