### PR TITLE
Sentinel scan iterator

### DIFF
--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -160,3 +160,27 @@ try {
   clientLease.release();
 }
 ```
+
+## Scan Iterator
+
+The sentinel client supports `scanIterator` for iterating over keys on the master node:
+
+```javascript
+for await (const keys of sentinel.scanIterator()) {
+  // ...
+}
+```
+
+If a failover occurs during the scan, the iterator will automatically restart from the beginning on the new master to ensure all keys are covered. This may result in duplicate keys being yielded. If your application requires processing each key exactly once, you should implement a deduplication mechanism (like a `Set` or Bloom filter).
+
+```javascript
+const processed = new Set();
+for await (const keys of sentinel.scanIterator()) {
+  for (const key of keys) {
+    if (processed.has(key)) continue;
+    processed.add(key);
+
+    // process key
+  }
+}
+```

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -175,17 +175,21 @@ for await (const keys of sentinel.scanIterator()) {
 
 SCAN cursors are node-local — a cursor returned by one Redis instance is meaningless on any other instance. Because of this, the sentinel iterator cannot transparently survive a master failover: the in-flight cursor cannot be resumed on the promoted replica, and silently restarting from cursor `0` on the new master would hide both duplicate keys (already yielded from the old master) and data loss (writes that had not yet replicated before the failover).
 
-Instead, if the master changes while an iteration is in progress, the iterator throws `SentinelMasterChangeError`. The caller decides whether to retry the iteration from scratch, accept the partial result, or fail the surrounding operation.
+Instead, if the iterator observes a `MASTER_CHANGE` topology event while an iteration is in progress, it throws `ScanIteratorInterruptedError`. The caller decides whether to retry the iteration from scratch, accept the partial result, or fail the surrounding operation.
+
+Connection-level errors raised by the underlying client (e.g. `SocketClosedUnexpectedlyError`, `SocketTimeoutError`, `ReconnectStrategyError`) are **not** wrapped. A dropped socket is not by itself evidence of a failover — it may also be a transient network blip on the same master, in which case the cursor is still valid and a higher-level retry policy is appropriate. The original error is propagated as-is, and the caller can distinguish failover from a blip by checking for `ScanIteratorInterruptedError` versus other error types.
+
+In a real failover the dropped socket often precedes the Sentinel `MASTER_CHANGE` event (gated by `down-after-milliseconds`), so callers that want to treat both signals uniformly should catch both `ScanIteratorInterruptedError` **and** connection-class errors:
 
 ```javascript
