### PR TITLE
feat(commands): ZINTER, ZINTERSTORE, ZUNION, ZUNIONSTORE: add a new aggregator: COUNT

### DIFF
--- a/packages/client/lib/commands/ZINTER.spec.ts
+++ b/packages/client/lib/commands/ZINTER.spec.ts
@@ -52,6 +52,15 @@ describe('ZINTER', () => {
         ['ZINTER', '1', 'key', 'AGGREGATE', 'SUM']
       );
     });
+
+    it('with AGGREGATE COUNT', () => {
+      assert.deepEqual(
+        parseArgs(ZINTER, 'key', {
+          AGGREGATE: 'COUNT'
+        }),
+        ['ZINTER', '1', 'key', 'AGGREGATE', 'COUNT']
+      );
+    });
   });
 
   testUtils.testAll('zInter', async client => {
@@ -59,6 +68,80 @@ describe('ZINTER', () => {
       await client.zInter('key'),
       []
     );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('zInter with AGGREGATE COUNT', async client => {
+    const keys = [
+      '{tag}zinter-count-1',
+      '{tag}zinter-count-2',
+      '{tag}zinter-count-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 2 },
+        { value: 'only1', score: 3 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 4 },
+        { value: 'common2', score: 5 },
+        { value: 'only2', score: 6 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 7 },
+        { value: 'common2', score: 8 },
+        { value: 'only3', score: 9 }
+      ])
+    ]);
+
+    assert.deepEqual(
+      await client.zInter(keys, {
+        AGGREGATE: 'COUNT'
+      }),
+      ['common1', 'common2']
+    );
+  }, {
+    client: { ...GLOBAL.SERVERS.OPEN, minimumDockerVersion: [8, 8] },
+    cluster: { ...GLOBAL.CLUSTERS.OPEN, minimumDockerVersion: [8, 8] }
+  });
+
+  testUtils.testAll('zInter with AGGREGATE SUM, MIN, MAX', async client => {
+    const keys = [
+      '{tag}zinter-other-1',
+      '{tag}zinter-other-2',
+      '{tag}zinter-other-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 10 },
+        { value: 'only1', score: 3 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 5 },
+        { value: 'common2', score: 2 },
+        { value: 'only2', score: 6 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 7 },
+        { value: 'common2', score: 4 },
+        { value: 'only3', score: 9 }
+      ])
+    ]);
+
+    const aggregators = ['SUM', 'MIN', 'MAX'] as const;
+    for (const aggregate of aggregators) {
+      const result = await client.zInter(keys, {
+        AGGREGATE: aggregate
+      });
+
+      assert.deepEqual(result.sort(), ['common1', 'common2']);
+    }
   }, {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN

--- a/packages/client/lib/commands/ZINTER.ts
+++ b/packages/client/lib/commands/ZINTER.ts
@@ -12,7 +12,8 @@ export type ZInterKeys<T> = T | [T, ...Array<T>];
 export type ZInterKeysType = ZInterKeys<RedisArgument> | ZInterKeys<ZInterKeyAndWeight>;
 
 export interface ZInterOptions {
-  AGGREGATE?: 'SUM' | 'MIN' | 'MAX';
+  /** `COUNT` added in 8.8 */
+  AGGREGATE?: 'SUM' | 'MIN' | 'MAX' | 'COUNT';
 }
 
 export function parseZInterArguments(

--- a/packages/client/lib/commands/ZINTERSTORE.spec.ts
+++ b/packages/client/lib/commands/ZINTERSTORE.spec.ts
@@ -50,6 +50,15 @@ describe('ZINTERSTORE', () => {
         ['ZINTERSTORE', 'destination', '1', 'source', 'AGGREGATE', 'SUM']
       );
     });
+
+    it('with AGGREGATE COUNT', () => {
+      assert.deepEqual(
+        parseArgs(ZINTERSTORE, 'destination', 'source', {
+          AGGREGATE: 'COUNT'
+        }),
+        ['ZINTERSTORE', 'destination', '1', 'source', 'AGGREGATE', 'COUNT']
+      );
+    });
   });
 
   testUtils.testAll('zInterStore', async client => {
@@ -57,6 +66,114 @@ describe('ZINTERSTORE', () => {
       await client.zInterStore('{tag}destination', '{tag}key'),
       0
     );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('zInterStore with AGGREGATE COUNT', async client => {
+    const keys = [
+      '{tag}zinterstore-count-1',
+      '{tag}zinterstore-count-2',
+      '{tag}zinterstore-count-3'
+    ];
+    const destination = '{tag}zinterstore-count-destination';
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 2 },
+        { value: 'only1', score: 3 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 4 },
+        { value: 'common2', score: 5 },
+        { value: 'only2', score: 6 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 7 },
+        { value: 'common2', score: 8 },
+        { value: 'only3', score: 9 }
+      ])
+    ]);
+
+    assert.equal(
+      await client.zInterStore(destination, keys, {
+        AGGREGATE: 'COUNT'
+      }),
+      2
+    );
+
+    const result = await client.zRangeWithScores(destination, 0, -1);
+    assert.deepEqual(result, [
+      { value: 'common1', score: 3 },
+      { value: 'common2', score: 3 }
+    ]);
+
+    const scores = result.map(item => item.score);
+    assert.equal(Math.min(...scores), 3);
+    assert.equal(Math.max(...scores), 3);
+  }, {
+    client: { ...GLOBAL.SERVERS.OPEN, minimumDockerVersion: [8, 8] },
+    cluster: { ...GLOBAL.CLUSTERS.OPEN, minimumDockerVersion: [8, 8] }
+  });
+
+  testUtils.testAll('zInterStore with AGGREGATE SUM, MIN, MAX', async client => {
+    const keys = [
+      '{tag}zinterstore-other-1',
+      '{tag}zinterstore-other-2',
+      '{tag}zinterstore-other-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 10 },
+        { value: 'only1', score: 3 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 5 },
+        { value: 'common2', score: 2 },
+        { value: 'only2', score: 6 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 7 },
+        { value: 'common2', score: 4 },
+        { value: 'only3', score: 9 }
+      ])
+    ]);
+
+    const expectedByAggregate = {
+      SUM: {
+        common1: 13,
+        common2: 16
+      },
+      MIN: {
+        common1: 1,
+        common2: 2
+      },
+      MAX: {
+        common1: 7,
+        common2: 10
+      }
+    };
+
+    const aggregators = ['SUM', 'MIN', 'MAX'] as const;
+    for (const aggregate of aggregators) {
+      const destination = `{tag}zinterstore-other-destination-${aggregate}`;
+      assert.equal(
+        await client.zInterStore(destination, keys, {
+          AGGREGATE: aggregate
+        }),
+        2
+      );
+
+      const result = await client.zRangeWithScores(destination, 0, -1);
+      assert.deepEqual(
+        Object.fromEntries(result.map(({ value, score }) => [value.toString(), score])),
+        expectedByAggregate[aggregate]
+      );
+    }
   }, {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN

--- a/packages/client/lib/commands/ZINTER_WITHSCORES.spec.ts
+++ b/packages/client/lib/commands/ZINTER_WITHSCORES.spec.ts
@@ -52,6 +52,15 @@ describe('ZINTER WITHSCORES', () => {
         ['ZINTER', '1', 'key', 'AGGREGATE', 'SUM', 'WITHSCORES']
       );
     });
