### PR TITLE
token-manager: Correct documentation for jitterPercentage

### DIFF
--- a/packages/client/lib/authx/token-manager.ts
+++ b/packages/client/lib/authx/token-manager.ts
@@ -33,9 +33,10 @@ export interface RetryPolicy {
   backoffMultiplier: number;
 
   /**
-   * The percentage of jitter to apply to the delay.
+   * The percentage range of jitter to apply to the delay.
+   * The jitter will be evenly distributed between -jitterPercentage/2 and +jitterPercentage/2.
    * @example
-   * A value of 0.1 will add or subtract up to 10% of the delay.
+   * A value of 10 will add or subtract up to 5% of the delay (ranging from 95% to 105% of the original delay).
    */
   jitterPercentage?: number;
 


### PR DESCRIPTION

### Description

Correct the documentation for the `jitterPercentage` parameter to match the behavior in the code.

The relevant code (unchanged) in token-manager is:

```ts
      const jitterRange = delay * (jitterPercentage / 100);
      const jitterAmount = Math.random() * jitterRange - (jitterRange / 2);
      delay += jitterAmount;
```

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
