### PR TITLE
chore(release): use deploy keys for relese

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
main branch is protected and does not allow direct pushes. the release action needs to push.
branch protection rules can be bypassed for people and apps, but not github actions.

one of the workarounds is to use a ruleset in which we set a deploy key

see: https://github.com/orgs/community/discussions/25305\#discussioncomment-10728028



