### PR TITLE
fix(client): return Promise consistently in cluster functions

### DIFF
--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -740,10 +740,10 @@ class RedisSentinelInternal<
    * @returns A client info object or a promise that resolves to a client info object
    *          when a client becomes available
    */
-  getClientLease(): ClientInfo | Promise<ClientInfo> {
+  getClientLease(): Promise<ClientInfo> {
     const id = this.#masterClientQueue.shift();
     if (id !== undefined) {
-      return { id };
+      return Promise.resolve({ id });
     }
 
     return this.#masterClientQueue.wait().then(id => ({ id }));


### PR DESCRIPTION
It is confusing for the same function to sometimes return an object and sometimes return a Promise.

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Does `npm test` pass with this change (including linting)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
