### PR TITLE
Add TLS client test utils and cases

### DIFF
--- a/packages/client/lib/client/tls.spec.ts
+++ b/packages/client/lib/client/tls.spec.ts
@@ -5,57 +5,59 @@ import { createClient } from "../..";
 describe("TLS", () => {
   describe("Basic TLS connection", () => {
     testUtils.testWithTlsClient(
-      "should connect via TLS",
-      async (tlsClient) => {
-        const nonTlsClient = createClient({
-          socket: {
-            port: (tlsClient.options.socket as any)?.port,
-            tls: true,
-          },
-        });
-        assert.rejects(nonTlsClient.connect());
-        nonTlsClient.destroy();
-
+      "should connect with valid certificates",
+      async (tlsClient, { tlsPort }) => {
+        // Verify valid TLS connection works
         const pong = await tlsClient.ping();
         assert.equal(pong, "PONG");
+
+        // Verify that connecting with wrong CA fails (proves TLS is enforced)
+        const clientWithWrongCA = createClient({
+          socket: {
+            port: tlsPort,
+            tls: true,
+            ca: "wrong-ca-certificate",
+            reconnectStrategy: false,
+          },
+        });
+        clientWithWrongCA.on("error", () => {});
+
+        await assert.rejects(clientWithWrongCA.connect());
       },
       {
         ...GLOBAL.SERVERS.OPEN,
-        minimumDockerVersion: [6, 0], // TLS support
+        minimumDockerVersion: [6, 0],
       },
     );
   });
+
   describe("CN-based authentication", () => {
     const CLIENT_CN = "node-redis-test-client";
 
     testUtils.testWithTlsClient(
       "should authenticate TLS client using certificate CN",
       async (client) => {
-        try {
-          // Verify we're connected as default user
-          const initialWhoami = await client.aclWhoAmI();
-          assert.equal(initialWhoami, "default");
+        // Verify we're connected as default user
+        const initialWhoami = await client.aclWhoAmI();
+        assert.equal(initialWhoami, "default");
 
-          // Set up ACL user matching the certificate CN
-          await client.aclSetUser(CLIENT_CN, [
-            "on",
-            ">clientpass",
-            "allcommands",
-            "allkeys",
-          ]);
+        // Set up ACL user matching the certificate CN
+        await client.aclSetUser(CLIENT_CN, [
+          "on",
+          ">clientpass",
+          "allcommands",
+          "allkeys",
+        ]);
 
-          // Disconnect the client
-          client.destroy();
+        // Disconnect the client
+        client.destroy();
 
-          // Reconnect the client
-          await client.connect();
+        // Reconnect the client
+        await client.connect();
 
-          // Verify the TLS client is authenticated as the CN user
-          const whoami = await client.aclWhoAmI();
-          assert.equal(whoami, CLIENT_CN);
-        } finally {
-          client.destroy();
-        }
+        // Verify the TLS client is authenticated as the CN user
+        const whoami = await client.aclWhoAmI();
+        assert.equal(whoami, CLIENT_CN);
       },
       {
         ...GLOBAL.SERVERS.OPEN,


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

Adds TLS coverage to the test suite by introducing reusable TLS test infrastructure (test-utils + updated test container) and new client tests that validate connecting to Redis over TLS.  ￼
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
