### PR TITLE
feat: expose sendCommand on multi for all clients

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -510,6 +510,16 @@ describe('Client', () => {
       );
     }, GLOBAL.SERVERS.OPEN);
 
+    testUtils.testWithClient('multi sendCommand', async client => {
+      assert.deepEqual(
+        await client.multi()
+          .sendCommand(['SET', 'key', 'value'])
+          .sendCommand(['GET', 'key'])
+          .exec(),
+        ['OK', 'value']
+      );
+    }, GLOBAL.SERVERS.OPEN);
+
     testUtils.testWithClient('should reject the whole chain on error', client => {
       return assert.rejects(
         client.multi()

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -1,6 +1,6 @@
 import COMMANDS from '../commands';
 import RedisMultiCommand, { MULTI_MODE, MULTI_REPLY, MultiMode, MultiReply, MultiReplyType, RedisMultiQueuedCommand } from '../multi-command';
-import { ReplyWithTypeMapping, CommandReply, Command, CommandArguments, CommanderConfig, RedisFunctions, RedisModules, RedisScripts, RespVersions, TransformReply, RedisScript, RedisFunction, TypeMapping } from '../RESP/types';
+import { ReplyWithTypeMapping, CommandReply, Command, CommandArguments, CommanderConfig, RedisFunctions, RedisModules, RedisScripts, RespVersions, TransformReply, RedisScript, RedisFunction, TypeMapping, RedisArgument } from '../RESP/types';
 import { attachConfig, functionArgumentsPrefix, getTransformReply } from '../commander';
 import { BasicCommandParser } from './parser';
 import { Tail } from '../commands/generic-transformers';
@@ -79,7 +79,7 @@ type InternalRedisClientMultiCommandType<
   TYPE_MAPPING extends TypeMapping
 > = (
   RedisClientMultiCommand<REPLIES> &
-  WithCommands<REPLIES, M, F, S, RESP, TYPE_MAPPING> & 
+  WithCommands<REPLIES, M, F, S, RESP, TYPE_MAPPING> &
   WithModules<REPLIES, M, F, S, RESP, TYPE_MAPPING> &
   WithFunctions<REPLIES, M, F, S, RESP, TYPE_MAPPING> &
   WithScripts<REPLIES, M, F, S, RESP, TYPE_MAPPING>
@@ -248,5 +248,18 @@ export default class RedisClientMultiCommand<REPLIES = []> {
 
   execAsPipelineTyped() {
     return this.execAsPipeline<MULTI_REPLY['TYPED']>();
+  }
+
+  /**
+   * Adds a raw command to the multi/pipeline queue.
+   *
+   * Note: Using this method breaks the type inference for `execTyped` and
+   * `execAsPipelineTyped`. This is a known limitation and will be addressed
+   * in the future.
+   */
+  sendCommand(args: ReadonlyArray<RedisArgument>) {
+    const redisArgs: CommandArguments = args.slice();
+    this.#multi.addCommand(redisArgs);
+    return this;
   }
 }

--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -23,6 +23,16 @@ describe('RedisClientPool', () => {
     );
   }, GLOBAL.SERVERS.OPEN);
 
+  testUtils.testWithClientPool('multi sendCommand', async pool => {
+    assert.deepEqual(
+      await pool.multi()
+        .sendCommand(['SET', 'key', 'value'])
+        .sendCommand(['GET', 'key'])
+        .exec(),
+      ['OK', 'value']
+    );
+  }, GLOBAL.SERVERS.OPEN);
+
   testUtils.testWithClientPool('close', async pool => {
     await pool.close()
     assert.equal(pool.totalClients, 0)

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -48,6 +48,23 @@ describe('Cluster', () => {
     );
   }, GLOBAL.CLUSTERS.OPEN);
 
+  testUtils.testWithCluster('multi sendCommand', async cluster => {
+    const key = 'key';
+    assert.deepEqual(
+      await cluster.multi()
+        .sendCommand(['SET', key, 'value'], {
+          firstKey: key,
+          isReadonly: false
+        })
+        .sendCommand(['GET', key], {
+          firstKey: key,
+          isReadonly: true
+        })
+        .exec(),
+      ['OK', 'value']
+    );
+  }, GLOBAL.CLUSTERS.OPEN);
+
   testUtils.testWithCluster('scripts', async cluster => {
     const [, reply] = await Promise.all([
       cluster.set('key', '2'),

--- a/packages/client/lib/cluster/multi-command.ts
+++ b/packages/client/lib/cluster/multi-command.ts
@@ -276,4 +276,23 @@ export default class RedisClusterMultiCommand<REPLIES = []> {
   execAsPipelineTyped() {
     return this.execAsPipeline<MULTI_REPLY['TYPED']>();
   }
+
+  /**
+   * Adds a raw command to the multi/pipeline queue.
+   *
+   * Note: Using this method breaks the type inference for `execTyped` and
+   * `execAsPipelineTyped`. This is a known limitation and will be addressed
+   * in the future.
+   */
+  sendCommand(
+    args: ReadonlyArray<RedisArgument>,
+    options?: {
+      firstKey?: RedisArgument;
+      isReadonly?: boolean;
+    }
+  ) {
+    const redisArgs: CommandArguments = args.slice();
+    this.addCommand(options?.firstKey, options?.isReadonly, redisArgs);
+    return this;
+  }
 }

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -137,6 +137,16 @@ describe('RedisSentinel', () => {
       await assert.rejects(sentinel.connect());
     }, testOptions);
 
+    testUtils.testWithClientSentinel('multi sendCommand', async sentinel => {
+      assert.deepEqual(
+        await sentinel.multi()
+          .sendCommand(['SET', 'x', '1'])
+          .sendCommand(['GET', 'x'])
+          .exec(),
+        ['OK', '1']
+      );
+    }, testOptions);
+
 
     testUtils.testWithClientSentinel('should respect type mapping', async sentinel => {
       const typeMapped = sentinel.withTypeMapping({

--- a/packages/client/lib/sentinel/multi-commands.ts
+++ b/packages/client/lib/sentinel/multi-commands.ts
@@ -1,6 +1,6 @@
 import { NON_STICKY_COMMANDS } from '../commands';
 import RedisMultiCommand, { MULTI_REPLY, MultiReply, MultiReplyType } from '../multi-command';
-import { ReplyWithTypeMapping, CommandReply, Command, CommandArguments, CommanderConfig, RedisFunctions, RedisModules, RedisScripts, RespVersions, TransformReply, RedisScript, RedisFunction, TypeMapping } from '../RESP/types';
+import { ReplyWithTypeMapping, CommandReply, Command, CommandArguments, CommanderConfig, RedisFunctions, RedisModules, RedisScripts, RespVersions, TransformReply, RedisScript, RedisFunction, TypeMapping, RedisArgument } from '../RESP/types';
 import { attachConfig, functionArgumentsPrefix, getTransformReply } from '../commander';
 import { RedisSentinelType } from './types';
 import { BasicCommandParser } from '../client/parser';
@@ -81,7 +81,7 @@ export type RedisSentinelMultiCommandType<
   TYPE_MAPPING extends TypeMapping
 > = (
   RedisSentinelMultiCommand<REPLIES> &
-  WithCommands<REPLIES, M, F, S, RESP, TYPE_MAPPING> & 
+  WithCommands<REPLIES, M, F, S, RESP, TYPE_MAPPING> &
   WithModules<REPLIES, M, F, S, RESP, TYPE_MAPPING> &
   WithFunctions<REPLIES, M, F, S, RESP, TYPE_MAPPING> &
   WithScripts<REPLIES, M, F, S, RESP, TYPE_MAPPING>
@@ -247,5 +247,23 @@ export default class RedisSentinelMultiCommand<REPLIES = []> {
 
   execAsPipelineTyped() {
     return this.execAsPipeline<MULTI_REPLY['TYPED']>();
+  }
+
+  /**
+   * Adds a raw command to the multi/pipeline queue.
+   *
+   * Note: Using this method breaks the type inference for `execTyped` and
+   * `execAsPipelineTyped`. This is a known limitation and will be addressed
+   * in the future.
+   */
+  sendCommand(
+    args: ReadonlyArray<RedisArgument>,
+    options?: {
+      isReadonly?: boolean;
+    }
+  ) {
+    const redisArgs: CommandArguments = args.slice();
+    this.addCommand(options?.isReadonly, redisArgs);
+    return this;
   }
 }


### PR DESCRIPTION
This change makes sendCommand a public method on multi/pipeline for standalone client, cluster, sentinel, and pool.

Note: Using sendCommand breaks the type inference for execTyped and execAsPipelineTyped. It is possible to fix this by modifying InternalRedisClientMultiCommandType, but this significantly hinders TypeScript performance and is unfeasible for now.

fixes #3172

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
