### PR TITLE
Add mocha multi-reporters and junit reporter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 dump.rdb
 documentation/
 tsconfig.tsbuildinfo
+junit-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "@types/node": "^20.11.16",
         "gh-pages": "^6.1.1",
         "mocha": "^10.2.0",
+        "mocha-junit-reporter": "^2.2.1",
+        "mocha-multi-reporters": "^1.5.1",
         "nyc": "^15.1.0",
         "release-it": "^19.0.2",
         "ts-node": "^10.9.2",
@@ -2285,6 +2287,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/cheerio": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
@@ -2575,6 +2587,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/css-select": {
@@ -4062,6 +4084,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "license": "MIT",
@@ -4679,6 +4708,18 @@
         "node": ">= 12"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -4809,6 +4850,22 @@
         "node": "*"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mocha": {
       "version": "10.2.0",
       "dev": true,
@@ -4846,6 +4903,40 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha-junit-reporter": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.2.1.tgz",
+      "integrity": "sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "md5": "^2.3.0",
+        "mkdirp": "^3.0.0",
+        "strip-ansi": "^6.0.1",
+        "xml": "^1.0.1"
+      },
+      "peerDependencies": {
+        "mocha": ">=2.2.5"
+      }
+    },
+    "node_modules/mocha-multi-reporters": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.5.1.tgz",
+      "integrity": "sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "mocha": ">=3.1.2"
       }
     },
     "node_modules/mocha/node_modules/glob": {
@@ -7210,6 +7301,13 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "test-single": "TS_NODE_PROJECT='./packages/test-utils/tsconfig.json' mocha --require ts-node/register/transpile-only ",
-    "test": "npm run test -ws --if-present",
+    "cleanup": "rm -rf junit-results",
+    "test": "npm run cleanup && npm run test -ws --if-present",
     "build": "tsc --build",
     "documentation": "typedoc --out ./documentation",
     "gh-pages": "gh-pages -d ./documentation -e ./documentation -u 'documentation-bot <documentation@bot>'",
@@ -26,6 +27,8 @@
     "@types/node": "^20.11.16",
     "gh-pages": "^6.1.1",
     "mocha": "^10.2.0",
+    "mocha-junit-reporter": "^2.2.1",
+    "mocha-multi-reporters": "^1.5.1",
     "nyc": "^15.1.0",
     "release-it": "^19.0.2",
     "ts-node": "^10.9.2",

--- a/packages/bloom/mocha-multi-reporter-config.json
+++ b/packages/bloom/mocha-multi-reporter-config.json
@@ -1,0 +1,8 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "../../junit-results/bloom.xml",
+    "toConsole": false,
+    "testsuitesTitle": "@redis/bloom"
+  }
+}

--- a/packages/bloom/package.json
+++ b/packages/bloom/package.json
@@ -9,7 +9,7 @@
     "!dist/tsconfig.tsbuildinfo"
   ],
   "scripts": {
-    "test": "nyc -r text-summary -r lcov mocha -r tsx './lib/**/*.spec.ts'",
+    "test": "nyc -r text-summary -r lcov mocha -r tsx --reporter mocha-multi-reporters --reporter-options configFile=mocha-multi-reporter-config.json --exit  './lib/**/*.spec.ts'",
     "release": "release-it"
   },
   "peerDependencies": {

--- a/packages/client/mocha-multi-reporter-config.json
+++ b/packages/client/mocha-multi-reporter-config.json
@@ -1,0 +1,8 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "../../junit-results/client.xml",
+    "toConsole": false,
+    "testsuitesTitle": "@redis/client"
+  }
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,7 +9,7 @@
     "!dist/tsconfig.tsbuildinfo"
   ],
   "scripts": {
-    "test": "nyc -r text-summary -r lcov mocha -r tsx './lib/**/*.spec.ts'",
+    "test": "nyc -r text-summary -r lcov mocha -r tsx --reporter mocha-multi-reporters --reporter-options configFile=mocha-multi-reporter-config.json --exit './lib/**/*.spec.ts'",
     "release": "release-it"
   },
   "dependencies": {

--- a/packages/entraid/mocha-multi-reporter-config.json
+++ b/packages/entraid/mocha-multi-reporter-config.json
@@ -1,0 +1,8 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "../../junit-results/entraid.xml",
+    "toConsole": false,
+    "testsuitesTitle": "@redis/entraid"
+  }
+}

