### PR TITLE
fix(ci): build monorepo before documentation generation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-node@v3
       - name: Install Packages
         run: npm ci
+      - name: Build Packages
+        run: npm run build
       - name: Generate Documentation
         run: npm run documentation
       - name: Upload
@@ -25,4 +27,3 @@ jobs:
           npm run gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds a missing build step; main impact is on documentation pipeline timing and potential build failures surfacing earlier.
> 
> **Overview**
> The documentation GitHub Actions workflow now runs `npm run build` after `npm ci` and before `npm run documentation`, ensuring packages are built before docs are generated and published via `gh-pages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d309d1e5d49f7f14bb8beecaeea59d13e6b40f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->