+
+    it('with AGGREGATE COUNT', () => {
+      assert.deepEqual(
+        parseArgs(ZINTER_WITHSCORES, 'key', {
+          AGGREGATE: 'COUNT'
+        }),
+        ['ZINTER', '1', 'key', 'AGGREGATE', 'COUNT', 'WITHSCORES']
+      );
+    });
   });
 
   testUtils.testAll('zInterWithScores', async client => {
@@ -59,6 +68,104 @@ describe('ZINTER WITHSCORES', () => {
       await client.zInterWithScores('key'),
       []
     );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('zInterWithScores with AGGREGATE COUNT', async client => {
+    const keys = [
+      '{tag}zinterws-count-1',
+      '{tag}zinterws-count-2',
+      '{tag}zinterws-count-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 2 },
+        { value: 'only1', score: 3 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 4 },
+        { value: 'common2', score: 5 },
+        { value: 'only2', score: 6 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 7 },
+        { value: 'common2', score: 8 },
+        { value: 'only3', score: 9 }
+      ])
+    ]);
+
+    const result = await client.zInterWithScores(keys, {
+      AGGREGATE: 'COUNT'
+    });
+
+    assert.deepEqual(result, [
+      { value: 'common1', score: 3 },
+      { value: 'common2', score: 3 }
+    ]);
+
+    const scores = result.map(item => item.score);
+    assert.equal(Math.min(...scores), 3);
+    assert.equal(Math.max(...scores), 3);
+  }, {
+    client: { ...GLOBAL.SERVERS.OPEN, minimumDockerVersion: [8, 8] },
+    cluster: { ...GLOBAL.CLUSTERS.OPEN, minimumDockerVersion: [8, 8] }
+  });
+
+  testUtils.testAll('zInterWithScores with AGGREGATE SUM, MIN, MAX', async client => {
+    const keys = [
+      '{tag}zinterws-other-1',
+      '{tag}zinterws-other-2',
+      '{tag}zinterws-other-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 10 },
+        { value: 'only1', score: 3 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 5 },
+        { value: 'common2', score: 2 },
+        { value: 'only2', score: 6 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 7 },
+        { value: 'common2', score: 4 },
+        { value: 'only3', score: 9 }
+      ])
+    ]);
+
+    const expectedByAggregate = {
+      SUM: {
+        common1: 13,
+        common2: 16
+      },
+      MIN: {
+        common1: 1,
+        common2: 2
+      },
+      MAX: {
+        common1: 7,
+        common2: 10
+      }
+    };
+
+    const aggregators = ['SUM', 'MIN', 'MAX'] as const;
+    for (const aggregate of aggregators) {
+      const result = await client.zInterWithScores(keys, {
+        AGGREGATE: aggregate
+      });
+
+      assert.deepEqual(
+        Object.fromEntries(result.map(({ value, score }) => [value.toString(), score])),
+        expectedByAggregate[aggregate]
+      );
+    }
   }, {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN

--- a/packages/client/lib/commands/ZUNION.spec.ts
+++ b/packages/client/lib/commands/ZUNION.spec.ts
@@ -52,6 +52,15 @@ describe('ZUNION', () => {
         ['ZUNION', '1', 'key', 'AGGREGATE', 'SUM']
       );
     });