-import { SentinelMasterChangeError } from '@redis/client';
+import { ScanIteratorInterruptedError } from '@redis/client';
 
 try {
   for await (const keys of sentinel.scanIterator()) {
     // ...
   }
 } catch (err) {
-  if (err instanceof SentinelMasterChangeError) {
+  if (err instanceof ScanIteratorInterruptedError) {
     // master failed over mid-iteration; restart from the beginning if desired
   } else {
     throw err;

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -171,7 +171,15 @@ for await (const keys of sentinel.scanIterator()) {
 }
 ```
 
-If a failover occurs during the scan, the iterator will automatically restart from the beginning on the new master to ensure all keys are covered. This may result in duplicate keys being yielded. If your application requires processing each key exactly once, you should implement a deduplication mechanism (like a `Set` or Bloom filter).
+### Semantics and differences from standalone `scanIterator`
+
+The standalone `RedisClient.scanIterator()` inherits SCAN's documented guarantees: a full iteration returns every key present from start to end, and may return a key multiple times. See the [SCAN guarantees](https://redis.io/docs/latest/commands/scan/#scan-guarantees) page.
+
+The sentinel iterator adds one extra source of duplicates: **master failover**. If the master changes mid-iteration (detected via the `topology-change` event with `type: "MASTER_CHANGE"`), the cursor is invalidated (SCAN cursors are node-local) and the iterator restarts from cursor `0` on the new master. Keys already yielded before the failover may be yielded again from the new master.
+
+Because Redis replication is asynchronous, the new master may also have a slightly different keyset than the old master at the moment of promotion — writes that had not yet replicated will be missing, and writes accepted on the new master after promotion will be present.
+
+If your processing must be exactly-once, deduplicate with a `Set`:
 
 ```javascript
 const processed = new Set();
@@ -184,3 +192,9 @@ for await (const keys of sentinel.scanIterator()) {
   }
 }
 ```
+
+For very large keyspaces a `Set` may be memory-prohibitive. A Bloom filter is a lower-memory alternative but is **not** suitable for strict exactly-once processing: its false positives will cause some real keys to be skipped. Use it only when occasional skips are acceptable.
+
+### Pool behaviour
+
+The iterator acquires a master client lease only for the duration of each `SCAN` call and releases it before yielding to the consumer. This means commands issued from inside the `for await` loop body (e.g. `sentinel.mGet(keys)`) will not deadlock against the iterator, even with the default `masterPoolSize` of `1`.

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -175,7 +175,9 @@ for await (const keys of sentinel.scanIterator()) {
 
 SCAN cursors are node-local — a cursor returned by one Redis instance is meaningless on any other instance. Because of this, the sentinel iterator cannot transparently survive a master failover: the in-flight cursor cannot be resumed on the promoted replica, and silently restarting from cursor `0` on the new master would hide both duplicate keys (already yielded from the old master) and data loss (writes that had not yet replicated before the failover).
 
-Instead, if the iterator observes a `MASTER_CHANGE` topology event while an iteration is in progress, it throws `ScanIteratorInterruptedError`. The caller decides whether to retry the iteration from scratch, accept the partial result, or fail the surrounding operation.
+If a `MASTER_CHANGE` topology event is observed while an iteration is in progress **and** the iterator still needs to issue another `SCAN` (i.e. the cursor has not yet returned to `0`), it throws `ScanIteratorInterruptedError` rather than send a stale, node-local cursor to a different master. The caller decides whether to retry the iteration from scratch, accept the partial result, or fail the surrounding operation.
+
+If the responding master returns `cursor=0` on the same call during which `MASTER_CHANGE` fires, no error is thrown — that node honored SCAN's contract ("every key present at iteration start was returned") and no further calls are needed. SCAN never claims to reflect "the current dataset" at the moment iteration ends, with or without a failover, so this case is not treated as an interruption.
 
 Connection-level errors raised by the underlying client (e.g. `SocketClosedUnexpectedlyError`, `SocketTimeoutError`, `ReconnectStrategyError`) are **not** wrapped. A dropped socket is not by itself evidence of a failover — it may also be a transient network blip on the same master, in which case the cursor is still valid and a higher-level retry policy is appropriate. The original error is propagated as-is, and the caller can distinguish failover from a blip by checking for `ScanIteratorInterruptedError` versus other error types.
 

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -171,31 +171,31 @@ for await (const keys of sentinel.scanIterator()) {
 }
 ```
 
-### Semantics and differences from standalone `scanIterator`
+### Behaviour on master failover
 
-The standalone `RedisClient.scanIterator()` inherits SCAN's documented guarantees: a full iteration returns every key present from start to end, and may return a key multiple times. See the [SCAN guarantees](https://redis.io/docs/latest/commands/scan/#scan-guarantees) page.
+SCAN cursors are node-local — a cursor returned by one Redis instance is meaningless on any other instance. Because of this, the sentinel iterator cannot transparently survive a master failover: the in-flight cursor cannot be resumed on the promoted replica, and silently restarting from cursor `0` on the new master would hide both duplicate keys (already yielded from the old master) and data loss (writes that had not yet replicated before the failover).
 
-The sentinel iterator adds one extra source of duplicates: **master failover**. If the master changes mid-iteration (detected via the `topology-change` event with `type: "MASTER_CHANGE"`), the cursor is invalidated (SCAN cursors are node-local) and the iterator restarts from cursor `0` on the new master. Keys already yielded before the failover may be yielded again from the new master.
-
-A user-supplied `cursor` option (e.g. `sentinel.scanIterator({ cursor: '1234' })`) is honored on the first SCAN call only. If a failover then resets the iterator, it restarts from cursor `0` (not the user-supplied value), because the original cursor was bound to the old master and would be meaningless on the new one.
-
-Because Redis replication is asynchronous, the new master may also have a slightly different keyset than the old master at the moment of promotion — writes that had not yet replicated will be missing, and writes accepted on the new master after promotion will be present.
-
-If your processing must be exactly-once, deduplicate with a `Set`:
+Instead, if the master changes while an iteration is in progress, the iterator throws `SentinelMasterChangeError`. The caller decides whether to retry the iteration from scratch, accept the partial result, or fail the surrounding operation.
 
 ```javascript
-const processed = new Set();
-for await (const keys of sentinel.scanIterator()) {
-  for (const key of keys) {
-    if (processed.has(key)) continue;
-    processed.add(key);
+import { SentinelMasterChangeError } from '@redis/client';
 
-    // process key
+try {
+  for await (const keys of sentinel.scanIterator()) {
+    // ...
+  }
+} catch (err) {
+  if (err instanceof SentinelMasterChangeError) {
+    // master failed over mid-iteration; restart from the beginning if desired
+  } else {
+    throw err;
   }
 }
 ```
 
-For very large keyspaces a `Set` may be memory-prohibitive. A Bloom filter is a lower-memory alternative but is **not** suitable for strict exactly-once processing: its false positives will cause some real keys to be skipped. Use it only when occasional skips are acceptable.
+The iterator listens for the `topology-change` event with `type: "MASTER_CHANGE"`. The listener is attached when the generator body first runs (on the first `.next()` call) and is detached in a `finally` block, so an early `break` out of the `for await` loop will not leak listeners.
+
+The standalone `RedisClient.scanIterator()` still inherits SCAN's documented guarantees, including the possibility of returning the same key multiple times within a single iteration; see the [SCAN guarantees](https://redis.io/docs/latest/commands/scan/#scan-guarantees) page.
 
 ### Pool behaviour
 

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -177,6 +177,8 @@ The standalone `RedisClient.scanIterator()` inherits SCAN's documented guarantee
 
 The sentinel iterator adds one extra source of duplicates: **master failover**. If the master changes mid-iteration (detected via the `topology-change` event with `type: "MASTER_CHANGE"`), the cursor is invalidated (SCAN cursors are node-local) and the iterator restarts from cursor `0` on the new master. Keys already yielded before the failover may be yielded again from the new master.
 
+A user-supplied `cursor` option (e.g. `sentinel.scanIterator({ cursor: '1234' })`) is honored on the first SCAN call only. If a failover then resets the iterator, it restarts from cursor `0` (not the user-supplied value), because the original cursor was bound to the old master and would be meaningless on the new one.
+
 Because Redis replication is asynchronous, the new master may also have a slightly different keyset than the old master at the moment of promotion — writes that had not yet replicated will be missing, and writes accepted on the new master after promotion will be present.
 
 If your processing must be exactly-once, deduplicate with a `Set`:

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -274,7 +274,7 @@ type ProxyClient = RedisClient<RedisModules, RedisFunctions, RedisScripts, RespV
 
 type NamespaceProxyClient = { _self: ProxyClient };
 
-interface ScanIteratorOptions {
+export interface ScanIteratorOptions {
   cursor?: RedisArgument;
 }
 

--- a/packages/client/lib/errors.ts
+++ b/packages/client/lib/errors.ts
@@ -52,6 +52,12 @@ export class RootNodesUnavailableError extends Error {
   }
 }
 
+export class SentinelMasterChangeError extends Error {
+  constructor(cause?: unknown) {
+    super('Sentinel master changed during operation', cause === undefined ? undefined : { cause });
+  }
+}
+
 export class ReconnectStrategyError extends Error {
   originalError: Error;
   socketError: unknown;

--- a/packages/client/lib/errors.ts
+++ b/packages/client/lib/errors.ts
@@ -52,9 +52,9 @@ export class RootNodesUnavailableError extends Error {
   }
 }
 
-export class SentinelMasterChangeError extends Error {
+export class ScanIteratorInterruptedError extends Error {
   constructor(cause?: unknown) {
-    super('Sentinel master changed during operation', cause === undefined ? undefined : { cause });
+    super('Scan iteration was interrupted by a Sentinel master change', cause === undefined ? undefined : { cause });
   }
 }
 

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -1427,6 +1427,26 @@ describe('legacy tests', () => {
       const expectedKeys = new Set(['match:1', 'match:2']);
       assert.deepEqual(foundKeys, expectedKeys);
     }, GLOBAL.SENTINEL.OPEN);
+
+    testUtils.testWithClientSentinel('should not deadlock when consumer runs commands inside the loop with masterPoolSize 1', async sentinel => {
+      const entries: Array<string> = [];
+      for (let i = 0; i < 20; i++) {
+        entries.push(`deadlock:${i}`, `value${i}`);
+      }
+      await sentinel.mSet(entries);
+
+      const collected = new Map<string, string | null>();
+      for await (const keyBatch of sentinel.scanIterator({ MATCH: 'deadlock:*', COUNT: 5 })) {
+        if (keyBatch.length === 0) continue;
+        const values = await sentinel.mGet(keyBatch);
+        keyBatch.forEach((key, i) => collected.set(key, values[i]));
+      }
+
+      assert.equal(collected.size, 20);
+      for (let i = 0; i < 20; i++) {
+        assert.equal(collected.get(`deadlock:${i}`), `value${i}`);
+      }
+    }, GLOBAL.SENTINEL.OPEN);
   });
 
   describe('scanIterator with master failover', () => {

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -1435,21 +1435,19 @@ describe('legacy tests', () => {
     let sentinel: RedisSentinelType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping> | undefined;
     const tracer: Array<string> = [];
 
-    before(async function () {
+    beforeEach(async function () {
       this.timeout(60000);
       await frame.spawnRedisSentinel();
+      await frame.getAllRunning();
       await steadyState(frame);
     });
 
     afterEach(async function () {
+      this.timeout(60000);
       if (sentinel !== undefined) {
         sentinel.destroy();
         sentinel = undefined;
       }
-    });
-
-    after(async function () {
-      this.timeout(60000);
       await frame.cleanup();
     });
 

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
 import testUtils, { GLOBAL, MATH_FUNCTION } from '../test-utils';
 import { RESP_TYPES } from '../RESP/decoder';
-import { SentinelMasterChangeError, WatchError } from "../errors";
+import { ScanIteratorInterruptedError, WatchError } from "../errors";
 import { RedisSentinelConfig, SentinelFramework } from "./test-util";
 import { RedisSentinelEvent, RedisSentinelType, RedisSentinelClientType, RedisNode } from "./types";
 import RedisSentinel from "./index";
@@ -1448,7 +1448,7 @@ describe('legacy tests', () => {
       }
     }, GLOBAL.SENTINEL.OPEN);
 
-    testUtils.testWithClientSentinel('should throw SentinelMasterChangeError when MASTER_CHANGE fires while cursor is "0"', async sentinel => {
+    testUtils.testWithClientSentinel('should throw ScanIteratorInterruptedError when MASTER_CHANGE fires while cursor is "0"', async sentinel => {
       await sentinel.mSet([
         'master-change-on-zero:1', '1',
         'master-change-on-zero:2', '2'
@@ -1463,7 +1463,7 @@ describe('legacy tests', () => {
         node: { host: 'synthetic', port: 0 }
       });
 
-      await assert.rejects(firstPagePromise, SentinelMasterChangeError);
+      await assert.rejects(firstPagePromise, ScanIteratorInterruptedError);
     }, GLOBAL.SENTINEL.OPEN);
 
     testUtils.testWithClientSentinel(
@@ -1603,7 +1603,7 @@ describe('legacy tests', () => {
       await frame.cleanup();
     });
 
-    it('should throw SentinelMasterChangeError when master changes during iteration', async function () {
+    it('should throw when master changes during iteration', async function () {
       this.timeout(60000);
 
       sentinel = frame.getSentinelClient({ scanInterval: 1000 });
@@ -1663,9 +1663,15 @@ describe('legacy tests', () => {
         tracer.push(`Error during scan: ${error}`);
       }
 
+      // The error may be either ScanIteratorInterruptedError (if the
+      // topology-change event was observed before the next scan call) or a
+      // raw connection-class error (if the dropped socket raced ahead of the
+      // Sentinel down detection — usually gated by down-after-milliseconds).
+      // Both outcomes are valid; what matters is that the iteration does not
+      // silently continue across the failover.
       assert.ok(
-        caught instanceof SentinelMasterChangeError,
-        `expected SentinelMasterChangeError, got ${caught}`
+        caught instanceof Error,
+        `iteration must throw on master failover, got ${caught}`
       );
       assert.equal(
         masterChangeDetected,

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -6,7 +6,7 @@ import { WatchError } from "../errors";
 import { RedisSentinelConfig, SentinelFramework } from "./test-util";
 import { RedisSentinelEvent, RedisSentinelType, RedisSentinelClientType, RedisNode } from "./types";
 import RedisSentinel from "./index";
-import { RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping } from '../RESP/types';
+import { RedisArgument, RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping } from '../RESP/types';
 import { promisify } from 'node:util';
 import { exec } from 'node:child_process';
 import { BasicPooledClientSideCache } from '../client/cache'
@@ -1468,12 +1468,127 @@ describe('legacy tests', () => {
       const firstPage = await firstPagePromise;
 
       assert.equal(firstPage.done, false, 'iterator must not terminate from a MASTER_CHANGE at cursor "0"');
+      assert.ok(Array.isArray(firstPage.value), 'iterator must yield the real scan reply, not the synthetic event payload');
       const collected = new Set<string>(firstPage.value as Array<string>);
       for await (const keys of iter) {
         for (const key of keys) collected.add(key);
       }
       assert.deepEqual(collected, new Set(['restart-on-zero:1', 'restart-on-zero:2']));
     }, GLOBAL.SENTINEL.OPEN);
+
+    testUtils.testWithClientSentinel(
+      'should terminate when Blob String type mapping returns the cursor as a Buffer',
+      async sentinel => {
+        // Regression: comparing the (Buffer) cursor to the literal string '0'
+        // with !== never becomes false, so the iterator looped forever.
+        await sentinel.mSet([
+          'buffer-cursor:1', '1',
+          'buffer-cursor:2', '2'
+        ]);
+
+        const found = new Set<string>();
+        for await (const keyBatch of sentinel.scanIterator({ MATCH: 'buffer-cursor:*' })) {
+          for (const key of keyBatch) {
+            found.add(key.toString());
+          }
+        }
+
+        assert.deepEqual(found, new Set(['buffer-cursor:1', 'buffer-cursor:2']));
+      },
+      {
+        ...GLOBAL.SENTINEL.OPEN,
+        clientOptions: {
+          commandOptions: {
+            typeMapping: { [RESP_TYPES.BLOB_STRING]: Buffer }
+          }
+        }
+      }
+    );
+
+    testUtils.testWithClientSentinel('should forward a user-supplied cursor to SCAN on the first call', async sentinel => {
+      await sentinel.mSet([
+        'cursor-opt:1', '1',
+        'cursor-opt:2', '2'
+      ]);
+
+      const seenCursors: Array<string> = [];
+      const sentinelAny = sentinel as unknown as {
+        _execute: (
+          isReadonly: boolean | undefined,
+          fn: (client: unknown) => Promise<unknown>
+        ) => Promise<unknown>;
+      };
+      const realExecute = sentinelAny._execute.bind(sentinel);
+      sentinelAny._execute = function (isReadonly, fn) {
+        return realExecute(isReadonly, (client: unknown) => {
+          const wrapped = new Proxy(client as object, {
+            get(target, prop, receiver) {
+              if (prop === 'scan') {
+                return (cursor: RedisArgument, opts: unknown) => {
+                  seenCursors.push(cursor.toString());
+                  return (target as { scan: (c: RedisArgument, o: unknown) => unknown }).scan(cursor, opts);
+                };
+              }
+              return Reflect.get(target, prop, receiver);
+            }
+          });
+          return fn(wrapped);
+        });
+      };
+
+      try {
+        const iter = sentinel.scanIterator({ MATCH: 'cursor-opt:*', cursor: '7' });
+        await iter.next();
+        await iter.return?.(undefined);
+      } finally {
+        sentinelAny._execute = realExecute;
+      }
+
+      assert.equal(seenCursors[0], '7', 'first SCAN call must use the user-supplied cursor');
+    }, GLOBAL.SENTINEL.OPEN);
+
+    testUtils.testWithClientSentinel('should remove the topology-change listener when the consumer breaks early', async sentinel => {
+      await sentinel.mSet([
+        'cleanup:1', '1',
+        'cleanup:2', '2'
+      ]);
+
+      const before = sentinel.listenerCount('topology-change');
+      for await (const _ of sentinel.scanIterator({ MATCH: 'cleanup:*' })) {
+        break;
+      }
+      assert.equal(
+        sentinel.listenerCount('topology-change'),
+        before,
+        'scanIterator must detach its topology-change listener on early break'
+      );
+    }, GLOBAL.SENTINEL.OPEN);
+
+    testUtils.testWithClientSentinel(
+      'should iterate without hanging when reserveClient:true and masterPoolSize:1',
+      async sentinel => {
+        // Regression: connect() consumes the only master lease into the
+        // reserved client, so an acquire() inside scanIterator would block
+        // forever on an empty pool. Routing through _execute reuses the
+        // reserved lease instead.
+        await sentinel.mSet([
+          'reserve-scan:1', '1',
+          'reserve-scan:2', '2'
+        ]);
+
+        const found = new Set<string>();
+        for await (const keyBatch of sentinel.scanIterator({ MATCH: 'reserve-scan:*' })) {
+          for (const key of keyBatch) found.add(key);
+        }
+
+        assert.deepEqual(found, new Set(['reserve-scan:1', 'reserve-scan:2']));
+      },
+      {
+        ...GLOBAL.SENTINEL.OPEN,
+        reserveClient: true,
+        masterPoolSize: 1
+      }
+    );
   });
 
   describe('scanIterator with master failover', () => {
@@ -1599,7 +1714,11 @@ describe('legacy tests', () => {
       );
     });
 
-    it('should handle master change at scan start', async function () {
+    // This test waits for MASTER_CHANGE to fire before constructing the
+    // iterator, so the iterator never sees a failover in flight — it only
+    // verifies that a scan started after a completed failover talks to the
+    // new master. The in-flight-failover case is covered by the test above.
+    it('should iterate against the new master when failover completes before scan starts', async function () {
       this.timeout(60000);
 
       sentinel = frame.getSentinelClient({ scanInterval: 1000 });

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -1379,4 +1379,237 @@ describe('legacy tests', () => {
       assert.equal(csc.stats().hitCount, 6);
     })
   });
+
+  describe('scanIterator tests', () => {
+    testUtils.testWithClientSentinel('should iterate through all keys in normal operation', async sentinel => {
+      // Set up test data
+      const testKeys = new Set<string>();
+      const entries: Array<string> = [];
+      
+      // Create 50 test keys to ensure we get multiple scan iterations
+      for (let i = 0; i < 50; i++) {
+        const key = `scantest:${i}`;
+        testKeys.add(key);
+        entries.push(key, `value${i}`);
+      }
+
+      // Insert all test data
+      await sentinel.mSet(entries);
+
+      // Collect all keys using scanIterator
+      const foundKeys = new Set<string>();
+      for await (const keyBatch of sentinel.scanIterator({ MATCH: 'scantest:*' })) {
+        for (const key of keyBatch) {
+          foundKeys.add(key);
+        }
+      }
+
+      // Verify all keys were found
+      assert.deepEqual(testKeys, foundKeys);
+    }, GLOBAL.SENTINEL.OPEN);
+
+    testUtils.testWithClientSentinel('should respect MATCH pattern', async sentinel => {
+      // Set up test data with different patterns
+      await sentinel.mSet([
+        'match:1', 'value1',
+        'match:2', 'value2', 
+        'nomatch:1', 'value3',
+        'nomatch:2', 'value4'
+      ]);
+
+      const foundKeys = new Set<string>();
+      for await (const keyBatch of sentinel.scanIterator({ MATCH: 'match:*' })) {
+        for (const key of keyBatch) {
+          foundKeys.add(key);
+        }
+      }
+
+      const expectedKeys = new Set(['match:1', 'match:2']);
+      assert.deepEqual(foundKeys, expectedKeys);
+    }, GLOBAL.SENTINEL.OPEN);
+  });
+
+  describe('scanIterator with master failover', () => {
+    const config: RedisSentinelConfig = { sentinelName: "test", numberOfNodes: 3, password: undefined };
+    const frame = new SentinelFramework(config);
+    let sentinel: RedisSentinelType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping> | undefined;
+    const tracer: Array<string> = [];
+
+    before(async function () {
+      this.timeout(60000);
+      await frame.spawnRedisSentinel();
+      await steadyState(frame);
+    });
+
+    afterEach(async function () {
+      if (sentinel !== undefined) {
+        sentinel.destroy();
+        sentinel = undefined;
+      }
+    });
+
+    after(async function () {
+      this.timeout(60000);
+      await frame.cleanup();
+    });
+
+    it('should restart scan from beginning when master changes during iteration', async function () {
+      this.timeout(60000);
+
+      sentinel = frame.getSentinelClient({ scanInterval: 1000 });
+      sentinel.setTracer(tracer);
+      sentinel.on("error", () => {});
+      await sentinel.connect();
+
+      // Set up test data
+      const testKeys = new Set<string>();
+      const entries: Array<string> = [];
+
+      for (let i = 0; i < 100; i++) {
+        const key = `failovertest:${i}`;
+        testKeys.add(key);
+        entries.push(key, `value${i}`);
+      }
+
+      await sentinel.mSet(entries);
+      // Wait for addded keys to be replicated
+      await setTimeout(2000);
+
+      let masterChangeDetected = false;
+      let iterationCount = 0;
+      const foundKeys = new Set<string>();
+
+      // Listen for manifest change events
+      sentinel.on("topology-change", (event: RedisSentinelEvent) => {
+        if (event.type === "MASTER_CHANGE") {
+          masterChangeDetected = true;
+          tracer.push(`Master change detected during scan: ${event.node.port}`);
+        }
+      });
+
+      // Get the current master node before starting scan
+      const originalMaster = sentinel.getMasterNode();
+      tracer.push(`Original master port: ${originalMaster?.port}`);
+
+      // Start scanning with a small COUNT to ensure multiple iterations
+      const scanIterator = sentinel.scanIterator({
+        MATCH: "failovertest:*",
+        COUNT: 10,
+      });
+
+      // Consume the scan iterator
+      try {
+        for await (const keyBatch of scanIterator) {
+          iterationCount++;
+          if (iterationCount === 1) {
+            tracer.push(
+              `Triggering master failover by stopping node ${originalMaster?.port}`
+            );
+            await frame.stopNode(originalMaster!.port.toString());
+            tracer.push(`Master node stopped`);
+          }
+          tracer.push(
+            `Scan iteration ${iterationCount}, got ${keyBatch.length} keys`
+          );
+
+          for (const key of keyBatch) {
+            foundKeys.add(key);
+          }
+        }
+      } catch (error) {
+        tracer.push(`Error during scan: ${error}`);
+        throw error;
+      }
+
+      // Verify that master change was detected
+      assert.equal(
+        masterChangeDetected,
+        true,
+        "Master change should have been detected"
+      );
+
+      // Verify that we eventually got all keys despite the master change
+      assert.equal(
+        foundKeys.size,
+        testKeys.size,
+        "Should find all keys despite master failover"
+      );
+      assert.deepEqual(
+        foundKeys,
+        testKeys,
+        "Found keys should match test keys"
+      );
+
+      // Verify that the master actually changed
+      const newMaster = sentinel.getMasterNode();
+      tracer.push(`New master port: ${newMaster?.port}`);
+      assert.notEqual(
+        originalMaster?.port,
+        newMaster?.port,
+        "Master should have changed"
+      );
+
+      tracer.push(
+        `Test completed successfully with ${iterationCount} scan iterations`
+      );
+    });
+
+    it('should handle master change at scan start', async function () {
+      this.timeout(60000);
+
+      sentinel = frame.getSentinelClient({ scanInterval: 1000 });
+      sentinel.setTracer(tracer);
+      sentinel.on("error", () => { });
+      await sentinel.connect();
+
+      // Set up test data
+      const entries: Array<string> = [];
+      for (let i = 0; i < 30; i++) {
+        entries.push(`startfailover:${i}`, `value${i}`);
+      }
+      await sentinel.mSet(entries);
+
+      // Wait for addded keys to be replicated
+      await setTimeout(2000);
+
+      // Get original master and trigger immediate failover
+      const originalMaster = sentinel.getMasterNode();
+      
+      // Stop master immediately before starting scan
+      await frame.stopNode(originalMaster!.port.toString());
+      
+      let masterChangeDetected = false;
+      let masterChangeResolve: () => void;
+      const masterChangePromise = new Promise<void>((resolve) => {
+        masterChangeResolve = resolve;
+      });
+
+      // Listen for manifest change events
+      sentinel.on('topology-change', (event: RedisSentinelEvent) => {
+        if (event.type === "MASTER_CHANGE") {
+          masterChangeDetected = true;
+          tracer.push(`Master change detected during scan: ${event.node.port}`);
+          if (masterChangeResolve) masterChangeResolve();
+        }
+      });
+
+      await masterChangePromise;
+
+      // Now start scan - should work with new master
+      const foundKeys = new Set<string>();
+      for await (const keyBatch of sentinel.scanIterator({ MATCH: 'startfailover:*' })) {
+        for (const key of keyBatch) {
+          foundKeys.add(key);
+        }
+      }
+
+      assert.equal(masterChangeDetected, true, 'Master change should have been detected');
+      // Should find all keys even though master changed before scan started
+      assert.equal(foundKeys.size, 30);
+      
+      // Verify master actually changed
+      const newMaster = sentinel.getMasterNode();
+      assert.notEqual(originalMaster?.port, newMaster?.port);
+    });
+  });
 });

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -1448,22 +1448,25 @@ describe('legacy tests', () => {
       }
     }, GLOBAL.SENTINEL.OPEN);
 
-    testUtils.testWithClientSentinel('should throw ScanIteratorInterruptedError when MASTER_CHANGE fires while cursor is "0"', async sentinel => {
-      await sentinel.mSet([
-        'master-change-on-zero:1', '1',
-        'master-change-on-zero:2', '2'
-      ]);
+    testUtils.testWithClientSentinel('should throw ScanIteratorInterruptedError on the next page after MASTER_CHANGE is observed', async sentinel => {
+      const entries: Array<string> = [];
+      for (let i = 0; i < 200; i++) {
+        entries.push(`master-change-mid:${i}`, String(i));
+      }
+      await sentinel.mSet(entries);
 
-      const iter = sentinel.scanIterator({ MATCH: 'master-change-on-zero:*' });
-      // Calling .next() runs the generator body up to the first `await`, which
-      // means the `topology-change` listener is attached before this point.
-      const firstPagePromise = iter.next();
+      const iter = sentinel.scanIterator({ MATCH: 'master-change-mid:*', COUNT: 10 });
+      // First page: cursor must come back non-zero so the iterator still has
+      // work to do after the synthetic event fires.
+      const firstPage = await iter.next();
+      assert.equal(firstPage.done, false, 'first page must not terminate iteration');
+
       sentinel.emit('topology-change', {
         type: 'MASTER_CHANGE',
         node: { host: 'synthetic', port: 0 }
       });
 
-      await assert.rejects(firstPagePromise, ScanIteratorInterruptedError);
+      await assert.rejects(iter.next(), ScanIteratorInterruptedError);
     }, GLOBAL.SENTINEL.OPEN);
 
     testUtils.testWithClientSentinel(

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -1469,6 +1469,49 @@ describe('legacy tests', () => {
       await assert.rejects(iter.next(), ScanIteratorInterruptedError);
     }, GLOBAL.SENTINEL.OPEN);
 
+    testUtils.testWithClientSentinel('should throw ScanIteratorInterruptedError when MASTER_CHANGE fires during _execute (after pre-check, before scan)', async sentinel => {
+      const entries: Array<string> = [];
+      for (let i = 0; i < 200; i++) {
+        entries.push(`master-change-race:${i}`, String(i));
+      }
+      await sentinel.mSet(entries);
+
+      let executeCalls = 0;
+      const sentinelAny = sentinel as unknown as {
+        _execute: (
+          isReadonly: boolean | undefined,
+          fn: (client: unknown) => Promise<unknown>
+        ) => Promise<unknown>;
+      };
+      const realExecute = sentinelAny._execute.bind(sentinel);
+      sentinelAny._execute = function (isReadonly, fn) {
+        executeCalls++;
+        // On the second SCAN call the iterator already ran its pre-check at the
+        // top of the loop (masterChanged was still false). Fire MASTER_CHANGE
+        // synchronously inside _execute so the listener flips masterChanged
+        // before the lambda passed to _execute is invoked. Without the
+        // in-lambda re-check, scan would proceed against the (now potentially
+        // stale) lease and the failure would be silent.
+        if (executeCalls === 2) {
+          sentinel.emit('topology-change', {
+            type: 'MASTER_CHANGE',
+            node: { host: 'synthetic', port: 0 }
+          });
+        }
+        return realExecute(isReadonly, fn);
+      };
+
+      try {
+        const iter = sentinel.scanIterator({ MATCH: 'master-change-race:*', COUNT: 10 });
+        const firstPage = await iter.next();
+        assert.equal(firstPage.done, false, 'first page must not terminate iteration');
+
+        await assert.rejects(iter.next(), ScanIteratorInterruptedError);
+      } finally {
+        sentinelAny._execute = realExecute;
+      }
+    }, GLOBAL.SENTINEL.OPEN);
+
     testUtils.testWithClientSentinel(
       'should terminate when Blob String type mapping returns the cursor as a Buffer',
       async sentinel => {

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
 import testUtils, { GLOBAL, MATH_FUNCTION } from '../test-utils';
 import { RESP_TYPES } from '../RESP/decoder';
-import { WatchError } from "../errors";
+import { SentinelMasterChangeError, WatchError } from "../errors";
 import { RedisSentinelConfig, SentinelFramework } from "./test-util";
 import { RedisSentinelEvent, RedisSentinelType, RedisSentinelClientType, RedisNode } from "./types";
 import RedisSentinel from "./index";
@@ -1448,16 +1448,13 @@ describe('legacy tests', () => {
       }
     }, GLOBAL.SENTINEL.OPEN);
 
-    testUtils.testWithClientSentinel('should restart and not silently terminate when MASTER_CHANGE fires while cursor is "0"', async sentinel => {
-      // Regression: a topology change during the first scan (cursor "0") used
-      // to `continue` past the cursor assignment, then the do/while condition
-      // saw the still-"0" cursor and exited, yielding nothing.
+    testUtils.testWithClientSentinel('should throw SentinelMasterChangeError when MASTER_CHANGE fires while cursor is "0"', async sentinel => {
       await sentinel.mSet([
-        'restart-on-zero:1', '1',
-        'restart-on-zero:2', '2'
+        'master-change-on-zero:1', '1',
+        'master-change-on-zero:2', '2'
       ]);
 
-      const iter = sentinel.scanIterator({ MATCH: 'restart-on-zero:*' });
+      const iter = sentinel.scanIterator({ MATCH: 'master-change-on-zero:*' });
       // Calling .next() runs the generator body up to the first `await`, which
       // means the `topology-change` listener is attached before this point.
       const firstPagePromise = iter.next();
@@ -1465,15 +1462,8 @@ describe('legacy tests', () => {
         type: 'MASTER_CHANGE',
         node: { host: 'synthetic', port: 0 }
       });
-      const firstPage = await firstPagePromise;
 
-      assert.equal(firstPage.done, false, 'iterator must not terminate from a MASTER_CHANGE at cursor "0"');
-      assert.ok(Array.isArray(firstPage.value), 'iterator must yield the real scan reply, not the synthetic event payload');
-      const collected = new Set<string>(firstPage.value as Array<string>);
-      for await (const keys of iter) {
-        for (const key of keys) collected.add(key);
-      }
-      assert.deepEqual(collected, new Set(['restart-on-zero:1', 'restart-on-zero:2']));
+      await assert.rejects(firstPagePromise, SentinelMasterChangeError);
     }, GLOBAL.SENTINEL.OPEN);
 
     testUtils.testWithClientSentinel(
@@ -1613,7 +1603,7 @@ describe('legacy tests', () => {
       await frame.cleanup();
     });
 
-    it('should restart scan from beginning when master changes during iteration', async function () {
+    it('should throw SentinelMasterChangeError when master changes during iteration', async function () {
       this.timeout(60000);
 
       sentinel = frame.getSentinelClient({ scanInterval: 1000 });
@@ -1621,25 +1611,19 @@ describe('legacy tests', () => {
       sentinel.on("error", () => {});
       await sentinel.connect();
 
-      // Set up test data
-      const testKeys = new Set<string>();
       const entries: Array<string> = [];
-
       for (let i = 0; i < 100; i++) {
-        const key = `failovertest:${i}`;
-        testKeys.add(key);
-        entries.push(key, `value${i}`);
+        entries.push(`failovertest:${i}`, `value${i}`);
       }
 
       await sentinel.mSet(entries);
-      // Wait for addded keys to be replicated
+      // Wait for added keys to be replicated
       await setTimeout(2000);
 
       let masterChangeDetected = false;
       let iterationCount = 0;
       const foundKeys = new Set<string>();
 
-      // Listen for manifest change events
       sentinel.on("topology-change", (event: RedisSentinelEvent) => {
         if (event.type === "MASTER_CHANGE") {
           masterChangeDetected = true;
@@ -1647,17 +1631,15 @@ describe('legacy tests', () => {
         }
       });
 
-      // Get the current master node before starting scan
       const originalMaster = sentinel.getMasterNode();
       tracer.push(`Original master port: ${originalMaster?.port}`);
 
-      // Start scanning with a small COUNT to ensure multiple iterations
       const scanIterator = sentinel.scanIterator({
         MATCH: "failovertest:*",
         COUNT: 10,
       });
 
-      // Consume the scan iterator
+      let caught: unknown;
       try {
         for await (const keyBatch of scanIterator) {
           iterationCount++;
@@ -1677,40 +1659,26 @@ describe('legacy tests', () => {
           }
         }
       } catch (error) {
+        caught = error;
         tracer.push(`Error during scan: ${error}`);
-        throw error;
       }
 
-      // Verify that master change was detected
+      assert.ok(
+        caught instanceof SentinelMasterChangeError,
+        `expected SentinelMasterChangeError, got ${caught}`
+      );
       assert.equal(
         masterChangeDetected,
         true,
         "Master change should have been detected"
       );
 
-      // Verify that we eventually got all keys despite the master change
-      assert.equal(
-        foundKeys.size,
-        testKeys.size,
-        "Should find all keys despite master failover"
-      );
-      assert.deepEqual(
-        foundKeys,
-        testKeys,
-        "Found keys should match test keys"
-      );
-
-      // Verify that the master actually changed
       const newMaster = sentinel.getMasterNode();
       tracer.push(`New master port: ${newMaster?.port}`);
       assert.notEqual(
         originalMaster?.port,
         newMaster?.port,
         "Master should have changed"
-      );
-
-      tracer.push(
-        `Test completed successfully with ${iterationCount} scan iterations`
       );
     });
 

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -1447,6 +1447,33 @@ describe('legacy tests', () => {
         assert.equal(collected.get(`deadlock:${i}`), `value${i}`);
       }
     }, GLOBAL.SENTINEL.OPEN);
+
+    testUtils.testWithClientSentinel('should restart and not silently terminate when MASTER_CHANGE fires while cursor is "0"', async sentinel => {
+      // Regression: a topology change during the first scan (cursor "0") used
+      // to `continue` past the cursor assignment, then the do/while condition
+      // saw the still-"0" cursor and exited, yielding nothing.
+      await sentinel.mSet([
+        'restart-on-zero:1', '1',
+        'restart-on-zero:2', '2'
+      ]);
+
+      const iter = sentinel.scanIterator({ MATCH: 'restart-on-zero:*' });
+      // Calling .next() runs the generator body up to the first `await`, which
+      // means the `topology-change` listener is attached before this point.
+      const firstPagePromise = iter.next();
+      sentinel.emit('topology-change', {
+        type: 'MASTER_CHANGE',
+        node: { host: 'synthetic', port: 0 }
+      });
+      const firstPage = await firstPagePromise;
+
+      assert.equal(firstPage.done, false, 'iterator must not terminate from a MASTER_CHANGE at cursor "0"');
+      const collected = new Set<string>(firstPage.value as Array<string>);
+      for await (const keys of iter) {
+        for (const key of keys) collected.add(key);
+      }
+      assert.deepEqual(collected, new Set(['restart-on-zero:1', 'restart-on-zero:2']));
+    }, GLOBAL.SENTINEL.OPEN);
   });
 
   describe('scanIterator with master failover', () => {

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { CommandArguments, RedisArgument, RedisFunctions, RedisModules, RedisScripts, ReplyUnion, RespVersions, TypeMapping, DEFAULT_RESP } from '../RESP/types';
-import { SentinelMasterChangeError } from '../errors';
+import { ScanIteratorInterruptedError } from '../errors';
 import RedisClient, { AnyRedisClientOptions, RedisClientOptions, RedisClientType, ScanIteratorOptions } from '../client';
 import { CommandOptions } from '../client/commands-queue';
 import { attachConfig } from '../commander';
@@ -673,7 +673,7 @@ export default class RedisSentinel<
 
     try {
       do {
-        if (masterChanged) throw new SentinelMasterChangeError();
+        if (masterChanged) throw new ScanIteratorInterruptedError();
 
         // Route through _execute so reserveClient:true reuses the reserved
         // lease (instead of waiting forever on an empty master pool), and the
@@ -686,11 +686,11 @@ export default class RedisSentinel<
             client => (client as RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>).scan(cursor, options)
           );
         } catch (err) {
-          // A master failover mid-SCAN can surface as a connection error
-          // before the topology-change event is processed. Surface it as a
-          // SentinelMasterChangeError so callers can distinguish failover
-          // from other transient failures.
-          if (masterChanged) throw new SentinelMasterChangeError(err);
+          // Only wrap when MASTER_CHANGE has been observed; otherwise let the
+          // underlying error propagate. A bare socket disconnect alone is not
+          // sufficient evidence of a failover (could be a transient network
+          // blip on the same master, in which case the cursor is still valid).
+          if (masterChanged) throw new ScanIteratorInterruptedError(err);
           throw err;
         }
 

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -701,9 +701,18 @@ export default class RedisSentinel<
         try {
           reply = await this._execute(
             false,
-            client => (client as RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>).scan(cursor, options)
+            client => {
+              // Re-check after the lease resolves: a failover may have landed
+              // while waiting on an empty master pool, in which case the lease
+              // now points to a fresh client on the new master and SCAN would
+              // resume with a cursor from the old master.
+              if (masterChanged) throw new ScanIteratorInterruptedError();
+              return (client as RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>).scan(cursor, options);
+            }
           );
         } catch (err) {
+          // Pass through if already wrapped (from the in-lambda re-check).
+          if (err instanceof ScanIteratorInterruptedError) throw err;
           // Only wrap when MASTER_CHANGE has been observed; otherwise let the
           // underlying error propagate. A bare socket disconnect alone is not
           // sufficient evidence of a failover (could be a transient network

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -664,43 +664,46 @@ export default class RedisSentinel<
     this: RedisSentinelType<M, F, S, RESP, TYPE_MAPPING>,
     options?: ScanOptions & ScanIteratorOptions
   ) {
-    // Acquire a master client lease
-    const masterClient = await this.acquire();
     let cursor = options?.cursor ?? "0";
     let shouldRestart = false;
 
-    // Set up topology change listener
     const handleTopologyChange = (event: RedisSentinelEvent) => {
       if (event.type === "MASTER_CHANGE") {
         shouldRestart = true;
       }
     };
-
-    // Listen for master changes
     this.on("topology-change", handleTopologyChange);
 
     try {
       do {
-        // Check if we need to restart due to master change
         if (shouldRestart) {
           cursor = "0";
           shouldRestart = false;
         }
 
-        const reply = await masterClient.scan(cursor, options);
-        // If a topology change happened during the scan command (which caused a retry),
-        // the reply is from the new master using the old cursor. We should discard it
-        // and let the loop restart the scan from cursor "0".
+        // Acquire the master lease only for the scan command itself, then
+        // release it before yielding so the consumer can run other commands
+        // (e.g. mGet) inside the for-await loop without exhausting the pool.
+        const masterClient = await this.acquire();
+        let reply;
+        try {
+          reply = await masterClient.scan(cursor, options);
+        } finally {
+          const release = masterClient.release();
+          if (release) await release;
+        }
+
+        // If a topology change occurred during the scan command, the reply may
+        // mix keys from old and new masters. Discard and restart from cursor 0.
         if (shouldRestart) {
           continue;
         }
+
         cursor = reply.cursor;
         yield reply.keys;
       } while (cursor !== "0");
     } finally {
-      // Clean up: remove event listener and release the client
       this.removeListener("topology-change", handleTopologyChange);
-      masterClient.release();
     }
   }
 }

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -701,7 +701,7 @@ export default class RedisSentinel<
 
         cursor = reply.cursor;
         yield reply.keys;
-      } while (cursor !== "0");
+      } while (cursor !== "0" || shouldRestart);
     } finally {
       this.removeListener("topology-change", handleTopologyChange);
     }

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { CommandArguments, RedisFunctions, RedisModules, RedisScripts, ReplyUnion, RespVersions, TypeMapping, DEFAULT_RESP } from '../RESP/types';
+import { CommandArguments, RedisArgument, RedisFunctions, RedisModules, RedisScripts, ReplyUnion, RespVersions, TypeMapping, DEFAULT_RESP } from '../RESP/types';
 import RedisClient, { AnyRedisClientOptions, RedisClientOptions, RedisClientType } from '../client';
 import { CommandOptions } from '../client/commands-queue';
 import { attachConfig } from '../commander';
@@ -19,9 +19,14 @@ import { RedisTcpSocketOptions } from '../client/socket';
 import { BasicPooledClientSideCache, PooledClientSideCacheProvider } from '../client/cache';
 import { ClientIdentity, ClientRole, generateClientId } from '../client/identity';
 import { DEFAULT_COMMAND_TIMEOUT } from '../defaults';
+import { ScanOptions } from '../commands/SCAN';
 
 interface ClientInfo {
   id: number;
+}
+
+interface ScanIteratorOptions {
+  cursor?: RedisArgument;
 }
 
 export class RedisSentinelClient<
@@ -653,6 +658,50 @@ export default class RedisSentinel<
     }
 
     this._self.#internal.setTracer(tracer);
+  }
+
+  async *scanIterator(
+    this: RedisSentinelType<M, F, S, RESP, TYPE_MAPPING>,
+    options?: ScanOptions & ScanIteratorOptions
+  ) {
+    // Acquire a master client lease
+    const masterClient = await this.acquire();
+    let cursor = options?.cursor ?? "0";
+    let shouldRestart = false;
+
+    // Set up topology change listener
+    const handleTopologyChange = (event: RedisSentinelEvent) => {
+      if (event.type === "MASTER_CHANGE") {
+        shouldRestart = true;
+      }
+    };
+
+    // Listen for master changes
+    this.on("topology-change", handleTopologyChange);
+
+    try {
+      do {
+        // Check if we need to restart due to master change
+        if (shouldRestart) {
+          cursor = "0";
+          shouldRestart = false;
+        }
+
+        const reply = await masterClient.scan(cursor, options);
+        // If a topology change happened during the scan command (which caused a retry),
+        // the reply is from the new master using the old cursor. We should discard it
+        // and let the loop restart the scan from cursor "0".
+        if (shouldRestart) {
+          continue;
+        }
+        cursor = reply.cursor;
+        yield reply.keys;
+      } while (cursor !== "0");
+    } finally {
+      // Clean up: remove event listener and release the client
+      this.removeListener("topology-change", handleTopologyChange);
+      masterClient.release();
+    }
   }
 }
 

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -657,6 +657,24 @@ export default class RedisSentinel<
     this._self.#internal.setTracer(tracer);
   }
 
+  /**
+   * Async generator that iterates over keys on the Sentinel master by issuing
+   * paged `SCAN` calls. Yields one array of keys per page until the SCAN cursor
+   * returns to `0`.
+   *
+   * The master client lease is acquired for the duration of each `SCAN` call
+   * and released before yielding, so consumers can issue other commands from
+   * inside the `for await` loop body without deadlocking against the iterator
+   * — even with `masterPoolSize: 1`.
+   *
+   * Throws `ScanIteratorInterruptedError` on observed `MASTER_CHANGE`.
+   * Throws the underlying error on any other failure.
+   *
+   * @param options - SCAN options and an optional starting `cursor`. The
+   *   starting cursor is honored only on the first call.
+   * @yields Arrays of keys returned by each `SCAN` page. Pages may be empty.
+   * @throws {ScanIteratorInterruptedError} On observed `MASTER_CHANGE`.
+   */
   async *scanIterator(
     this: RedisSentinelType<M, F, S, RESP, TYPE_MAPPING>,
     options?: ScanOptions & ScanIteratorOptions

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { CommandArguments, RedisArgument, RedisFunctions, RedisModules, RedisScripts, ReplyUnion, RespVersions, TypeMapping, DEFAULT_RESP } from '../RESP/types';
-import RedisClient, { AnyRedisClientOptions, RedisClientOptions, RedisClientType } from '../client';
+import RedisClient, { AnyRedisClientOptions, RedisClientOptions, RedisClientType, ScanIteratorOptions } from '../client';
 import { CommandOptions } from '../client/commands-queue';
 import { attachConfig } from '../commander';
 import { NON_STICKY_COMMANDS } from '../commands';
@@ -23,10 +23,6 @@ import { ScanOptions } from '../commands/SCAN';
 
 interface ClientInfo {
   id: number;
-}
-
-interface ScanIteratorOptions {
-  cursor?: RedisArgument;
 }
 
 export class RedisSentinelClient<
@@ -664,33 +660,40 @@ export default class RedisSentinel<
     this: RedisSentinelType<M, F, S, RESP, TYPE_MAPPING>,
     options?: ScanOptions & ScanIteratorOptions
   ) {
-    let cursor = options?.cursor ?? "0";
+    let cursor: RedisArgument = options?.cursor ?? '0';
     let shouldRestart = false;
 
     const handleTopologyChange = (event: RedisSentinelEvent) => {
-      if (event.type === "MASTER_CHANGE") {
+      if (event.type === 'MASTER_CHANGE') {
         shouldRestart = true;
       }
     };
-    this.on("topology-change", handleTopologyChange);
+    this.on('topology-change', handleTopologyChange);
 
     try {
       do {
         if (shouldRestart) {
-          cursor = "0";
+          cursor = '0';
           shouldRestart = false;
         }
 
-        // Acquire the master lease only for the scan command itself, then
-        // release it before yielding so the consumer can run other commands
-        // (e.g. mGet) inside the for-await loop without exhausting the pool.
-        const masterClient = await this.acquire();
+        // Route through _execute so reserveClient:true reuses the reserved
+        // lease (instead of waiting forever on an empty master pool), and the
+        // lease is released before yielding — consumers can issue other
+        // commands inside the for-await loop without exhausting the pool.
         let reply;
         try {
-          reply = await masterClient.scan(cursor, options);
-        } finally {
-          const release = masterClient.release();
-          if (release) await release;
+          reply = await this._execute(
+            false,
+            client => (client as RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>).scan(cursor, options)
+          );
+        } catch (err) {
+          // A master failover mid-SCAN can surface as a connection error
+          // before the topology-change event is processed. If the iterator
+          // has already been flagged to restart, swallow and retry on the
+          // new master instead of propagating the transient error.
+          if (shouldRestart) continue;
+          throw err;
         }
 
         // If a topology change occurred during the scan command, the reply may
@@ -701,9 +704,11 @@ export default class RedisSentinel<
 
         cursor = reply.cursor;
         yield reply.keys;
-      } while (cursor !== "0" || shouldRestart);
+        // Cursor may be a Buffer when a Blob String type mapping is in use;
+        // compare by string value so iteration actually terminates.
+      } while (cursor.toString() !== '0' || shouldRestart);
     } finally {
-      this.removeListener("topology-change", handleTopologyChange);
+      this.removeListener('topology-change', handleTopologyChange);
     }
   }
 }

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { CommandArguments, RedisArgument, RedisFunctions, RedisModules, RedisScripts, ReplyUnion, RespVersions, TypeMapping, DEFAULT_RESP } from '../RESP/types';
+import { SentinelMasterChangeError } from '../errors';
 import RedisClient, { AnyRedisClientOptions, RedisClientOptions, RedisClientType, ScanIteratorOptions } from '../client';
 import { CommandOptions } from '../client/commands-queue';
 import { attachConfig } from '../commander';
@@ -661,21 +662,18 @@ export default class RedisSentinel<
     options?: ScanOptions & ScanIteratorOptions
   ) {
     let cursor: RedisArgument = options?.cursor ?? '0';
-    let shouldRestart = false;
+    let masterChanged = false;
 
     const handleTopologyChange = (event: RedisSentinelEvent) => {
       if (event.type === 'MASTER_CHANGE') {
-        shouldRestart = true;
+        masterChanged = true;
       }
     };
     this.on('topology-change', handleTopologyChange);
 
     try {
       do {
-        if (shouldRestart) {
-          cursor = '0';
-          shouldRestart = false;
-        }
+        if (masterChanged) throw new SentinelMasterChangeError();
 
         // Route through _execute so reserveClient:true reuses the reserved
         // lease (instead of waiting forever on an empty master pool), and the
@@ -689,24 +687,18 @@ export default class RedisSentinel<
           );
         } catch (err) {
           // A master failover mid-SCAN can surface as a connection error
-          // before the topology-change event is processed. If the iterator
-          // has already been flagged to restart, swallow and retry on the
-          // new master instead of propagating the transient error.
-          if (shouldRestart) continue;
+          // before the topology-change event is processed. Surface it as a
+          // SentinelMasterChangeError so callers can distinguish failover
+          // from other transient failures.
+          if (masterChanged) throw new SentinelMasterChangeError(err);
           throw err;
-        }
-
-        // If a topology change occurred during the scan command, the reply may
-        // mix keys from old and new masters. Discard and restart from cursor 0.
-        if (shouldRestart) {
-          continue;
         }
 
         cursor = reply.cursor;
         yield reply.keys;
         // Cursor may be a Buffer when a Blob String type mapping is in use;
         // compare by string value so iteration actually terminates.
-      } while (cursor.toString() !== '0' || shouldRestart);
+      } while (cursor.toString() !== '0');
     } finally {
       this.removeListener('topology-change', handleTopologyChange);
     }


### PR DESCRIPTION
### Description

This PR implements the scanIterator method for the `RedisSentinel` client.
Previously, scanIterator was not exposed on the Sentinel client, limiting the ability to iterate over keys on the master node directly through the Sentinel interface. This implementation adds that capability with  handling for failovers.

Issue: #2999 

Changes:
- **Automatic Failover Handling:** If a master failover occurs during iteration, the iterator detects the `MASTER_CHANGE` topology event and automatically restarts the scan from the beginning on the new master. This ensures all keys are eventually covered, even if the topology changes mid-scan.
- **Reset-on-Failover Strategy**: Since Redis cursors are stateful and specific to a node instance, the iterator deliberately restarts from cursor 0 (the beginning) upon detecting a master failover. This guarantees data completeness but may result in duplicate keys being yielded, as documented.
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Does `npm test` pass with this change (including linting)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New master-key iteration API with explicit failover semantics and pool/lease behavior; incorrect caller handling could miss keys or retry incorrectly, but changes are localized to Sentinel scanning.
> 
> **Overview**
> Adds **`scanIterator`** on the **Redis Sentinel** client so callers can page over keys on the current master with the same **SCAN** options as standalone clients (including an optional starting **`cursor`**).
> 
> Each page runs **`SCAN`** through **`_execute`**, so the master lease is held only for that call and released before **`yield`**—avoiding deadlocks when the loop body runs other commands (e.g. **`mGet`**) with **`masterPoolSize: 1`** or **`reserveClient: true`**.
> 
> On **`MASTER_CHANGE`** while another page is still needed (cursor not yet **`0`**), iteration **stops** with a new **`ScanIteratorInterruptedError`** instead of reusing a node-local cursor on a new master; plain connection errors are **not** wrapped. Termination compares the cursor with **`cursor.toString() !== '0'`** so **Buffer** cursors from type mapping do not loop forever.
> 
> **`ScanIteratorOptions`** is **exported** from the client package. **Sentinel docs** describe iterator usage, failover semantics, and pool behavior. **Tests** cover happy path, **`MATCH`**, synthetic and real failover, race inside **`_execute`**, listener cleanup, and regressions above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cae392d32fefdc29ca029c665c63dad297d8860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->