### PR TITLE
chore(build): fix npm run build command

### DIFF
--- a/packages/client/lib/commands/CLIENT_INFO.spec.ts
+++ b/packages/client/lib/commands/CLIENT_INFO.spec.ts
@@ -2,9 +2,15 @@ import { strict as assert } from 'node:assert';
 import CLIENT_INFO from './CLIENT_INFO';
 import testUtils, { GLOBAL } from '../test-utils';
 import { parseArgs } from './generic-transformers';
-import { version } from '../../package.json';
+import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
 
 describe('CLIENT INFO', () => {
+
+  const filePath = resolve(__dirname, "..", "..", "package.json");
+  const data = readFileSync(filePath, "utf8");
+  const version = JSON.parse(data).version;
+
   testUtils.isVersionGreaterThanHook([6, 2]);
 
   it('transformArguments', () => {


### PR DESCRIPTION
### Description
importing from 'package.json' messes typescript, as it starts thinking it depends on the files it wants to write, resulting in build errors if the dist folders are not deleted. ultimately it was very annoying to delete all dist folders and then build when you just want to build. and its also much slower because you loose all your cache

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
