### PR TITLE
[8.6] Xinfostream - new idempotency fields

### DIFF
--- a/packages/client/lib/commands/XINFO_STREAM.spec.ts
+++ b/packages/client/lib/commands/XINFO_STREAM.spec.ts
@@ -29,6 +29,14 @@ describe('XINFO STREAM', () => {
         'entries-added': 0,
         'recorded-first-entry-id': '0-0',
       },
+      ...testUtils.isVersionGreaterThan([8, 6]) && {
+        'idmp-duration': 100,
+        'idmp-maxsize': 100,
+        'pids-tracked': 0,
+        'iids-tracked': 0,
+        'iids-added': 0,
+        'iids-duplicates': 0,
+      },
       groups: 1,
       'first-entry': null,
       'last-entry': null
@@ -36,5 +44,43 @@ describe('XINFO STREAM', () => {
   }, {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testWithClient('xInfoStream with RESP3', async client => {
+    const [, reply] = await Promise.all([
+      client.xGroupCreate('key', 'group', '$', {
+        MKSTREAM: true
+      }),
+      client.xInfoStream('key')
+    ]);
+
+    const expected = Object.assign(Object.create(null), {
+      length: 0,
+      'radix-tree-keys': 0,
+      'radix-tree-nodes': 1,
+      'last-generated-id': '0-0',
+      ...testUtils.isVersionGreaterThan([7, 0]) && {
+        'max-deleted-entry-id': '0-0',
+        'entries-added': 0,
+        'recorded-first-entry-id': '0-0',
+      },
+      ...testUtils.isVersionGreaterThan([8, 6]) && {
+        'idmp-duration': 100,
+        'idmp-maxsize': 100,
+        'pids-tracked': 0,
+        'iids-tracked': 0,
+        'iids-added': 0,
+        'iids-duplicates': 0,
+      },
+      groups: 1,
+      'first-entry': null,
+      'last-entry': null
+    });
+    assert.deepEqual(reply, expected);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    clientOptions: {
+      RESP: 3
+    }
   });
 });


### PR DESCRIPTION
### Description

New fields in response:

- idmp-duration - The duration value configured for the stream’s IDMP map.
- idmp-maxsize - The maxsize value configured for the stream’s IDMP map.
- pids-tracked - The number of idempotent pids currently tracked in the stream.
- iids-tracked - The number of idempotent ids currently tracked in the stream - This 	count reflects active iids that haven't expired or been evicted yet.
- iids-added - The count of all entries with an idempotent iid added to the stream during its lifetime - This is a cumulative counter that increases with each idempotent entry added.
- iids-duplicates - The count of all duplicate iids (for all pids) detected during the stream's lifetime - This is a cumulative counter that increases with each duplicate iid. 

https://docs.google.com/document/d/1vUj47wK8lIvE294IOG8BA5FlU5Jj9j3KHOD4lFERnEk

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
