### PR TITLE
fix(release): bump dist/package.json version

### DIFF
--- a/packages/client/.release-it.json
+++ b/packages/client/.release-it.json
@@ -9,5 +9,13 @@
     "commitMessage": "Release ${tagName}",
     "tagAnnotation": "Release ${tagName}",
     "commitArgs": "--all"
+  },
+  "plugins": {
+    "@release-it/bumper": {
+      "out": {
+        "file": "dist/package.json",
+        "path": "version"
+      }
+    }
   }
 }


### PR DESCRIPTION
Currently, the release process incorrectly leaves the dist/package.json's version to be the old version. This in turn makes the client setinfo lib-ver command to send wrong version to redis.
Fix: use the release-it/bumper package to update dist/package.json with the correct version upon release.

fixes: #3118

