### PR TITLE
fix(client): Support IPv6 literals in URL

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -388,7 +388,8 @@ export default class RedisClient<
         }
       } = {
         socket: {
-          host: hostname,
+          // Use net.SocketAddress.parse() once supported.
+          host: hostname.replace(/^\[([0-9a-f:]+)\]$/, '$1'),
           tls: false
         }
       };


### PR DESCRIPTION
### Description

Fixes redis/node-redis#3175.

With node.js 22.13.0 / 23.4.0 the manual regex replacement can be avoided in favor of [`SocketAddress.parse()`](https://nodejs.org/api/net.html#socketaddressparseinput).

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?