### PR TITLE
chore(tests): bump default docker test image to 8.8-m03

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
             version: "8.2"
           - tag: "8.4.0"
             version: "8.4"
-          - tag: "8.8-m02"
+          - tag: "8.8-m03"
             version: "8.8"
     steps:
       - uses: actions/checkout@v4

--- a/packages/bloom/lib/test-utils.ts
+++ b/packages/bloom/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default  TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8-m02', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8-m03', version: '8.8' }
 });
 
 export const GLOBAL = {

--- a/packages/client/lib/sentinel/test-util.ts
+++ b/packages/client/lib/sentinel/test-util.ts
@@ -175,7 +175,7 @@ export class SentinelFramework extends DockerBase {
       dockerImageName: 'redislabs/client-libs-test',
       dockerImageTagArgument: 'redis-tag',
       dockerImageVersionArgument: 'redis-version',
-      defaultDockerVersion: { tag: '8.8-m02', version: '8.8' }
+      defaultDockerVersion: { tag: '8.8-m03', version: '8.8' }
     });
     this.#nodeMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelNodes']>>>>();
     this.#sentinelMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelSentinels']>>>>();

--- a/packages/client/lib/sentinel/test-util.ts
+++ b/packages/client/lib/sentinel/test-util.ts
@@ -4,9 +4,9 @@ import { once } from 'node:events';
 import { promisify } from 'node:util';
 import { exec } from 'node:child_process';
 import { RedisSentinelOptions, RedisSentinelType } from './types';
-import RedisClient, {RedisClientType} from '../client';
+import RedisClient from '../client';
 import RedisSentinel from '.';
-import { RedisArgument, RedisFunctions, RedisModules, RedisScripts, RespVersions, TypeMapping } from '../RESP/types';
+import { RedisFunctions, RedisModules, RedisScripts, RespVersions, TypeMapping } from '../RESP/types';
 const execAsync = promisify(exec);
 import RedisSentinelModule from './module'
 import TestUtils from '@redis/test-utils';
