### PR TITLE
fix(ts): use all commands in cluster type

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -146,14 +146,14 @@ export interface RedisClientOptions<
   clientInfoTag?: string;
 }
 
-type WithCommands<
+export type WithCommands<
   RESP extends RespVersions,
   TYPE_MAPPING extends TypeMapping
 > = {
     [P in keyof typeof COMMANDS]: CommandSignature<(typeof COMMANDS)[P], RESP, TYPE_MAPPING>;
   };
 
-type WithModules<
+export type WithModules<
   M extends RedisModules,
   RESP extends RespVersions,
   TYPE_MAPPING extends TypeMapping
@@ -163,7 +163,7 @@ type WithModules<
     };
   };
 
-type WithFunctions<
+export type WithFunctions<
   F extends RedisFunctions,
   RESP extends RespVersions,
   TYPE_MAPPING extends TypeMapping
@@ -173,7 +173,7 @@ type WithFunctions<
     };
   };
 
-type WithScripts<
+export type WithScripts<
   S extends RedisScripts,
   RESP extends RespVersions,
   TYPE_MAPPING extends TypeMapping
@@ -498,7 +498,7 @@ export default class RedisClient<
 
     if (options?.url) {
       const parsedOptions = RedisClient.parseOptions(options);
-    
+
       if (parsedOptions?.database) {
         this._self.#selectedDB = parsedOptions.database;
       }

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -1,6 +1,6 @@
 import { RedisClientOptions, RedisClientType } from '../client';
 import { CommandOptions } from '../client/commands-queue';
-import { Command, CommandArguments, CommanderConfig, CommandSignature, /*CommandPolicies, CommandWithPoliciesSignature,*/ TypeMapping, RedisArgument, RedisFunction, RedisFunctions, RedisModules, RedisScript, RedisScripts, ReplyUnion, RespVersions } from '../RESP/types';
+import { Command, CommandArguments, CommanderConfig, TypeMapping, RedisArgument, RedisFunction, RedisFunctions, RedisModules, RedisScript, RedisScripts, ReplyUnion, RespVersions } from '../RESP/types';
 import COMMANDS from '../commands';
 import { EventEmitter } from 'node:events';
 import { attachConfig, functionArgumentsPrefix, getTransformReply, scriptArgumentsPrefix } from '../commander';
@@ -13,6 +13,8 @@ import { ClientSideCacheConfig, PooledClientSideCacheProvider } from '../client/
 import { BasicCommandParser } from '../client/parser';
 import { ASKING_CMD } from '../commands/ASKING';
 import SingleEntryCache from '../single-entry-cache'
+import { WithCommands, WithFunctions, WithModules, WithScripts } from '../client';
+
 interface ClusterCommander<
   M extends RedisModules,
   F extends RedisFunctions,
@@ -102,50 +104,6 @@ export interface RedisClusterOptions<
    */
   clientSideCache?: PooledClientSideCacheProvider | ClientSideCacheConfig;
 }
-
-// remove once request & response policies are ready
-type ClusterCommand<
-  NAME extends PropertyKey,
-  COMMAND extends Command
-> = COMMAND['NOT_KEYED_COMMAND'] extends true ? (
-  COMMAND['IS_FORWARD_COMMAND'] extends true ? NAME : never
-) : NAME;
-
-// CommandWithPoliciesSignature<(typeof COMMANDS)[P], RESP, TYPE_MAPPING, POLICIES>
-type WithCommands<
-  RESP extends RespVersions,
-  TYPE_MAPPING extends TypeMapping
-> = {
-  [P in keyof typeof COMMANDS as ClusterCommand<P, (typeof COMMANDS)[P]>]: CommandSignature<(typeof COMMANDS)[P], RESP, TYPE_MAPPING>;
-};
-
-type WithModules<
-  M extends RedisModules,
-  RESP extends RespVersions,
-  TYPE_MAPPING extends TypeMapping
-> = {
-  [P in keyof M]: {
-    [C in keyof M[P] as ClusterCommand<C, M[P][C]>]: CommandSignature<M[P][C], RESP, TYPE_MAPPING>;
-  };
-};
-
-type WithFunctions<
-  F extends RedisFunctions,
-  RESP extends RespVersions,
-  TYPE_MAPPING extends TypeMapping
-> = {
-  [L in keyof F]: {
-    [C in keyof F[L] as ClusterCommand<C, F[L][C]>]: CommandSignature<F[L][C], RESP, TYPE_MAPPING>;
-  };
-};
-
-type WithScripts<
-  S extends RedisScripts,
-  RESP extends RespVersions,
-  TYPE_MAPPING extends TypeMapping
-> = {
-  [P in keyof S as ClusterCommand<P, S[P]>]: CommandSignature<S[P], RESP, TYPE_MAPPING>;
-};
 
 export type RedisClusterType<
   M extends RedisModules = {},


### PR DESCRIPTION
RedisClusterType was using some type restrictions to hide some commands based on its properties. In reality, all commands should be exposed to user ( as in v4 ).

fixes #3064

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
