### PR TITLE
fix(test-utils): support object format for defaultDockerVersion with separate tag and version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,15 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ["18", "20", "22"]
-        redis-version: ["rs-7.4.0-v1", "8.0.2", "8.2", "8.4.0"]
+        redis:
+          - tag: "rs-7.4.0-v1"
+            version: "7.4"
+          - tag: "8.2"
+            version: "8.2"
+          - tag: "8.4.0"
+            version: "8.4"
+          - tag: "custom-21183968220-debian-amd64"
+            version: "8.6"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,7 +47,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Run Tests
-        run: npm run test -ws --if-present -- --forbid-only --redis-version=${{ matrix.redis-version }}
+        run: npm run test -ws --if-present -- --forbid-only --redis-tag=${{ matrix.redis.tag }} --redis-version=${{ matrix.redis.version }}
       - name: Upload to Codecov
         run: |
           curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import

--- a/packages/bloom/lib/test-utils.ts
+++ b/packages/bloom/lib/test-utils.ts
@@ -3,8 +3,9 @@ import RedisBloomModules from '.';
 
 export default  TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
+  dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: '8.4.0'
+  defaultDockerVersion: { tag: 'custom-21183968220-debian-amd64', version: '8.6' }
 });
 
 export const GLOBAL = {

--- a/packages/client/lib/sentinel/test-util.ts
+++ b/packages/client/lib/sentinel/test-util.ts
@@ -173,8 +173,9 @@ export class SentinelFramework extends DockerBase {
     this.config = config;
     this.#testUtils = TestUtils.createFromConfig({
       dockerImageName: 'redislabs/client-libs-test',
+      dockerImageTagArgument: 'redis-tag',
       dockerImageVersionArgument: 'redis-version',
-      defaultDockerVersion: '8.4.0'
+      defaultDockerVersion: { tag: 'custom-21183968220-debian-amd64', version: '8.6' }
     });
     this.#nodeMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelNodes']>>>>();
     this.#sentinelMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelSentinels']>>>>();

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -8,8 +8,9 @@ import { defineScript } from './lua-script';
 import RedisBloomModules from '@redis/bloom';
 const utils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
+  dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: '8.4.0'
+  defaultDockerVersion: { tag: 'custom-21183968220-debian-amd64', version: '8.6' }
 });
 
 export default utils;

--- a/packages/entraid/lib/test-utils.ts
+++ b/packages/entraid/lib/test-utils.ts
@@ -5,8 +5,9 @@ import { EntraidCredentialsProvider } from './entraid-credentials-provider';
 
 export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
+  dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: '8.4.0'
+  defaultDockerVersion: { tag: 'custom-21183968220-debian-amd64', version: '8.6' }
 });
 
 const DEBUG_MODE_ARGS = testUtils.isVersionGreaterThan([7]) ?

--- a/packages/json/lib/test-utils.ts
+++ b/packages/json/lib/test-utils.ts
@@ -3,8 +3,9 @@ import RedisJSON from '.';
 
 export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
+  dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: '8.4.0'
+  defaultDockerVersion: { tag: 'custom-21183968220-debian-amd64', version: '8.6' }
 });
 
 export const GLOBAL = {

--- a/packages/search/lib/test-utils.ts
+++ b/packages/search/lib/test-utils.ts
@@ -4,8 +4,9 @@ import { RespVersions } from '@redis/client';
 
 export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
+  dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: '8.4.0'
+  defaultDockerVersion: { tag: 'custom-21183968220-debian-amd64', version: '8.6' }
 });
 
 export const GLOBAL = {

--- a/packages/test-utils/lib/index.spec.ts
+++ b/packages/test-utils/lib/index.spec.ts
@@ -95,7 +95,7 @@ describe('Version Comparison', () => {
     ];
 
     tests.forEach(([version, min, max, expected]) => {
-      const testUtils = new TestUtils({ string: version.join('.'), numbers: version }, "test")
+      const testUtils = new TestUtils({ tag: version.join('.'), numbers: version }, "test")
       assert.equal(
         testUtils.isVersionInRange(min, max),
         expected,

--- a/packages/test-utils/lib/test-utils.ts
+++ b/packages/test-utils/lib/test-utils.ts
@@ -2,8 +2,9 @@ import TestUtils from './index'
 
 export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
+  dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: '8.4.0'
+  defaultDockerVersion: { tag: 'custom-21183968220-debian-amd64', version: '8.6' }
 });
 
 

--- a/packages/time-series/lib/test-utils.ts
+++ b/packages/time-series/lib/test-utils.ts
@@ -3,8 +3,9 @@ import TimeSeries from '.';
 
 export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
+  dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: '8.4.0'
+  defaultDockerVersion: { tag: 'custom-21183968220-debian-amd64', version: '8.6' }
 });
 
 export const GLOBAL = {


### PR DESCRIPTION
### Description

 - Update defaultDockerVersion to use { tag, version } format to handle custom Docker tags that don't contain semantic versions
- Tag 'custom-21183968220-debian-amd64' now correctly parses as version 8.6
- Updated all test-utils files across packages to use the new format
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
