### PR TITLE
docs: fix migration guide typo

### DIFF
--- a/docs/v4-to-v5.md
+++ b/docs/v4-to-v5.md
@@ -4,7 +4,7 @@
 
 ### Keep Alive
 
-To better align with Node.js build-in [`net`](https://nodejs.org/api/net.html) and [`tls`](https://nodejs.org/api/tls.html) modules, the `keepAlive` option has been split into 2 options: `keepAlive` (`boolean`) and `keepAliveInitialDelay` (`number`). The defaults remain `true` and `5000`.
+To better align with Node.js built-in [`net`](https://nodejs.org/api/net.html) and [`tls`](https://nodejs.org/api/tls.html) modules, the `keepAlive` option has been split into 2 options: `keepAlive` (`boolean`) and `keepAliveInitialDelay` (`number`). The defaults remain `true` and `5000`.
 
 ### Legacy Mode
 


### PR DESCRIPTION
## Summary
- fix a typo in the v4 to v5 migration guide

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- reviewed `CONTRIBUTING.md`
- kept the change to one docs file with no behavior impact

## Validation
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects wording in the migration guide with no behavior impact.
> 
> **Overview**
> Fixes a typo in the v4→v5 migration guide by correcting “built-in” wording in the Node.js module reference for the `keepAlive` option split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff074ece8881dd2f0122fee92d277fb7b70703c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->