### PR TITLE
fix(search): use @redis/client dist imports in CREATE command

### DIFF
--- a/packages/search/lib/commands/CREATE.ts
+++ b/packages/search/lib/commands/CREATE.ts
@@ -1,6 +1,6 @@
-import { CommandParser } from '@redis/client/lib/client/parser';
-import { RedisArgument, SimpleStringReply, Command } from '@redis/client/lib/RESP/types';
-import { RedisVariadicArgument, parseOptionalVariadicArgument } from '@redis/client/lib/commands/generic-transformers';
+import { CommandParser } from '@redis/client/dist/lib/client/parser';
+import { RedisArgument, SimpleStringReply, Command } from '@redis/client/dist/lib/RESP/types';
+import { RedisVariadicArgument, parseOptionalVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
 
 export const SCHEMA_FIELD_TYPE = {
   TEXT: 'TEXT',


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small import-path adjustment with no behavioral changes beyond resolving module/packaging compatibility at build/runtime.
> 
> **Overview**
> Updates the RediSearch `FT.CREATE` command implementation to import Redis client types/helpers from `@redis/client/dist/...` instead of `@redis/client/lib/...`, aligning `CREATE.ts` with the rest of the search commands’ import strategy and avoiding issues when consuming the packaged build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19fe9749c6dbe0f06de87928acc46748242dd49a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->