### PR TITLE
fix(otel): record client connection errors

### DIFF
--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -125,6 +125,12 @@ export default class RedisSocket extends EventEmitter {
           }
           return retryIn;
         } catch (err) {
+          publish(CHANNELS.ERROR, () => ({
+            error: err as Error,
+            origin: 'client',
+            internal: false,
+            clientId: this.#clientId
+          }));
           this.emit('error', err);
           return this.defaultReconnectStrategy(retries, err);
         }
@@ -142,15 +148,15 @@ export default class RedisSocket extends EventEmitter {
         port: options?.port ?? 6379,
         // https://nodejs.org/api/tls.html#tlsconnectoptions-callback "Any socket.connect() option not already listed"
         // @types/node is... incorrect...
-        // @ts-expect-error
+        // @ts-expect-error - @types/node omits socket.connect noDelay.
         noDelay: options?.noDelay ?? true,
         // https://nodejs.org/api/tls.html#tlsconnectoptions-callback "Any socket.connect() option not already listed"
         // @types/node is... incorrect...
-        // @ts-expect-error
+        // @ts-expect-error - @types/node omits socket.connect keepAlive.
         keepAlive: options?.keepAlive ?? true,
         // https://nodejs.org/api/tls.html#tlsconnectoptions-callback "Any socket.connect() option not already listed"
         // @types/node is... incorrect...
-        // @ts-expect-error
+        // @ts-expect-error - @types/node omits socket.connect keepAliveInitialDelay.
         keepAliveInitialDelay: options?.keepAliveInitialDelay ?? 5000,
         timeout: undefined,
         onread: undefined,
@@ -206,10 +212,22 @@ export default class RedisSocket extends EventEmitter {
     const retryIn = this.#reconnectStrategy(retries, cause);
     if (retryIn === false) {
       this.#isOpen = false;
+      publish(CHANNELS.ERROR, () => ({
+        error: cause,
+        origin: 'client',
+        internal: false,
+        clientId: this.#clientId
+      }));
       this.emit('error', cause);
       return cause;
     } else if (retryIn instanceof Error) {
       this.#isOpen = false;
+      publish(CHANNELS.ERROR, () => ({
+        error: cause,
+        origin: 'client',
+        internal: false,
+        clientId: this.#clientId
+      }));
       this.emit('error', cause);
       return new ReconnectStrategyError(retryIn, cause);
     }
@@ -265,6 +283,12 @@ export default class RedisSocket extends EventEmitter {
           throw retryIn;
         }
 
+        publish(CHANNELS.ERROR, () => ({
+          error: err as Error,
+          origin: 'client',
+          internal: false,
+          clientId: this.#clientId
+        }));
         this.emit('error', err);
         await setTimeout(retryIn);
         this.emit('reconnecting');
@@ -335,6 +359,12 @@ export default class RedisSocket extends EventEmitter {
   #onSocketError(err: Error): void {
     const wasReady = this.#isReady;
     this.#isReady = false;
+    publish(CHANNELS.ERROR, () => ({
+      error: err,
+      origin: 'client',
+      internal: false,
+      clientId: this.#clientId
+    }));
     this.emit('error', err);
 
     if (wasReady) {

--- a/packages/client/lib/opentelemetry/metrics.spec.ts
+++ b/packages/client/lib/opentelemetry/metrics.spec.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from "node:assert";
+import dc from "node:diagnostics_channel";
 
 import * as api from "@opentelemetry/api";
 import {
@@ -12,7 +13,6 @@ import {
 import { createClient } from "@redis/client/index";
 import { OTelMetrics } from "./metrics";
 import {
-  METRIC_ERROR_ORIGIN,
   CONNECTION_CLOSE_REASON,
   CSC_EVICTION_REASON,
   CSC_RESULT,
@@ -58,7 +58,6 @@ describe("OTel Metrics Unit Tests", () => {
     });
 
     // Emit TC events for GET (excluded) and SET (included)
-    const dc = require("node:diagnostics_channel");
     const getCtx = { command: "GET", clientId: "test" };
     dc.channel("tracing:node-redis:command:start").publish(getCtx);
     dc.channel("tracing:node-redis:command:asyncEnd").publish(getCtx);
@@ -102,7 +101,6 @@ describe("OTel Metrics Unit Tests", () => {
       },
     });
 
-    const dc = require("node:diagnostics_channel");
     const getCtx = { command: "GET", clientId: "test" };
     dc.channel("tracing:node-redis:command:start").publish(getCtx);
     dc.channel("tracing:node-redis:command:asyncEnd").publish(getCtx);
@@ -146,7 +144,6 @@ describe("OTel Metrics Unit Tests", () => {
       },
     });
 
-    const dc = require("node:diagnostics_channel");
     const ctx = { command: "SET", clientId: "test" };
     dc.channel("tracing:node-redis:command:start").publish(ctx);
     dc.channel("tracing:node-redis:command:asyncEnd").publish(ctx);
@@ -183,7 +180,6 @@ describe("OTel Metrics Unit Tests", () => {
       },
     });
 
-    const dc = require("node:diagnostics_channel");
     const ctx = { command: "SET", clientId: "test" };
     dc.channel("tracing:node-redis:command:start").publish(ctx);
     dc.channel("tracing:node-redis:command:asyncEnd").publish(ctx);
@@ -198,7 +194,7 @@ describe("OTel Metrics Unit Tests", () => {
     // No data points should exist — SET is excluded
     const dataPoints = metric?.dataPoints ?? [];
     assert.ok(
-      !dataPoints.some((dp: any) => dp.attributes[OTEL_ATTRIBUTES.dbOperationName] === "SET"),
+      !dataPoints.some((dp) => dp.attributes[OTEL_ATTRIBUTES.dbOperationName] === "SET"),
       "expected excludeCommands to take precedence over includeCommands",
     );
 
@@ -221,8 +217,6 @@ describe("OTel Metrics Unit Tests", () => {
         },
       },
     });
-
-    const dc = require("node:diagnostics_channel");
 
     // Client-origin MOVED — should be deduplicated (not recorded)
     dc.channel("node-redis:error").publish({
@@ -272,6 +266,62 @@ describe("OTel Metrics Unit Tests", () => {
     await meterProvider.shutdown().catch(() => {});
     api.metrics.disable();
   });
+
+  it("should record Redis client connection errors", async () => {
+    const exporter = new InMemoryMetricExporter(
+      AggregationTemporality.CUMULATIVE,
+    );
+    const reader = new PeriodicExportingMetricReader({ exporter });
+    const meterProvider = new MeterProvider({ readers: [reader] });
+
+    OTelMetrics.init({
+      api,
+      config: {
+        metrics: {
+          enabled: true,
+          enabledMetricGroups: ["resiliency"],
+          meterProvider,
+        },
+      },
+    });
+
+    const client = createClient({
+      socket: {
+        host: "error",
+        connectTimeout: 1,
+        reconnectStrategy: false,
+      },
+    });
+    client.on("error", () => {
+      // ignore expected connection error
+    });
+
+    await assert.rejects(client.connect());
+
+    await meterProvider.forceFlush();
+
+    const dataPoints = getMetricDataPoints<api.Counter>(
+      exporter.getMetrics(),
+      METRIC_NAMES.redisClientErrors,
+    );
+
+    assert.strictEqual(dataPoints[0].value, 1);
+    assert.strictEqual(
+      dataPoints[0].attributes[OTEL_ATTRIBUTES.redisClientErrorsCategory],
+      ERROR_CATEGORY.NETWORK,
+    );
+    assert.strictEqual(
+      dataPoints[0].attributes[OTEL_ATTRIBUTES.redisClientErrorsInternal],
+      false,
+    );
+
+    await reader.collect().catch(() => {});
+    await meterProvider.shutdown().catch(() => {});
+    if (client.isOpen) {
+      client.destroy();
+    }
+    api.metrics.disable();
+  });
 });
 
 describe("OTel Metrics E2E", function () {
@@ -317,7 +367,6 @@ describe("OTel Metrics E2E", function () {
 
     OTelMetrics.init({ api, config });
 
-    const dc = require("node:diagnostics_channel");
     dc.channel("node-redis:error").publish({
       error: new Error("Test error 1"),
       origin: "client",
@@ -359,7 +408,6 @@ describe("OTel Metrics E2E", function () {
 
     OTelMetrics.init({ api, config });
 
-    const dc = require("node:diagnostics_channel");
     dc.channel("node-redis:error").publish({
       error: new Error("Test error 1"),
       origin: "client",
@@ -407,7 +455,6 @@ describe("OTel Metrics E2E", function () {
       isConnected: () => true,
     });
 
-    const dc = require("node:diagnostics_channel");
     dc.channel("node-redis:error").publish({
       error: new Error("Test error"),
       origin: "client",
@@ -448,7 +495,6 @@ describe("OTel Metrics E2E", function () {
       },
     });
 
-    const dc = require("node:diagnostics_channel");
     dc.channel("node-redis:error").publish({
       error: new Error("Test error"),
       origin: "client",
@@ -677,8 +723,6 @@ describe("OTel Metrics E2E", function () {
           assert.ok(attributes[OTEL_ATTRIBUTES.serverPort]);
           assert.ok(attributes[OTEL_ATTRIBUTES.redisClientLibrary]);
           assert.ok(attributes[OTEL_ATTRIBUTES.dbSystemName]);
-        } catch (error) {
-          throw error;
         } finally {
           await client.destroy();
         }
@@ -716,8 +760,6 @@ describe("OTel Metrics E2E", function () {
           assert.ok(attributes[OTEL_ATTRIBUTES.dbClientConnectionPoolName]);
           assert.ok(attributes[OTEL_ATTRIBUTES.redisClientLibrary]);
           assert.ok(attributes[OTEL_ATTRIBUTES.dbSystemName]);
-        } catch (error) {
-          throw error;
         } finally {
           await client.destroy();
         }
@@ -1742,7 +1784,6 @@ describe("OTel Metrics E2E", function () {
     );
 
     it("should ignore malformed stream replies without emitting redis.client.stream.lag", async () => {
-      const dc = require("node:diagnostics_channel");
       dc.channel("node-redis:command:reply").publish({
         args: ["XREADGROUP", "GROUP", "group-1", "consumer-1"],
         reply: undefined,


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core socket error/reconnect paths and increases diagnostics-channel error publishing, which could affect error reporting volume and downstream telemetry behavior, but changes are additive and covered by a new metric test.
> 
> **Overview**
> **Client connection failures are now observable via OTel error metrics.** The socket layer (`client/socket.ts`) now publishes `CHANNELS.ERROR` events (with `clientId`, `origin`, `internal`) when reconnect strategy evaluation fails, when reconnect is aborted/returns an error, during connect retry loops, and on socket `'error'` events.
> 
> Tests in `opentelemetry/metrics.spec.ts` are updated to use a single `diagnostics_channel` import and add a new unit test asserting that a failed `client.connect()` (with `reconnectStrategy: false`) increments `redisClientErrors` with the expected *network* category and `internal=false` attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf8152ad6c273af541ce749a1e518e8f1022bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->