### PR TITLE
[#3127] Fix for Redis Sentinel client doesn't reconnect after connection failure

### DIFF
--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -18,7 +18,7 @@ import { TcpNetConnectOpts } from 'node:net';
 import { RedisTcpSocketOptions } from '../client/socket';
 import { BasicPooledClientSideCache, PooledClientSideCacheProvider } from '../client/cache';
 
-function areSentinelListsEqual(a: ReadonlyArray<RedisNode>, b: ReadonlyArray<RedisNode>): boolean {
+export function areSentinelListsEqual(a: ReadonlyArray<RedisNode>, b: ReadonlyArray<RedisNode>): boolean {
   if (a.length !== b.length) return false;
   return a.every((nodeA, i) => nodeA.host === b[i].host && nodeA.port === b[i].port);
 }


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

When a Redis Sentinel goes down and comes back up, the node-redis client fails to reconnect, throwing "None of the sentinels are available". It seems this is a regression introduced in v5.9.0 (commit 73413e086c — "fix: resolve doubly linked list push issue (#3085)").

**Root Cause:** `#handleSentinelFailure()` (added in v5.9.0) permanently removes the sentinel node from `#sentinelRootNodes` via `splice()` when its connection drops. When `#reset()` then calls `observe()`, the sentinel list is empty (or missing that node), so reconnection is impossible.

**Secondary issue:** The sentinel list update in `transform()` (line 1350) compares only array lengths (`analyzed.sentinelList.length != this.#sentinelRootNodes.length`), so even if reconnection succeeds via another sentinel, a removed node may never be restored if the list sizes happen to match.

Fix:

1. Stop removing sentinels from #sentinelRootNodes in #handleSentinelFailure — just call #reset() so reconnection is retried against all known sentinels.
2. Fix the sentinel list update check: the old code only compared array lengths, so it missed cases where the list contents changed but the length stayed the same. Replaced with a proper element-wise comparison (areSentinelListsEqual).

Fixes #3127 

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? N/A no API changes, this is a bug fix for internal reconnection logic.

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
