### PR TITLE
Flatten array arguments in legacyMode multi commands

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -294,6 +294,20 @@ describe('Client', () => {
                 }
             }
         });
+
+        testUtils.testWithClient('client.multi.{command}.exec should flatten array arguments', async client => {
+            assert.deepEqual(
+                await client.multi()
+                    .sAdd('a', ['b', 'c'])
+                    .v4.exec(),
+                [2])
+        }, {
+            ...GLOBAL.SERVERS.OPEN,
+            clientOptions: {
+                legacyMode: true
+            }
+        });
+
     });
 
     describe('events', () => {

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -87,7 +87,7 @@ export default class RedisClientMultiCommand {
     #defineLegacyCommand(name: string): void {
         this.v4[name] = (this as any)[name].bind(this.v4);
         (this as any)[name] =
-            (...args: Array<unknown>): void => (this as any).addCommand(name, args);
+            (...args: Array<unknown>): void => (this as any).addCommand(name, ...args);
     }
 
     commandsExecutor(command: RedisCommand, args: Array<unknown>): this {


### PR DESCRIPTION
### Description
https://github.com/redis/node-redis/issues/2071

In legacy mode multi commands, array arguments are not flattened. This is a bug.
For example, this command that adds two elements to a set:
`sadd('a', ['b', 'c'])`
when called in a multi will instead add the single element "['b', 'c']".

This bug is a blocker that surfaced while trying to upgrade from node-redis v3 to v4.

The root problem seems to be an inconsistency with the schema of queued multi vs single command arguments.
In a non-multi, the command that gets queued up in our sadd example would be:
`["sAdd", "a", ["b", "c"]]`
This is later flattened before getting serialized into a redis command.

However, multi commands queue up commands as the tuple: [commandName, args]. In this example:
`["sAdd", ["a", ["b", "c"]]]`
This is also flattened before getting serialized into a redis command, but only to one level, which is why this issue only surfaces for array arguments.

We fix this inconsistency in this diff by enqueing multi commands in the same format as their non-multi counterparts.

Thank you!

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
  - I am not able to run the entire test suite on my machine (even master), however I have confirmed that the entire client/lib/client/index.spec.ts file passes on this branch, and the newly added unit test fails on master
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
  - No document changes needed

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