--- a/packages/entraid/package.json
+++ b/packages/entraid/package.json
@@ -14,7 +14,7 @@
     "start:auth-pkce": "tsx --tsconfig tsconfig.samples.json ./samples/auth-code-pkce/index.ts",
     "start:interactive-browser": "tsx --tsconfig tsconfig.samples.json ./samples/interactive-browser/index.ts",
     "test-integration": "mocha -r tsx --tsconfig tsconfig.integration-tests.json './integration-tests/**/*.spec.ts'",
-    "test": "nyc -r text-summary -r lcov mocha -r tsx './lib/**/*.spec.ts'",
+    "test": "nyc -r text-summary -r lcov mocha -r tsx --reporter mocha-multi-reporters --reporter-options configFile=mocha-multi-reporter-config.json --exit  './lib/**/*.spec.ts'",
     "release": "release-it"
   },
   "dependencies": {

--- a/packages/json/mocha-multi-reporter-config.json
+++ b/packages/json/mocha-multi-reporter-config.json
@@ -1,0 +1,8 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "../../junit-results/json.xml",
+    "toConsole": false,
+    "testsuitesTitle": "@redis/json"
+  }
+}

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -9,7 +9,7 @@
     "!dist/tsconfig.tsbuildinfo"
   ],
   "scripts": {
-    "test": "nyc -r text-summary -r lcov mocha -r tsx './lib/**/*.spec.ts'",
+    "test": "nyc -r text-summary -r lcov mocha -r tsx --reporter mocha-multi-reporters --reporter-options configFile=mocha-multi-reporter-config.json --exit  './lib/**/*.spec.ts'",
     "release": "release-it"
   },
   "peerDependencies": {

--- a/packages/redis/mocha-multi-reporter-config.json
+++ b/packages/redis/mocha-multi-reporter-config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "../../junit-results/redis.xml"
+  }
+}

--- a/packages/search/mocha-multi-reporter-config.json
+++ b/packages/search/mocha-multi-reporter-config.json
@@ -1,0 +1,8 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "../../junit-results/search.xml",
+    "toConsole": false,
+    "testsuitesTitle": "@redis/search"
+  }
+}

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -9,7 +9,7 @@
     "!dist/tsconfig.tsbuildinfo"
   ],
   "scripts": {
-    "test": "nyc -r text-summary -r lcov mocha -r tsx './lib/**/*.spec.ts'",
+    "test": "nyc -r text-summary -r lcov mocha -r tsx --reporter mocha-multi-reporters --reporter-options configFile=mocha-multi-reporter-config.json --exit  './lib/**/*.spec.ts'",
     "test-sourcemap": "mocha -r ts-node/register/transpile-only './lib/**/*.spec.ts'",
     "release": "release-it"
   },

--- a/packages/time-series/mocha-multi-reporter-config.json
+++ b/packages/time-series/mocha-multi-reporter-config.json
@@ -1,0 +1,8 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "../../junit-results/time-series.xml",
+    "toConsole": false,
+    "testsuitesTitle": "@redis/time-series"
+  }
+}

--- a/packages/time-series/package.json
+++ b/packages/time-series/package.json
@@ -9,7 +9,7 @@
     "!dist/tsconfig.tsbuildinfo"
   ],
   "scripts": {
-    "test": "nyc -r text-summary -r lcov mocha -r tsx './lib/**/*.spec.ts'",
+    "test": "nyc -r text-summary -r lcov mocha -r tsx --reporter mocha-multi-reporters --reporter-options configFile=mocha-multi-reporter-config.json --exit  './lib/**/*.spec.ts'",
     "release": "release-it"
   },
   "peerDependencies": {


### PR DESCRIPTION
Update test scripts to use mocha-multi-reporters with JUnit output. Add junit-results/ to .gitignore and cleanup script.
