### PR TITLE
Improve stale issue management workflow

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,25 +1,95 @@
-name: "Close stale issues"
+name: "Stale Issue Management"
 on:
   schedule:
-  - cron: "0 0 * * *"
+    # Run daily at midnight UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch: # Allow manual triggering
 
-permissions: {}
+env:
+  # Default stale policy timeframes
+  DAYS_BEFORE_STALE: 365
+  DAYS_BEFORE_CLOSE: 30
+
+  # Accelerated timeline for needs-information issues
+  NEEDS_INFO_DAYS_BEFORE_STALE: 30
+  NEEDS_INFO_DAYS_BEFORE_CLOSE: 7
+
 jobs:
   stale:
-    permissions:
-      issues: write  #  to close stale issues (actions/stale)
-      pull-requests: write  #  to close stale PRs (actions/stale)
-
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is marked stale. It will be closed in 30 days if it is not updated.'
-        stale-pr-message: 'This pull request is marked stale. It will be closed in 30 days if it is not updated.'
-        days-before-stale: 365
-        days-before-close: 30
-        stale-issue-label: "Stale"
-        stale-pr-label: "Stale"
-        operations-per-run: 10
-        remove-stale-when-updated: true
+      # First step: Handle regular issues (excluding needs-information)
+      - name: Mark regular issues as stale
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Default stale policy
+          days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}
+
+          # Explicit stale label configuration
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+
+          stale-issue-message: |
+            This issue has been automatically marked as stale due to inactivity.
+            It will be closed in 30 days if no further activity occurs.
+            If you believe this issue is still relevant, please add a comment to keep it open.
+
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity.
+            If you believe this issue is still relevant, please reopen it or create a new issue with updated information.
+
+          # Exclude needs-information issues from this step
+          exempt-issue-labels: 'no-stale,needs-information'
+
+          # Remove stale label when issue/PR becomes active again
+          remove-stale-when-updated: true
+
+          # Apply to pull requests with same timeline
+          days-before-pr-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-pr-close: ${{ env.DAYS_BEFORE_CLOSE }}
+
+          stale-pr-message: |
+            This pull request has been automatically marked as stale due to inactivity.
+            It will be closed in 30 days if no further activity occurs.
+
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity.
+            If you would like to continue this work, please reopen the PR or create a new one.
+
+          # Only exclude no-stale PRs (needs-information PRs follow standard timeline)
+          exempt-pr-labels: 'no-stale'
+
+      # Second step: Handle needs-information issues with accelerated timeline
+      - name: Mark needs-information issues as stale
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Accelerated timeline for needs-information
+          days-before-stale: ${{ env.NEEDS_INFO_DAYS_BEFORE_STALE }}
+          days-before-close: ${{ env.NEEDS_INFO_DAYS_BEFORE_CLOSE }}
+
+          # Explicit stale label configuration
+          stale-issue-label: "stale"
+
+          # Only target ISSUES with needs-information label (not PRs)
+          only-issue-labels: 'needs-information'
+
+          stale-issue-message: |
+            This issue has been marked as stale because it requires additional information
+            that has not been provided for 30 days. It will be closed in 7 days if the
+            requested information is not provided.
+
+          close-issue-message: |
+            This issue has been closed because the requested information was not provided within the specified timeframe.
+            If you can provide the missing information, please reopen this issue or create a new one.
+
+          # Disable PR processing for this step
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          # Remove stale label when issue becomes active again
+          remove-stale-when-updated: true


### PR DESCRIPTION
**Added Dual-Tier Stale Policy:**

- Standard timeline: Issues/PRs still follow 365→30 day cycle
- Accelerated timeline: Issues with needs-information label now get 30→7 day cycle
- Separate jobs handle each policy independently
- Detailed messages explaining why items are marked stale and how to keep them open
- Exempt labels: `no-stale`, `needs-information` (for standard policy)
- Only `no-stale` exempt for PRs (`needs-info` doesn't apply)