### PR TITLE
fix(cluster): prevent infinite loop

### DIFF
--- a/packages/client/lib/cluster/cluster-slots.spec.ts
+++ b/packages/client/lib/cluster/cluster-slots.spec.ts
@@ -5,7 +5,6 @@ import RedisClusterSlots from './cluster-slots';
 
 describe('RedisClusterSlots', () => {
   describe('initialization', () => {
-
     describe('clientSideCache validation', () => {
       const mockEmit = ((_event: string | symbol, ..._args: any[]): boolean => true) as EventEmitter['emit'];
       const clientSideCacheConfig = { ttl: 0, maxEntries: 0 };
@@ -44,5 +43,15 @@ describe('RedisClusterSlots', () => {
         );
       });
     });
+  });
+
+  describe('getRandomNode', ()=> {
+    it('should not enter infinite loop when no nodes', () => {
+        const slots = new RedisClusterSlots({
+          rootNodes: []
+        }, () => true)
+        slots.getRandomNode()
+        slots.getRandomNode()
+      });
   });
 });

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -462,6 +462,7 @@ export default class RedisClusterSlots<
   }
 
   *#iterateAllNodes() {
+    if(this.masters.length + this.replicas.length === 0) return
     let i = Math.floor(Math.random() * (this.masters.length + this.replicas.length));
     if (i < this.masters.length) {
       do {
@@ -542,7 +543,7 @@ export default class RedisClusterSlots<
         this.masters[index] :
         this.replicas[index - this.masters.length],
         client = this.#createClient(node, false);
-      
+
     this.pubSubNode = {
       address: node.address,
       client,


### PR DESCRIPTION
getRandomNode could end up in an infinite loop if
this.masters is empty and this.replicas is empty.

fixes: #3075


- [x] Is the new or changed code fully tested?

