### PR TITLE
fix(commands): sPopCount return Array<string>

### DIFF
--- a/packages/client/lib/commands/SPOP.spec.ts
+++ b/packages/client/lib/commands/SPOP.spec.ts
@@ -1,12 +1,14 @@
 import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import SPOP from './SPOP';
-import { parseArgs } from './generic-transformers';
+import { BasicCommandParser } from '../client/parser';
 
 describe('SPOP', () => {
   it('transformArguments', () => {
+    const parser = new BasicCommandParser();
+    SPOP.parseCommand(parser, 'key');
     assert.deepEqual(
-      parseArgs(SPOP, 'key'),
+      parser.redisArgs,
       ['SPOP', 'key']
     );
   });
@@ -16,6 +18,19 @@ describe('SPOP', () => {
       await client.sPop('key'),
       null
     );
+
+    await client.sAdd('key', 'member');
+
+    assert.equal(
+      await client.sPop('key'),
+      'member'
+    );
+
+    assert.equal(
+      await client.sPop('key'),
+      null
+    );
+
   }, {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN

--- a/packages/client/lib/commands/SPOP_COUNT.spec.ts
+++ b/packages/client/lib/commands/SPOP_COUNT.spec.ts
@@ -1,21 +1,36 @@
 import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import SPOP_COUNT from './SPOP_COUNT';
-import { parseArgs } from './generic-transformers';
+import { BasicCommandParser } from '../client/parser';
 
 describe('SPOP_COUNT', () => {
   it('transformArguments', () => {
+    const parser = new BasicCommandParser();
+    SPOP_COUNT.parseCommand(parser, 'key', 1);
     assert.deepEqual(
-      parseArgs(SPOP_COUNT, 'key', 1),
+      parser.redisArgs,
       ['SPOP', 'key', '1']
     );
   });
 
   testUtils.testAll('sPopCount', async client => {
+
     assert.deepEqual(
       await client.sPopCount('key', 1),
       []
     );
+
+    await Promise.all([
+      client.sAdd('key', 'member'),
+      client.sAdd('key', 'member2'),
+      client.sAdd('key', 'member3')
+    ])
+
+    assert.deepEqual(
+      (await client.sPopCount('key', 3)).length,
+      3
+    );
+
   }, {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN

--- a/packages/client/lib/commands/SPOP_COUNT.ts
+++ b/packages/client/lib/commands/SPOP_COUNT.ts
@@ -1,5 +1,5 @@
 import { CommandParser } from '../client/parser';
-import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/types';
+import { RedisArgument, Command, ArrayReply } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: false,
@@ -16,5 +16,5 @@ export default {
     parser.pushKey(key);
     parser.push(count.toString());
   },
-  transformReply: undefined as unknown as () => BlobStringReply | NullReply
+  transformReply: undefined as unknown as () => ArrayReply<string>
 } as const satisfies Command;


### PR DESCRIPTION
fix sPopCount return type - should be an array instead of string | null

Also, touch the tests for sPop and sPopCount to use the new parseCommand API

fixes #3004

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