+
+    it('with AGGREGATE COUNT', () => {
+      assert.deepEqual(
+        parseArgs(ZUNION, 'key', {
+          AGGREGATE: 'COUNT'
+        }),
+        ['ZUNION', '1', 'key', 'AGGREGATE', 'COUNT']
+      );
+    });
   });
 
   testUtils.testAll('zUnion', async client => {
@@ -59,6 +68,93 @@ describe('ZUNION', () => {
       await client.zUnion('key'),
       []
     );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('zUnion with AGGREGATE COUNT', async client => {
+    const keys = [
+      '{tag}zunion-count-1',
+      '{tag}zunion-count-2',
+      '{tag}zunion-count-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 2 },
+        { value: 'pair12', score: 3 },
+        { value: 'only1', score: 4 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 5 },
+        { value: 'common2', score: 6 },
+        { value: 'pair12', score: 7 },
+        { value: 'pair23', score: 8 },
+        { value: 'only2', score: 9 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 10 },
+        { value: 'common2', score: 11 },
+        { value: 'pair23', score: 12 },
+        { value: 'only3', score: 13 }
+      ])
+    ]);
+
+    const result = await client.zUnion(keys, {
+      AGGREGATE: 'COUNT'
+    });
+
+    assert.deepEqual(
+      result.sort(),
+      ['common1', 'common2', 'only1', 'only2', 'only3', 'pair12', 'pair23']
+    );
+  }, {
+    client: { ...GLOBAL.SERVERS.OPEN, minimumDockerVersion: [8, 8] },
+    cluster: { ...GLOBAL.CLUSTERS.OPEN, minimumDockerVersion: [8, 8] }
+  });
+
+  testUtils.testAll('zUnion with AGGREGATE SUM, MIN, MAX', async client => {
+    const keys = [
+      '{tag}zunion-other-1',
+      '{tag}zunion-other-2',
+      '{tag}zunion-other-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 10 },
+        { value: 'pair12', score: 3 },
+        { value: 'only1', score: 4 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 5 },
+        { value: 'common2', score: 2 },
+        { value: 'pair12', score: 7 },
+        { value: 'pair23', score: 8 },
+        { value: 'only2', score: 9 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 7 },
+        { value: 'common2', score: 4 },
+        { value: 'pair23', score: 12 },
+        { value: 'only3', score: 13 }
+      ])
+    ]);
+
+    const aggregators = ['SUM', 'MIN', 'MAX'] as const;
+    for (const aggregate of aggregators) {
+      const result = await client.zUnion(keys, {
+        AGGREGATE: aggregate
+      });
+
+      assert.deepEqual(
+        result.sort(),
+        ['common1', 'common2', 'only1', 'only2', 'only3', 'pair12', 'pair23']
+      );
+    }
   }, {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN

--- a/packages/client/lib/commands/ZUNION.ts
+++ b/packages/client/lib/commands/ZUNION.ts
@@ -3,7 +3,8 @@ import { ArrayReply, BlobStringReply, Command } from '../RESP/types';
 import { ZKeys, parseZKeysArguments } from './generic-transformers';
 
 export interface ZUnionOptions {
-  AGGREGATE?: 'SUM' | 'MIN' | 'MAX';
+  /** `COUNT` added in 8.8 */
+  AGGREGATE?: 'SUM' | 'MIN' | 'MAX' | 'COUNT';
 }
 
 export default {

--- a/packages/client/lib/commands/ZUNIONSTORE.spec.ts
+++ b/packages/client/lib/commands/ZUNIONSTORE.spec.ts
@@ -50,6 +50,15 @@ describe('ZUNIONSTORE', () => {
         ['ZUNIONSTORE', 'destination', '1', 'source', 'AGGREGATE', 'SUM']
       );
     });
+
+    it('with AGGREGATE COUNT', () => {
+      assert.deepEqual(
+        parseArgs(ZUNIONSTORE, 'destination', 'source', {
+          AGGREGATE: 'COUNT'
+        }),
+        ['ZUNIONSTORE', 'destination', '1', 'source', 'AGGREGATE', 'COUNT']
+      );
+    });
   });
 
   testUtils.testAll('zUnionStore', async client => {
@@ -57,6 +66,145 @@ describe('ZUNIONSTORE', () => {
       await client.zUnionStore('{tag}destination', '{tag}key'),
       0
     );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('zUnionStore with AGGREGATE COUNT', async client => {
+    const keys = [
+      '{tag}zunionstore-count-1',
+      '{tag}zunionstore-count-2',
+      '{tag}zunionstore-count-3'
+    ];
+    const destination = '{tag}zunionstore-count-destination';
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 2 },
+        { value: 'pair12', score: 3 },
+        { value: 'only1', score: 4 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 5 },
+        { value: 'common2', score: 6 },
+        { value: 'pair12', score: 7 },
+        { value: 'pair23', score: 8 },
+        { value: 'only2', score: 9 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 10 },
+        { value: 'common2', score: 11 },
+        { value: 'pair23', score: 12 },
+        { value: 'only3', score: 13 }
+      ])
+    ]);
+
+    assert.equal(
+      await client.zUnionStore(destination, keys, {
+        AGGREGATE: 'COUNT'
+      }),
+      7
+    );
+
+    const result = await client.zRangeWithScores(destination, 0, -1);
+    assert.deepEqual(
+      Object.fromEntries(result.map(({ value, score }) => [value.toString(), score])),
+      {
+        common1: 3,
+        common2: 3,
+        only1: 1,
+        only2: 1,
+        only3: 1,
+        pair12: 2,
+        pair23: 2
+      }
+    );
+
+    const scores = result.map(item => item.score);
+    assert.equal(Math.min(...scores), 1);
+    assert.equal(Math.max(...scores), 3);
+  }, {
+    client: { ...GLOBAL.SERVERS.OPEN, minimumDockerVersion: [8, 8] },
+    cluster: { ...GLOBAL.CLUSTERS.OPEN, minimumDockerVersion: [8, 8] }
+  });
+
+  testUtils.testAll('zUnionStore with AGGREGATE SUM, MIN, MAX', async client => {
+    const keys = [
+      '{tag}zunionstore-other-1',
+      '{tag}zunionstore-other-2',
+      '{tag}zunionstore-other-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 10 },
+        { value: 'pair12', score: 3 },
+        { value: 'only1', score: 4 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 5 },
+        { value: 'common2', score: 2 },
+        { value: 'pair12', score: 7 },
+        { value: 'pair23', score: 8 },
+        { value: 'only2', score: 9 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 7 },
+        { value: 'common2', score: 4 },
+        { value: 'pair23', score: 12 },
+        { value: 'only3', score: 13 }
+      ])
+    ]);
+
+    const expectedByAggregate = {
+      SUM: {
+        common1: 13,
+        common2: 16,
+        pair12: 10,
+        pair23: 20,
+        only1: 4,
+        only2: 9,
+        only3: 13
+      },
+      MIN: {
+        common1: 1,
+        common2: 2,
+        pair12: 3,
+        pair23: 8,
+        only1: 4,
+        only2: 9,
+        only3: 13
+      },
+      MAX: {
+        common1: 7,
+        common2: 10,
+        pair12: 7,
+        pair23: 12,
+        only1: 4,
+        only2: 9,
+        only3: 13
+      }
+    };
+
+    const aggregators = ['SUM', 'MIN', 'MAX'] as const;
+    for (const aggregate of aggregators) {
+      const destination = `{tag}zunionstore-other-destination-${aggregate}`;
+      assert.equal(
+        await client.zUnionStore(destination, keys, {
+          AGGREGATE: aggregate
+        }),
+        7
+      );
+
+      const result = await client.zRangeWithScores(destination, 0, -1);
+      assert.deepEqual(
+        Object.fromEntries(result.map(({ value, score }) => [value.toString(), score])),
+        expectedByAggregate[aggregate]
+      );
+    }
   }, {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN

--- a/packages/client/lib/commands/ZUNIONSTORE.ts
+++ b/packages/client/lib/commands/ZUNIONSTORE.ts
@@ -3,7 +3,8 @@ import { RedisArgument, NumberReply, Command, } from '../RESP/types';
 import { ZKeys, parseZKeysArguments } from './generic-transformers';
 
 export interface ZUnionOptions {
-  AGGREGATE?: 'SUM' | 'MIN' | 'MAX';
+  /** `COUNT` added in 8.8 */
+  AGGREGATE?: 'SUM' | 'MIN' | 'MAX' | 'COUNT';
 }
 
 export default {

--- a/packages/client/lib/commands/ZUNIONSTORE.ts
+++ b/packages/client/lib/commands/ZUNIONSTORE.ts
@@ -1,11 +1,7 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command, } from '../RESP/types';
 import { ZKeys, parseZKeysArguments } from './generic-transformers';
-
-export interface ZUnionOptions {
-  /** `COUNT` added in 8.8 */
-  AGGREGATE?: 'SUM' | 'MIN' | 'MAX' | 'COUNT';
-}
+import { ZUnionOptions } from './ZUNION';
 
 export default {
   IS_READ_ONLY: false,

--- a/packages/client/lib/commands/ZUNION_WITHSCORES.spec.ts
+++ b/packages/client/lib/commands/ZUNION_WITHSCORES.spec.ts
@@ -52,6 +52,15 @@ describe('ZUNION WITHSCORES', () => {
         ['ZUNION', '1', 'key', 'AGGREGATE', 'SUM', 'WITHSCORES']
       );
     });
+
+    it('with AGGREGATE COUNT', () => {
+      assert.deepEqual(
+        parseArgs(ZUNION_WITHSCORES, 'key', {
+          AGGREGATE: 'COUNT'
+        }),
+        ['ZUNION', '1', 'key', 'AGGREGATE', 'COUNT', 'WITHSCORES']
+      );
+    });
   });
 
   testUtils.testAll('zUnionWithScores', async client => {
@@ -59,6 +68,135 @@ describe('ZUNION WITHSCORES', () => {
       await client.zUnionWithScores('key'),
       []
     );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('zUnionWithScores with AGGREGATE COUNT', async client => {
+    const keys = [
+      '{tag}zunionws-count-1',
+      '{tag}zunionws-count-2',
+      '{tag}zunionws-count-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 2 },
+        { value: 'pair12', score: 3 },
+        { value: 'only1', score: 4 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 5 },
+        { value: 'common2', score: 6 },
+        { value: 'pair12', score: 7 },
+        { value: 'pair23', score: 8 },
+        { value: 'only2', score: 9 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 10 },
+        { value: 'common2', score: 11 },
+        { value: 'pair23', score: 12 },
+        { value: 'only3', score: 13 }
+      ])
+    ]);
+
+    const result = await client.zUnionWithScores(keys, {
+      AGGREGATE: 'COUNT'
+    });
+
+    assert.deepEqual(
+      Object.fromEntries(result.map(({ value, score }) => [value.toString(), score])),
+      {
+        common1: 3,
+        common2: 3,
+        only1: 1,
+        only2: 1,
+        only3: 1,
+        pair12: 2,
+        pair23: 2
+      }
+    );
+
+    const scores = result.map(item => item.score);
+    assert.equal(Math.min(...scores), 1);
+    assert.equal(Math.max(...scores), 3);
+  }, {
+    client: { ...GLOBAL.SERVERS.OPEN, minimumDockerVersion: [8, 8] },
+    cluster: { ...GLOBAL.CLUSTERS.OPEN, minimumDockerVersion: [8, 8] }
+  });
+
+  testUtils.testAll('zUnionWithScores with AGGREGATE SUM, MIN, MAX', async client => {
+    const keys = [
+      '{tag}zunionws-other-1',
+      '{tag}zunionws-other-2',
+      '{tag}zunionws-other-3'
+    ];
+
+    await Promise.all([
+      client.zAdd(keys[0], [
+        { value: 'common1', score: 1 },
+        { value: 'common2', score: 10 },
+        { value: 'pair12', score: 3 },
+        { value: 'only1', score: 4 }
+      ]),
+      client.zAdd(keys[1], [
+        { value: 'common1', score: 5 },
+        { value: 'common2', score: 2 },
+        { value: 'pair12', score: 7 },
+        { value: 'pair23', score: 8 },
+        { value: 'only2', score: 9 }
+      ]),
+      client.zAdd(keys[2], [
+        { value: 'common1', score: 7 },
+        { value: 'common2', score: 4 },
+        { value: 'pair23', score: 12 },
+        { value: 'only3', score: 13 }
+      ])
+    ]);
+
+    const expectedByAggregate = {
+      SUM: {
+        common1: 13,
+        common2: 16,
+        pair12: 10,
+        pair23: 20,
+        only1: 4,
+        only2: 9,
+        only3: 13
+      },
+      MIN: {
+        common1: 1,
+        common2: 2,
+        pair12: 3,
+        pair23: 8,
+        only1: 4,
+        only2: 9,
+        only3: 13
+      },
+      MAX: {
+        common1: 7,
+        common2: 10,
+        pair12: 7,
+        pair23: 12,
+        only1: 4,
+        only2: 9,
+        only3: 13
+      }
+    };
+
+    const aggregators = ['SUM', 'MIN', 'MAX'] as const;
+    for (const aggregate of aggregators) {
+      const result = await client.zUnionWithScores(keys, {
+        AGGREGATE: aggregate
+      });
+
+      assert.deepEqual(
+        Object.fromEntries(result.map(({ value, score }) => [value.toString(), score])),
+        expectedByAggregate[aggregate]
+      );
+    }
   }, {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN


### PR DESCRIPTION


### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive API surface change (TypeScript union type widening) with extensive new tests; runtime behavior is limited to passing through an additional string to Redis on opt-in.
> 
> **Overview**
> Adds support for Redis 8.8’s `AGGREGATE COUNT` option across `ZINTER`, `ZINTERSTORE`, `ZINTER WITHSCORES`, `ZUNION`, `ZUNIONSTORE`, and `ZUNION WITHSCORES` by widening the options types and reusing `ZUNION`’s option type in `ZUNIONSTORE`.
> 
> Expands the test suite with argument-parsing assertions and integration tests (gated behind `minimumDockerVersion: [8, 8]`) to validate `COUNT` behavior and to ensure existing `SUM`/`MIN`/`MAX` aggregations still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff15eec04210e9367a19061e91e5b8b557cc9932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->