### PR TITLE
fix: decouple OTel public types from @opentelemetry/api

### DIFF
--- a/packages/client/lib/opentelemetry/index.ts
+++ b/packages/client/lib/opentelemetry/index.ts
@@ -1,7 +1,7 @@
 import { OpenTelemetryError } from "../errors";
 import { ClientRegistry } from "./client-registry";
 import { OTelMetrics } from "./metrics";
-import { ObservabilityConfig } from "./types";
+import { ObservabilityConfig, OpenTelemetryApiModule } from "./types";
 
 export class OpenTelemetry {
   private static _instance: OpenTelemetry | null = null;
@@ -57,7 +57,7 @@ export class OpenTelemetry {
       throw new OpenTelemetryError("OpenTelemetry already initialized");
     }
 
-    const api: typeof import("@opentelemetry/api") = (() => {
+    const api: OpenTelemetryApiModule = (() => {
       try {
         return require("@opentelemetry/api");
       } catch {

--- a/packages/client/lib/opentelemetry/metrics.ts
+++ b/packages/client/lib/opentelemetry/metrics.ts
@@ -1,10 +1,12 @@
 import type * as DC from 'node:diagnostics_channel';
-import { Meter, BatchObservableResult } from "@opentelemetry/api";
 import { ClientRegistry } from "./client-registry";
 import {
+  BatchObservableResult,
   DEFAULT_OTEL_ATTRIBUTES,
+  Meter,
   MetricInstruments,
   ObservabilityConfig,
+  OpenTelemetryApiModule,
   OTEL_ATTRIBUTES,
   MetricOptions,
   DEFAULT_METRIC_GROUPS,
@@ -499,7 +501,7 @@ export class OTelMetrics {
   readonly #options: MetricOptions;
 
   private constructor(
-    api: typeof import("@opentelemetry/api"),
+    api: OpenTelemetryApiModule,
     config?: ObservabilityConfig,
   ) {
     this.#options = this.parseOptions(config);
@@ -535,7 +537,7 @@ export class OTelMetrics {
     api,
     config,
   }: {
-    api: typeof import("@opentelemetry/api");
+    api: OpenTelemetryApiModule;
     config?: ObservabilityConfig;
   }) {
     if (OTelMetrics.#initialized) {
@@ -568,7 +570,7 @@ export class OTelMetrics {
 
 
   #getMeter(
-    api: typeof import("@opentelemetry/api"),
+    api: OpenTelemetryApiModule,
     options: MetricOptions,
   ): Meter {
     if (options.meterProvider) {

--- a/packages/client/lib/opentelemetry/types.ts
+++ b/packages/client/lib/opentelemetry/types.ts
@@ -1,12 +1,79 @@
-import {
-  Attributes,
-  Counter,
-  Histogram,
-  MeterProvider,
-  ObservableGauge,
-  UpDownCounter,
-} from "@opentelemetry/api";
 import { version } from "../../package.json";
+
+type AttributePrimitive = string | number | boolean;
+
+// Keep the public OTel-facing config structurally typed so consumers do not
+// need @opentelemetry/api installed unless they actually initialize it.
+export type AttributeValue =
+  | AttributePrimitive
+  | readonly AttributePrimitive[];
+
+export type Attributes = Record<string, AttributeValue | undefined>;
+
+type InstrumentOptions = {
+  unit?: string;
+  description?: string;
+};
+
+export interface Counter<TAttributes extends Attributes = Attributes> {
+  add(value: number, attributes?: TAttributes, context?: unknown): void;
+}
+
+export interface Histogram<TAttributes extends Attributes = Attributes> {
+  record(value: number, attributes?: TAttributes, context?: unknown): void;
+}
+
+export interface UpDownCounter<TAttributes extends Attributes = Attributes> {
+  add(value: number, attributes?: TAttributes, context?: unknown): void;
+}
+
+export interface ObservableGauge<TAttributes extends Attributes = Attributes> {
+  readonly _attributes?: TAttributes;
+}
+
+export interface BatchObservableResult {
+  observe<TAttributes extends Attributes>(
+    instrument: ObservableGauge<TAttributes>,
+    value: number,
+    attributes?: TAttributes,
+    context?: unknown,
+  ): void;
+}
+
+export interface Meter {
+  createHistogram(
+    name: string,
+    options?: InstrumentOptions & {
+      advice?: {
+        explicitBucketBoundaries?: number[];
+      };
+    },
+  ): Histogram<Attributes>;
+  createCounter(
+    name: string,
+    options?: InstrumentOptions,
+  ): Counter<Attributes>;
+  createUpDownCounter(
+    name: string,
+    options?: InstrumentOptions,
+  ): UpDownCounter<Attributes>;
+  createObservableGauge(
+    name: string,
+    options?: InstrumentOptions,
+  ): ObservableGauge<Attributes>;
+  addBatchObservableCallback(
+    callback: (observableResult: BatchObservableResult) => void,
+    observables: ObservableGauge[],
+  ): void;
+}
+
+export interface MeterProvider {
+  getMeter(name: string, version?: string, options?: unknown): Meter;
+}
+
+export interface OpenTelemetryApiModule {
+  metrics: Pick<MeterProvider, "getMeter">;
+}
 
 export const METRIC_GROUP = {
   COMMAND: "command",


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

Fixes #3227

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8e0afed1dd7ddf278b34a004101a9510e8498dff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->