### PR TITLE
docs: fix RESP documentation typo

### DIFF
--- a/docs/RESP.md
+++ b/docs/RESP.md
@@ -1,6 +1,6 @@
 # Mapping RESP types
 
-RESP, which stands for **R**edis **SE**rialization **P**rotocol, is the protocol used by Redis to communicate with clients. This document shows how RESP types can be mapped to JavaScript types. You can learn more about RESP itself in the [offical documentation](https://redis.io/docs/reference/protocol-spec/).
+RESP, which stands for **R**edis **SE**rialization **P**rotocol, is the protocol used by Redis to communicate with clients. This document shows how RESP types can be mapped to JavaScript types. You can learn more about RESP itself in the [official documentation](https://redis.io/docs/reference/protocol-spec/).
 
 By default, each type is mapped to the first option in the lists below. To change this, configure a [`typeMapping`](.).
 


### PR DESCRIPTION
## Summary
- fix a typo in the RESP mapping docs

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- reviewed `CONTRIBUTING.md`
- kept the change to one docs file with no behavior impact

## Validation
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that corrects a spelling typo with no runtime or API impact.
> 
> **Overview**
> Fixes a spelling typo in `docs/RESP.md`, updating the link text from “offical documentation” to “official documentation”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4146dcd96d82357fba36bc1f21b7dae76e0e9b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->