### PR TITLE
Call out sendCommand cluster difference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ await client.sendCommand(["SET", "key", "value", "NX"]); // 'OK'
 await client.sendCommand(["HGETALL", "key"]); // ['key1', 'field1', 'key2', 'field2']
 ```
 
+_Note: the [API is different when using a cluster](https://github.com/redis/node-redis/blob/master/docs/clustering.md#unsupported-redis-commands)._
+
 ### Transactions (Multi/Exec)
 
 Start a [transaction](https://redis.io/topics/transactions) by calling `.multi()`, then chaining your commands. When


### PR DESCRIPTION
### Description

This is just a one-line addition to the readme, with a link to further documentation.

It's a followup to https://github.com/redis/node-redis/pull/3053

Feel free to edit the wording/styling/etc. as desired.

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] ~~Is the new or changed code fully tested?~~
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
