### PR TITLE
tests: add test case for redis uri scheme

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -65,6 +65,19 @@ describe('Client', () => {
             );
         });
 
+        it('redis://localhost:6379?db=0', () => {
+            assert.deepEqual(
+                RedisClient.parseURL('redis://localhost:6379?db=0'),
+                {
+                    socket: {
+                        host: 'localhost',
+                        port: 6379
+                    },
+                    database: 0
+                }
+            );
+        });
+
         it('rediss://user:secret@localhost:6379/0', () => {
             assert.deepEqual(
                 RedisClient.parseURL('rediss://user:secret@localhost:6379/0'),


### PR DESCRIPTION
covering provision: 
> or the value from the key-value pair from the "query" URI field with the key "db"
