### PR TITLE
Rebuild after release - fix #3118

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,3 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Rebuild packages after version bump to ensure dist/package.json is updated
-      - name: Rebuild packages after version bump
-        run: npm run build

--- a/packages/client/.release-it.json
+++ b/packages/client/.release-it.json
@@ -9,5 +9,8 @@
     "commitMessage": "Release ${tagName}",
     "tagAnnotation": "Release ${tagName}",
     "commitArgs": "--all"
+  },
+  "hooks": {
+    "before:release": "npm run build"
   }
 }


### PR DESCRIPTION
### Description

wget https://registry.npmjs.org/@redis/client/-/client-5.9.0.tgz
mkdir client-5.9.0
tar -xzvf client-5.9.0.tgz -C client-5.9.0
grep "version" client-5.9.0/package.json # "version": "5.9.0",
# but inside the dist/
grep "version" client-5.9.0/dist/package.json # "version": "5.9.0-beta

The release workflow has a timing issue where:
- The build process (npm run build) runs before the version bump
This creates the dist/package.json with the beta version (5.9.0-beta.3)

- Then release-it updates the source package.json to the final version (5.9.0)
But the dist/package.json is never updated, so it still contains the beta version

The Solution:
The release workflow needs to rebuild the packages after the version bump but before publishing to npm.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ x] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
