### PR TITLE
docs: fix scan iterator example pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ You can override the default options by providing a configuration object:
 ```typescript
 client.scanIterator({
   TYPE: "string", // `SCAN` only
-  MATCH: "patter*",
+  MATCH: "pattern*",
   COUNT: 100,
 });
 ```


### PR DESCRIPTION
### Description

Fix the scan iterator example to use `pattern*` instead of `patter*` in the README.

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Validation

- Ran `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change correcting a typo in the `scanIterator` example; no runtime behavior is affected.
> 
> **Overview**
> Fixes a typo in the README `scanIterator` options example by correcting the `MATCH` glob from `patter*` to `pattern*`, so the docs show a valid key pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b300d5422d65607e2e527ba8fe987ce87e4d8ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->