### PR TITLE
chore(tests): bump default docker test image to unstable-24425681442-…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,8 @@ jobs:
             version: "8.2"
           - tag: "8.4.0"
             version: "8.4"
-          - tag: "custom-21860421418-debian-amd64"
-            version: "8.6"
+          - tag: "unstable-24425681442-debian"
+            version: "8.8"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/bloom/lib/test-utils.ts
+++ b/packages/bloom/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default  TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-21860421418-debian-amd64', version: '8.6' }
+  defaultDockerVersion: { tag: 'unstable-24425681442-debian', version: '8.8' }
 });
 
 export const GLOBAL = {

--- a/packages/client/lib/sentinel/test-util.ts
+++ b/packages/client/lib/sentinel/test-util.ts
@@ -175,7 +175,7 @@ export class SentinelFramework extends DockerBase {
       dockerImageName: 'redislabs/client-libs-test',
       dockerImageTagArgument: 'redis-tag',
       dockerImageVersionArgument: 'redis-version',
-      defaultDockerVersion: { tag: 'custom-21860421418-debian-amd64', version: '8.6' }
+      defaultDockerVersion: { tag: 'unstable-24425681442-debian', version: '8.8' }
     });
     this.#nodeMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelNodes']>>>>();
     this.#sentinelMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelSentinels']>>>>();

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -10,7 +10,7 @@ const utils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-21860421418-debian-amd64', version: '8.6' }
+  defaultDockerVersion: { tag: 'unstable-24425681442-debian', version: '8.8' }
 });
 
 export default utils;

--- a/packages/entraid/lib/test-utils.ts
+++ b/packages/entraid/lib/test-utils.ts
@@ -7,7 +7,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-21860421418-debian-amd64', version: '8.6' }
+  defaultDockerVersion: { tag: 'unstable-24425681442-debian', version: '8.8' }
 });
 
 const DEBUG_MODE_ARGS = testUtils.isVersionGreaterThan([7]) ?

--- a/packages/json/lib/test-utils.ts
+++ b/packages/json/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-21860421418-debian-amd64', version: '8.6' }
+  defaultDockerVersion: { tag: 'unstable-24425681442-debian', version: '8.8' }
 });
 
 export const GLOBAL = {

--- a/packages/search/lib/test-utils.ts
+++ b/packages/search/lib/test-utils.ts
@@ -6,7 +6,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-21860421418-debian-amd64', version: '8.6' }
+  defaultDockerVersion: { tag: 'unstable-24425681442-debian', version: '8.8' }
 });
 
 export const GLOBAL = {

--- a/packages/test-utils/lib/test-utils.ts
+++ b/packages/test-utils/lib/test-utils.ts
@@ -4,7 +4,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-21860421418-debian-amd64', version: '8.6' }
+  defaultDockerVersion: { tag: 'unstable-24425681442-debian', version: '8.8' }
 });
 
 

--- a/packages/time-series/lib/test-utils.ts
+++ b/packages/time-series/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-21860421418-debian-amd64', version: '8.6' }
+  defaultDockerVersion: { tag: 'unstable-24425681442-debian', version: '8.8' }
 });
 
 export const GLOBAL = {


### PR DESCRIPTION
…debian

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates test infrastructure defaults and CI matrix Redis versions; main risk is CI/test instability due to using an unstable Redis image.
> 
> **Overview**
> Updates the test harness default Redis Docker image/tag from a custom `8.6` build to `unstable-24425681442-debian` (`8.8`) across package test utilities.
> 
> Adjusts the GitHub Actions test matrix to run against the same `unstable` Redis `8.8` image instead of the previous custom `8.6` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5da454a11fa7f33dfc37b821a6e2601062f94d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->