### PR TITLE
docs: fix enterprise maintenance comment typo

### DIFF
--- a/packages/client/lib/client/enterprise-maintenance-manager.ts
+++ b/packages/client/lib/client/enterprise-maintenance-manager.ts
@@ -324,7 +324,7 @@ export default class EnterpriseMaintenanceManager {
   };
 
   #onMigrated = () => {
-    //ensure that #isMaintenance doesnt go under 0
+    //ensure that #isMaintenance doesn't go under 0
     this.#isMaintenance = Math.max(this.#isMaintenance - 1, 0);
     if (this.#isMaintenance > 0) {
       dbgMaintenance(`Not ready to unrelax timeouts yet`);


### PR DESCRIPTION
### Description
- fix `doesnt` in the enterprise maintenance manager comment
- keep the change limited to a single source comment

### Checklist
- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

Tests not run; this is a comment-only source fix.
