### PR TITLE
docs: fix built-in wording in migration guide

### DIFF
--- a/docs/v4-to-v5.md
+++ b/docs/v4-to-v5.md
@@ -4,7 +4,7 @@
 
 ### Keep Alive
 
-To better align with Node.js build-in [`net`](https://nodejs.org/api/net.html) and [`tls`](https://nodejs.org/api/tls.html) modules, the `keepAlive` option has been split into 2 options: `keepAlive` (`boolean`) and `keepAliveInitialDelay` (`number`). The defaults remain `true` and `5000`.
+To better align with Node.js built-in [`net`](https://nodejs.org/api/net.html) and [`tls`](https://nodejs.org/api/tls.html) modules, the `keepAlive` option has been split into 2 options: `keepAlive` (`boolean`) and `keepAliveInitialDelay` (`number`). The defaults remain `true` and `5000`.
 
 ### Legacy Mode
 


### PR DESCRIPTION
### Description

Replace "build-in" with "built-in" in the v4-to-v5 migration guide.

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Validation

- Ran `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that fixes a typo with no effect on runtime behavior.
> 
> **Overview**
> Fixes a typo in the v4-to-v5 migration guide by correcting “build-in” to **“built-in”** in the Keep Alive section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0d2ad02c4a86bf6c4964af0ec5989a96e8849f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->