### PR TITLE
feat(test-utils): add testAllAuto method for automatic cluster test generation

### DIFF
--- a/packages/search/lib/commands/AGGREGATE.spec.ts
+++ b/packages/search/lib/commands/AGGREGATE.spec.ts
@@ -4,7 +4,7 @@ import AGGREGATE from './AGGREGATE';
 import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
 import { DEFAULT_DIALECT } from '../dialect/default';
 
-describe('AGGREGATE', () => { 
+describe('AGGREGATE', () => {
   describe('transformArguments', () => {
     it('without options', () => {
       assert.deepEqual(
@@ -27,7 +27,7 @@ describe('AGGREGATE', () => {
         parseArgs(AGGREGATE, 'index', '*', { ADDSCORES: true }),
         ['FT.AGGREGATE', 'index', '*', 'ADDSCORES', 'DIALECT', DEFAULT_DIALECT]
       );
-    });  
+    });
 
     describe('with LOAD', () => {
       describe('single', () => {
@@ -477,13 +477,11 @@ describe('AGGREGATE', () => {
   });
 
   testUtils.testWithClient('client.ft.aggregate', async client => {
-    await Promise.all([
-      client.ft.create('index', {
-        field: 'NUMERIC'
-      }),
-      client.hSet('1', 'field', '1'),
-      client.hSet('2', 'field', '2')
-    ]);
+    await client.ft.create('index', {
+      field: 'NUMERIC'
+    });
+    await client.hSet('1', 'field', '1');
+    await client.hSet('2', 'field', '2');
 
     assert.deepEqual(
       await client.ft.aggregate('index', '*', {


### PR DESCRIPTION
Created a new `testAllAuto()` helper method in the test-utils package that automatically runs tests against both single-node and cluster instances with auto-generated cluster configuration from client configuration.

Previously, tests only ran against single-node clients using `testWithClient()`. To test both scenarios, developers had to either manually call `testWithCluster()` separately with hand-crafted cluster config, or use `testAll()` with both client and cluster configurations defined.

The new `testAllAuto()` method converts client configuration to cluster configuration by separating cluster-level properties (`modules`, `functions`, `scripts`) from client-level properties (`password`, `socket`, etc.), placing them at `clusterConfiguration` level and `clusterConfiguration.defaults` respectively.

Example usage:

Before:

```
testUtils.testWithClient('client.ft.aggregate', async client => {...}, GLOBAL.SERVERS.OPEN)

```

After:

```
testUtils.testAllAuto('client.ft.aggregate', async client => {...}, GLOBAL.SERVERS.OPEN)
```

Changes:
- Added `testAllAuto()` method in packages/test-utils/lib/index.ts
