### PR TITLE
docs: fix "official" spelling in RESP docs

### DIFF
--- a/docs/RESP.md
+++ b/docs/RESP.md
@@ -1,6 +1,6 @@
 # Mapping RESP types
 
-RESP, which stands for **R**edis **SE**rialization **P**rotocol, is the protocol used by Redis to communicate with clients. This document shows how RESP types can be mapped to JavaScript types. You can learn more about RESP itself in the [offical documentation](https://redis.io/docs/reference/protocol-spec/).
+RESP, which stands for **R**edis **SE**rialization **P**rotocol, is the protocol used by Redis to communicate with clients. This document shows how RESP types can be mapped to JavaScript types. You can learn more about RESP itself in the [official documentation](https://redis.io/docs/reference/protocol-spec/).
 
 By default, each type is mapped to the first option in the lists below. To change this, configure a [`typeMapping`](.).
 


### PR DESCRIPTION
### Description
- Fix `offical` -> `official` in `docs/RESP.md`.

### Checklist
- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Validation
- Not run; docs-only wording change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change correcting a spelling typo; no runtime, API, or behavior impact.
> 
> **Overview**
> Fixes a typo in `docs/RESP.md` by correcting “offical” to “official” in the Redis protocol documentation link text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0821ab6d11a2562c2ca43e1a41a93d7d1cb1dc87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->