### PR TITLE
fix(search): allow LOAD * in FT.AGGREGATE #2726

### DIFF
--- a/packages/search/lib/commands/AGGREGATE.spec.ts
+++ b/packages/search/lib/commands/AGGREGATE.spec.ts
@@ -30,6 +30,14 @@ describe('AGGREGATE', () => {
     });
 
     describe('with LOAD', () => {
+      it('all attributes (*)', () => {
+        assert.deepEqual(
+          parseArgs(AGGREGATE, 'index', '*', {
+            LOAD: '*'
+          }),
+          ['FT.AGGREGATE', 'index', '*', 'LOAD', '*', 'DIALECT', DEFAULT_DIALECT]
+        );
+      });
       describe('single', () => {
         describe('without alias', () => {
           it('string', () => {

--- a/packages/search/lib/commands/AGGREGATE.ts
+++ b/packages/search/lib/commands/AGGREGATE.ts
@@ -13,12 +13,12 @@ type LoadField = RediSearchProperty | {
 export const FT_AGGREGATE_STEPS = {
   GROUPBY: 'GROUPBY',
   SORTBY: 'SORTBY',
-  APPLY: 'APPLY', 
+  APPLY: 'APPLY',
   LIMIT: 'LIMIT',
   FILTER: 'FILTER'
 } as const;
 
-type FT_AGGREGATE_STEPS = typeof FT_AGGREGATE_STEPS;  
+type FT_AGGREGATE_STEPS = typeof FT_AGGREGATE_STEPS;
 
 export type FtAggregateStep = FT_AGGREGATE_STEPS[keyof FT_AGGREGATE_STEPS];
 
@@ -121,7 +121,7 @@ interface FilterStep extends AggregateStep<FT_AGGREGATE_STEPS['FILTER']> {
 export interface FtAggregateOptions {
   VERBATIM?: boolean;
   ADDSCORES?: boolean;
-  LOAD?: LoadField | Array<LoadField>;
+  LOAD?: '*' | LoadField | Array<LoadField>;
   TIMEOUT?: number;
   STEPS?: Array<GroupByStep | SortStep | ApplyStep | LimitStep | FilterStep>;
   PARAMS?: FtSearchParams;
@@ -166,7 +166,7 @@ export default {
           transformTuplesReply(rawReply[i] as ArrayReply<BlobStringReply>, preserve, typeMapping)
         );
       }
-  
+
       return {
         //  https://redis.io/docs/latest/commands/ft.aggregate/#return
         //  FT.AGGREGATE returns an array reply where each row is an array reply and represents a single aggregate result.
@@ -180,31 +180,33 @@ export default {
   unstableResp3: true
 } as const satisfies Command;
 
-export function parseAggregateOptions(parser: CommandParser , options?: FtAggregateOptions) {
+export function parseAggregateOptions(parser: CommandParser, options?: FtAggregateOptions) {
   if (options?.VERBATIM) {
     parser.push('VERBATIM');
   }
 
   if (options?.ADDSCORES) {
     parser.push('ADDSCORES');
-  }  
-
-  if (options?.LOAD) {
-    const args: Array<RedisArgument> = [];
-
-    if (Array.isArray(options.LOAD)) {
-      for (const load of options.LOAD) {
-        pushLoadField(args, load);
-      }
-    } else {
-      pushLoadField(args, options.LOAD);
-    }
-
-    parser.push('LOAD');
-    parser.pushVariadicWithLength(args);
   }
 
-  if (options?.TIMEOUT !== undefined) {
+  if (options?.LOAD) {
+    parser.push('LOAD');
+    if (options.LOAD === '*') {
+      parser.push('*');
+    } else {
+      const args: Array<RedisArgument> = [];
+
+      if (Array.isArray(options?.LOAD)) {
+        for (const load of options.LOAD) {
+          pushLoadField(args, load);
+        }
+      } else {
+        pushLoadField(args, options?.LOAD);
+      }
+
+      parser.pushVariadicWithLength(args);
+    }
+  } if (options?.TIMEOUT !== undefined) {
     parser.push('TIMEOUT', options.TIMEOUT.toString());
   }
 


### PR DESCRIPTION
### Description

This pull request adds support for the `LOAD *` syntax within the `FT.AGGREGATE` command.

**Purpose:**
According to the [[RediSearch documentation](https://redis.io/commands/ft.aggregate/)](https://redis.io/commands/ft.aggregate/), the `LOAD` clause typically expects a specific number of arguments (`nargs`). However, it also supports a wildcard `*` to project all document attributes into the aggregation pipeline.

**Problem:**
The previous implementation utilized `pushVariadicWithLength`, which automatically prepended a numeric count to the arguments. When passing `*`, the library generated `LOAD 1 *`, resulting in a Redis protocol error.

**Solution:**
The `parseAggregateOptions` function now includes type narrowing to handle the wildcard case:
* If `LOAD` is exactly `'*'`, the parser pushes the literal string `*` as the argument count substitute.
* For all other cases (individual strings, objects, or arrays of fields), the original `pushVariadicWithLength` logic is maintained to ensure backward compatibility.



### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `FT.AGGREGATE` argument construction to special-case `LOAD`, which can affect query serialization and compatibility with RediSearch. While covered by a new unit test, this touches core command parsing logic used broadly by clients.
> 
> **Overview**
> **Adds `LOAD *` support for `FT.AGGREGATE`.** `FtAggregateOptions.LOAD` now accepts the wildcard `'*'`, and `parseAggregateOptions` emits `LOAD *` directly instead of `LOAD 1 *` (while keeping the existing counted-args behavior for specific fields/aliases and arrays).
> 
> Updates tests to cover the new wildcard projection case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 095ae1cca9dfbfe5a98d1c11f2c3a468bd8a9f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->