### PR TITLE
feat: add duplicate() method to RedisSentinel

### DIFF
--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -433,7 +433,7 @@ export default class RedisSentinel<
   >(overrides?: Partial<RedisSentinelOptions<_M, _F, _S, _RESP, _TYPE_MAPPING>>) {
     return new (Object.getPrototypeOf(this).constructor)({
       ...this._self.#options,
-      commandOptions: this._commandOptions,
+      commandOptions: this._self.#commandOptions,
       ...overrides
     }) as RedisSentinelType<_M, _F, _S, _RESP, _TYPE_MAPPING>;
   }

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -424,6 +424,20 @@ export default class RedisSentinel<
     return this._commandOptionsProxy('typeMapping', typeMapping);
   }
 
+  duplicate<
+    _M extends RedisModules = M,
+    _F extends RedisFunctions = F,
+    _S extends RedisScripts = S,
+    _RESP extends RespVersions = RESP,
+    _TYPE_MAPPING extends TypeMapping = TYPE_MAPPING
+  >(overrides?: Partial<RedisSentinelOptions<_M, _F, _S, _RESP, _TYPE_MAPPING>>) {
+    return new (Object.getPrototypeOf(this).constructor)({
+      ...this._self.#options,
+      commandOptions: this._commandOptions,
+      ...overrides
+    }) as RedisSentinelType<_M, _F, _S, _RESP, _TYPE_MAPPING>;
+  }
+
   async connect() {
     await this._self.#internal.connect();
 


### PR DESCRIPTION
## Problem

`RedisClientType` and `RedisClusterType` both expose a `duplicate()` method for creating a new connection with the same configuration (plus optional overrides). `RedisSentinelType` is missing this method, forcing users to manually reconstruct the full sentinel configuration when they need a second connection.

Common use case: pub/sub requires a dedicated connection, so users need to duplicate their sentinel connection:

```typescript
const sentinel = createSentinel({ ... }).on('error', console.error);
await sentinel.connect();

// Currently impossible:
const subscriber = sentinel.duplicate();

// Users must manually reconstruct:
const subscriber = createSentinel({ ...sameConfigAgain }).on('error', console.error);
```

## Solution

Add `duplicate()` to the `RedisSentinel` class following the exact same pattern used by `RedisClient` (`client/index.ts:1028`) and `RedisCluster` (`cluster/index.ts`):

```typescript
duplicate<...>(overrides?) {
  return new (Object.getPrototypeOf(this).constructor)({
    ...this._self.#options,
    commandOptions: this._commandOptions,
    ...overrides
  }) as RedisSentinelType<...>;
}
```

The duplicated instance is not connected. Users call `.connect()` on it, same as with `RedisClient.duplicate()`.

## Changes

- `packages/client/lib/sentinel/index.ts` -- Added `duplicate()` method to `RedisSentinel` class

## Backwards Compatibility

Additive only. No existing methods or types are changed.

Closes #3107

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change that mirrors existing `duplicate()` implementations on `RedisClient`/`RedisCluster` and does not alter connection or command execution paths.
> 
> **Overview**
> Adds `RedisSentinel.duplicate()` to instantiate a new sentinel client using the current instance’s stored `#options` and `#commandOptions`, with optional overrides, matching the `duplicate()` behavior already available on `RedisClient` and `RedisCluster`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 113589557748215f453d131f5381e916fba8d942. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->