### PR TITLE
docs(*): additional clarification of Pub/Sub section

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,8 +532,8 @@ sub.subscribe("a nice channel");
 ```
 
 When a client issues a `SUBSCRIBE` or `PSUBSCRIBE`, that connection is put into
-a "subscriber" mode. At that point, only commands that modify the subscription
-set are valid and quit (and depending on the redis version ping as well). When
+a "subscriber" mode. At that point, the only valid commands are those that modify the subscription
+set, and quit (also ping on some redis versions). When
 the subscription set is empty, the connection is put back into regular mode.
 
 If you need to send regular commands to Redis while in subscriber mode, just


### PR DESCRIPTION
The previous phrasing wasn't clear to me. The oxford comma is necessary to avoid ambiguity.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm test` pass with this change (including linting)? N/A
- [x] Is the new or changed code fully tested? N/A
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? N/A

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Just a minor documentation change. 