### PR TITLE
docs: fix contraction in slotNumber comment

### DIFF
--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -635,7 +635,7 @@ export default class RedisCommandsQueue {
   /**
    *
    * Extracts commands for the given slots from the toWrite queue.
-   * Some commands dont have "slotNumber", which means they are not designated to particular slot/node.
+   * Some commands don't have "slotNumber", which means they are not designated to particular slot/node.
    * We ignore those.
    */
   extractCommandsForSlots(slots: Set<number>): CommandToWrite[] {


### PR DESCRIPTION
## Summary
- Fix the contraction in the `slotNumber` queue comment.

## Related issue
- N/A

## Guideline alignment
- Read `CONTRIBUTING.md` and kept this to one focused text-only file change.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this comment-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only change with no runtime behavior impact.
> 
> **Overview**
> Fixes a small documentation typo in `commands-queue.ts`, updating the `extractCommandsForSlots` comment to use the correct contraction (`don't`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 611767fdb5f26f48687b43f9a113620b260f2650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->