### PR TITLE
feat(json.set): add fpha option to json.set

### DIFF
--- a/packages/json/lib/commands/SET.spec.ts
+++ b/packages/json/lib/commands/SET.spec.ts
@@ -12,6 +12,20 @@ describe('JSON.SET', () => {
       );
     });
 
+    it('condition NX', () => {
+      assert.deepEqual(
+        parseArgs(SET, 'key', '$', 'json', { condition: 'NX' }),
+        ['JSON.SET', 'key', '$', '"json"', 'NX']
+      );
+    });
+
+    it('condition XX', () => {
+      assert.deepEqual(
+        parseArgs(SET, 'key', '$', 'json', { condition: 'XX' }),
+        ['JSON.SET', 'key', '$', '"json"', 'XX']
+      );
+    });
+
     it('NX', () => {
       assert.deepEqual(
         parseArgs(SET, 'key', '$', 'json', { NX: true }),
@@ -25,11 +39,60 @@ describe('JSON.SET', () => {
         ['JSON.SET', 'key', '$', '"json"', 'XX']
       );
     });
+
+    for (const fpha of ['BF16', 'FP16', 'FP32', 'FP64'] as const) {
+      it(`FPHA ${fpha}`, () => {
+        assert.deepEqual(
+          parseArgs(SET, 'key', '$', 'json', { fpha }),
+          ['JSON.SET', 'key', '$', '"json"', 'FPHA', fpha]
+        );
+      });
+    }
+
+    it('condition with FPHA', () => {
+      assert.deepEqual(
+        parseArgs(SET, 'key', '$', 'json', { condition: 'NX', fpha: 'FP32' }),
+        ['JSON.SET', 'key', '$', '"json"', 'NX', 'FPHA', 'FP32']
+      );
+    });
   });
 
   testUtils.testWithClient('client.json.set', async client => {
     assert.equal(
       await client.json.set('key', '$', 'json'),
+      'OK'
+    );
+  }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClientIfVersionWithinRange([[8, 8], 'LATEST'], 'client.json.set with FPHA', async client => {
+    const fpArray = [1.1, 2.2, 3.3, 4.4];
+
+    for (const fpha of ['FP32', 'FP64', 'FP16', 'BF16'] as const) {
+      const key = `fpha:${fpha}`;
+      assert.equal(
+        await client.json.set(key, '$', fpArray, { fpha }),
+        'OK'
+      );
+
+      const result = await client.json.get(key);
+      assert.equal(Array.isArray(result), true);
+      assert.equal((result as Array<unknown>).length, fpArray.length);
+    }
+  }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClientIfVersionWithinRange([[8, 8], 'LATEST'], 'client.json.set with FPHA and conditions', async client => {
+    const fpArray = [1.5, 2.5, 3.5];
+
+    assert.equal(
+      await client.json.set('fpha:nx', '$', fpArray, { condition: 'NX', fpha: 'FP32' }),
+      'OK'
+    );
+    assert.equal(
+      await client.json.set('fpha:nx', '$', [4.5, 5.5], { condition: 'NX', fpha: 'FP32' }),
+      null
+    );
+    assert.equal(
+      await client.json.set('fpha:nx', '$', [4.5, 5.5], { condition: 'XX', fpha: 'FP32' }),
       'OK'
     );
   }, GLOBAL.SERVERS.OPEN);

--- a/packages/json/lib/commands/SET.ts
+++ b/packages/json/lib/commands/SET.ts
@@ -14,6 +14,7 @@ export interface JsonSetOptions {
   XX?: boolean;
   /**
    * If set, forces Redis to use the specified floating-point type for storing all FP homogeneous arrays.
+   * available since 8.8
    */
   fpha?: 'BF16' | 'FP16' | 'FP32' | 'FP64';
 }

--- a/packages/json/lib/commands/SET.ts
+++ b/packages/json/lib/commands/SET.ts
@@ -12,6 +12,10 @@ export interface JsonSetOptions {
    * @deprecated Use `{ condition: 'XX' }` instead.
    */
   XX?: boolean;
+  /**
+   * If set, forces Redis to use the specified floating-point type for storing all FP homogeneous arrays.
+   */
+  fpha?: 'BF16' | 'FP16' | 'FP32' | 'FP64';
 }
 
 export default {
@@ -19,7 +23,7 @@ export default {
   /**
    * Sets a JSON value at a specific path in a JSON document.
    * Returns OK on success, or null if condition (NX/XX) is not met.
-   * 
+   *
    * @param parser - The Redis command parser
    * @param key - The key containing the JSON document
    * @param path - Path in the document to set
@@ -46,6 +50,9 @@ export default {
       parser.push('NX');
     } else if (options?.XX) {
       parser.push('XX');
+    }
+    if (options?.fpha !== undefined) {
+      parser.push('FPHA', options.fpha);
     }
   },
   transformReply: undefined as unknown as () => SimpleStringReply<'OK'> | NullReply


### PR DESCRIPTION
fpha - floating point homogenous array hint for how Redis should store arrays of fp values


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small additive change to command argument building, gated by an explicit new option and covered by unit/integration tests (including Redis 8.8+ checks).
> 
> **Overview**
> `JSON.SET` now accepts a new `fpha` option that appends `FPHA <type>` to the command, allowing callers to hint Redis on how to store floating-point homogeneous arrays (Redis 8.8+).
> 
> Tests are expanded to validate argument transformation for `condition`/legacy `NX`/`XX` plus `fpha`, and to run version-gated client integration checks for `fpha` behavior and interactions with `NX`/`XX` conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee134ef562560a0459031015894e4c18d47e74d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->