### PR TITLE
feat(sentinel): add sSubscribe/sUnsubscribe methods to Sentinel client

### DIFF
--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -231,6 +231,31 @@ describe('RedisSentinel', () => {
 
       assert.equal(tester, false);
   }, testOptions)
+
+    testUtils.testWithClientSentinel('plain pubsub - sharded', async sentinel => {
+      let pubSubResolve;
+      const pubSubPromise = new Promise((res) => {
+        pubSubResolve = res;
+      });
+
+      let tester = false;
+      await sentinel.sSubscribe('test', () => {
+        tester = true;
+        pubSubResolve && pubSubResolve(1);
+      })
+
+      await sentinel.sPublish('test', 'hello world');
+      await pubSubPromise;
+      assert.equal(tester, true);
+
+      // now unsubscribe
+      tester = false;
+      await sentinel.sUnsubscribe('test')
+      await sentinel.sPublish('test', 'hello world');
+      await setTimeout(1000);
+
+      assert.equal(tester, false);
+    }, testOptions);
   });
 });
 

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -552,6 +552,26 @@ export default class RedisSentinel<
 
   pUnsubscribe = this.PUNSUBSCRIBE;
 
+  async SSUBSCRIBE<T extends boolean = false>(
+    channels: string | Array<string>,
+    listener: PubSubListener<T>,
+    bufferMode?: T
+  ) {
+    return this._self.#internal.sSubscribe(channels, listener, bufferMode);
+  }
+
+  sSubscribe = this.SSUBSCRIBE;
+
+  async SUNSUBSCRIBE<T extends boolean = false>(
+    channels?: string | Array<string>,
+    listener?: PubSubListener<T>,
+    bufferMode?: T
+  ) {
+    return this._self.#internal.sUnsubscribe(channels, listener, bufferMode);
+  }
+
+  sUnsubscribe = this.SUNSUBSCRIBE;
+
   /**
    * Acquires a master client lease for exclusive operations
    *
@@ -1064,6 +1084,22 @@ class RedisSentinelInternal<
     bufferMode?: T
   ) {
     return this.#pubSubProxy.pUnsubscribe(patterns, listener, bufferMode);
+  }
+
+  async sSubscribe<T extends boolean = false>(
+    channels: string | Array<string>,
+    listener: PubSubListener<T>,
+    bufferMode?: T
+  ) {
+    return this.#pubSubProxy.sSubscribe(channels, listener, bufferMode);
+  }
+
+  async sUnsubscribe<T extends boolean = false>(
+    channels?: string | Array<string>,
+    listener?: PubSubListener<T>,
+    bufferMode?: T
+  ) {
+    return this.#pubSubProxy.sUnsubscribe(channels, listener, bufferMode);
   }
 
   // observe/analyze/transform remediation functions


### PR DESCRIPTION
Add sharded pub/sub methods (sSubscribe/sUnsubscribe) to the Sentinel client for API consistency with the standalone Redis client. Since Sentinel manages a single master with no sharding, these methods provide no sharding benefit - they simply pass through to the underlying Redis commands. This enables compatibility with libraries like @socket.io/redis-adapter that expect the sSubscribe method to be available.

fixes #3177

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
