### PR TITLE
docs: fix pool configuration grammar

### DIFF
--- a/docs/pool.md
+++ b/docs/pool.md
@@ -28,7 +28,7 @@ the function accepts two arguments, the client configuration (see [here](./clien
 | acquireTimeout | 3000    | The maximum time (in ms) a task can wait in the queue. The pool will reject the task with `TimeoutError` in case of a timeout. |
 | cleanupDelay   | 3000    | The time to wait before cleaning up unused clients.                                                                            |
 
-You can also create a pool from a client (reusing it's configuration):
+You can also create a pool from a client (reusing its configuration):
 ```javascript
 const pool = await client.createPool()
   .on('error', err => console.error('Redis Client Pool Error', err));


### PR DESCRIPTION
## Summary
- Change `it's configuration` to `its configuration` in the pool docs.

## Related issue
- N/A

## Guideline alignment
- Read the contribution guide where present and kept this to one focused text-only file change.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this text-only change.

## AI assistance
- Prepared with Codex and reviewed before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only grammar fix with no code or behavior changes, so risk is negligible.
> 
> **Overview**
> Fixes a small grammar typo in `docs/pool.md` by changing “reusing it's configuration” to “reusing its configuration” in the pool creation example text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a6c034c92196032c69849f67b6097b40e735735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->