@@ -16,7 +16,7 @@ interface ErrorWithCode extends Error {
 }
 
 async function isPortAvailable(port: number): Promise<boolean> {
-  var socket: Socket | undefined = undefined;
+  let socket: Socket | undefined = undefined;
   try {
     socket = createConnection({ port });
     await once(socket, 'connect');
@@ -81,7 +81,7 @@ abstract class DockerBase {
 
   async dockerRemove(dockerId: string): Promise<void> {
     try {
-      await this.dockerStop(dockerId); ``
+      await this.dockerStop(dockerId);
     } catch (err) {
       // its ok if stop failed, as we are just going to remove, will just be slower
       console.log(`dockerStop failed in remove: ${err}`);
@@ -98,11 +98,11 @@ abstract class DockerBase {
     /* this is an optimization to get around slow docker stop times, but will fail if container is already stopped */
     try {
       await execAsync(`docker exec ${dockerId} /bin/bash -c "kill -SIGINT 1"`);
-    } catch (err) {
+    } catch (_) {
       /* this will fail if container is already not running, can be ignored */
     }
 
-    let ret = await execAsync(`docker stop ${dockerId}`);
+    const ret = await execAsync(`docker stop ${dockerId}`);
     if (ret.stderr) {
       throw new Error(`docker stop error - ${ret.stderr}`);
     }
@@ -147,7 +147,7 @@ export interface SentinelController {
   restartNode(id: string): Promise<void>;
   stopSentinel(id: string): Promise<void>;
   restartSentinel(id: string): Promise<void>;
-  getSentinelClient(opts?: Partial<RedisSentinelOptions<{}, {}, {}, 2, {}>>): RedisSentinelType<{}, {}, {}, 2, {}>;
+  getSentinelClient(opts?: Partial<RedisSentinelOptions<RedisModules, RedisFunctions, RedisScripts, 2, TypeMapping>>): RedisSentinelType<RedisModules, RedisFunctions, RedisScripts, 2, TypeMapping>;
 }
 
 export class SentinelFramework extends DockerBase {
@@ -378,8 +378,7 @@ export class SentinelFramework extends DockerBase {
   }
 
   async stopNode(id: string) {
-//    console.log(`stopping node ${id}`);
-    let node = this.#nodeMap.get(id);
+    const node = this.#nodeMap.get(id);
     if (node === undefined) {
       throw new Error("unknown node: " + id);
     }
@@ -388,7 +387,7 @@ export class SentinelFramework extends DockerBase {
   }
 
   async restartNode(id: string) {
-    let node = this.#nodeMap.get(id);
+    const node = this.#nodeMap.get(id);
     if (node === undefined) {
       throw new Error("unknown node: " + id);
     }
@@ -397,7 +396,7 @@ export class SentinelFramework extends DockerBase {
   }
 
   async stopSentinel(id: string) {
-    let sentinel = this.#sentinelMap.get(id);
+    const sentinel = this.#sentinelMap.get(id);
     if (sentinel === undefined) {
       throw new Error("unknown sentinel: " + id);
     }
@@ -406,7 +405,7 @@ export class SentinelFramework extends DockerBase {
   }
 
   async restartSentinel(id: string) {
-    let sentinel = this.#sentinelMap.get(id);
+    const sentinel = this.#sentinelMap.get(id);
     if (sentinel === undefined) {
       throw new Error("unknown sentinel: " + id);
     }
@@ -415,7 +414,7 @@ export class SentinelFramework extends DockerBase {
   }
 
   getNodePort(id: string) {
-    let node = this.#nodeMap.get(id);
+    const node = this.#nodeMap.get(id);
     if (node === undefined) {
       throw new Error("unknown node: " + id);
     }
@@ -424,7 +423,7 @@ export class SentinelFramework extends DockerBase {
   }
 
   getAllNodesPort() {
-    let ports: Array<number> = [];
+    const ports: Array<number> = [];
     for (const node of this.#nodeList) {
       ports.push(node.port);
     }
@@ -433,7 +432,7 @@ export class SentinelFramework extends DockerBase {
   }
 
   getAllDockerIds() {
-    let ids = new Map<string, number>();
+    const ids = new Map<string, number>();
     for (const node of this.#nodeList) {
       ids.set(node.dockerId, node.port);
     }
@@ -442,7 +441,7 @@ export class SentinelFramework extends DockerBase {
   }
 
   getSentinelPort(id: string) {
-    let sentinel = this.#sentinelMap.get(id);
+    const sentinel = this.#sentinelMap.get(id);
     if (sentinel === undefined) {
       throw new Error("unknown sentinel: " + id);
     }
@@ -451,7 +450,7 @@ export class SentinelFramework extends DockerBase {
   }
 
   getAllSentinelsPort() {
-    let ports: Array<number> = [];
+    const ports: Array<number> = [];
     for (const sentinel of this.#sentinelList) {
       ports.push(sentinel.port);
     }

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -10,7 +10,7 @@ const utils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8-m02', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8-m03', version: '8.8' }
 });
 
 export default utils;

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -29,7 +29,7 @@ const streamingCredentialsProvider: CredentialsProvider =
   {
     type: 'streaming-credentials-provider',
 
-    subscribe : (observable) => ( Promise.resolve([
+    subscribe : (_) => ( Promise.resolve([
      { password: 'password' },
       {
        dispose: () => {
@@ -192,7 +192,7 @@ export const BLOCKING_MIN_VALUE = (
   1
 );
 
-export function parseFirstKey(command: Command, ...args: Array<any>) {
+export function parseFirstKey(command: Command, ...args: Array<unknown>) {
   const parser = new BasicCommandParser();
   command.parseCommand!(parser, ...args);
   return parser.firstKey;

--- a/packages/entraid/lib/test-utils.ts
+++ b/packages/entraid/lib/test-utils.ts
@@ -16,12 +16,11 @@ const DEBUG_MODE_ARGS = testUtils.isVersionGreaterThan([7]) ?
 
 const idp: IdentityProvider<AuthenticationResult> = {
   requestToken(): Promise<TokenResponse<AuthenticationResult>> {
-    // @ts-ignore
     return Promise.resolve({
       ttlMs: 100000,
       token: {
         accessToken: 'password'
-      }
+      } as AuthenticationResult
     })
   }
 }

--- a/packages/entraid/lib/test-utils.ts
+++ b/packages/entraid/lib/test-utils.ts
@@ -7,7 +7,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8-m02', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8-m03', version: '8.8' }
 });
 
 const DEBUG_MODE_ARGS = testUtils.isVersionGreaterThan([7]) ?

--- a/packages/json/lib/test-utils.ts
+++ b/packages/json/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8-m02', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8-m03', version: '8.8' }
 });
 
 export const GLOBAL = {

--- a/packages/search/lib/test-utils.ts
+++ b/packages/search/lib/test-utils.ts
@@ -6,7 +6,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8-m02', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8-m03', version: '8.8' }
 });
 
 export const GLOBAL = {

--- a/packages/test-utils/lib/test-utils.ts
+++ b/packages/test-utils/lib/test-utils.ts
@@ -4,7 +4,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8-m02', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8-m03', version: '8.8' }
 });
 
 

--- a/packages/time-series/lib/test-utils.ts
+++ b/packages/time-series/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8-m02', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8-m03', version: '8.8' }
 });
 
 export const GLOBAL = {


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a test-environment version bump plus small typing/cleanup changes; risk is limited to potential test behavior differences in the newer Redis 8.8 milestone image.
> 
> **Overview**
> Updates the CI Redis version matrix and all package `TestUtils.createFromConfig` defaults from `8.8-m02` to `8.8-m03`, so tests run against the newer 8.8 milestone image by default.
> 
> Also includes minor test-utility TypeScript hygiene fixes (sentinel test util import/type tightening, removing stray characters, `var`→`let/const`, ignoring unused params, and narrowing `parseFirstKey` args to `unknown`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e0b9cd8b0cba2b8a1ad8cc0a7ed431d426291af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->