### PR TITLE
fix(search): align ft.search with server

### DIFF
--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -221,6 +221,10 @@ export interface SearchReply {
 function documentValue(tuples: any) {
   const message = Object.create(null);
 
+  if(!tuples) {
+    return message;
+  }
+
   let i = 0;
   while (i < tuples.length) {
       const key = tuples[i++],


### PR DESCRIPTION
as per the ft.search docs ( https://redis.io/docs/latest/commands/ft.search ):

    If a relevant key expires while a query is running,
    an attempt to load the key's value will return a null array.
    However, the key is still counted in the total number of results.

So, instead of crashing when seeing a null as a value, we return empty object.

fixes #2772
see https://github.com/redis/node-redis/pull/2814

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
