### PR TITLE
docs: fix typo in topology change comment

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -449,7 +449,7 @@ export default class RedisClient<
   private _commandOptions?: CommandOptions<TYPE_MAPPING>;
   // flag used to annotate that the client
   // was in a watch transaction when
-  // a topology change occured
+  // a topology change occurred
   #dirtyWatch?: string;
   #watchEpoch?: number;
   #clientSideCache?: ClientSideCacheProvider;


### PR DESCRIPTION
## Summary
- Correct `occured` to `occurred` in the topology change comment.

## Related issue
- N/A

## Guideline alignment
- Read the contribution guide where present and kept this to one focused text-only file change.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this text-only change.

## AI assistance
- Prepared with Codex and reviewed before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only typo fix in `RedisClient`; no runtime behavior or API changes.
> 
> **Overview**
> Fixes a spelling typo in a `RedisClient` comment describing WATCH state invalidation on topology changes (`occured` → `occurred`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18709fedbae2c92680c4659711697fa3fc78d658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->