### PR TITLE
docs: fix cluster client comment typo

### DIFF
--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -704,7 +704,7 @@ export default class RedisCluster<
 
   /**
    * Returns a random node from the cluster.
-   * Userful for running "forward" commands (like PUBLISH) on a random node.
+   * Useful for running "forward" commands (like PUBLISH) on a random node.
    */
   getRandomNode() {
     return this._self._slots.getRandomNode();


### PR DESCRIPTION
### Description
- fix `Userful` in the cluster client comment
- keep the change limited to a single source comment

### Checklist
- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

Tests not run; this is a comment-only source fix.
