### PR TITLE
docs: fix dump-and-restore example comment

### DIFF
--- a/examples/dump-and-restore.js
+++ b/examples/dump-and-restore.js
@@ -15,7 +15,7 @@ const client = await createClient({
 // Make sure the source key exists
 await client.set('source', 'value');
 
-// Make sure destination doesnt exist
+// Make sure destination doesn't exist
 await client.del('destination');
 
 // DUMP a specific key into a local variable


### PR DESCRIPTION
### Description
- fix `doesnt` in the `dump-and-restore` example comment
- keep the change limited to a single example file

### Checklist
- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

Tests not run; this is a comment-only example fix.
