### PR TITLE
chore(lint): allow empty object types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,9 @@ export default [
         argsIgnorePattern: '^_',
         caughtErrorsIgnorePattern: '^_',
         varsIgnorePattern: '^_'
+      }],
+      '@typescript-eslint/no-empty-object-type': ['error', {
+        allowObjectTypes: 'always'
       }]
     }
   },


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it relaxes a TypeScript lint rule and could allow some previously-flagged empty object type usages to pass unnoticed.
> 
> **Overview**
> Updates `eslint.config.mjs` to enforce `@typescript-eslint/no-empty-object-type` while explicitly allowing object type forms (`allowObjectTypes: 'always'`) for TypeScript files, adjusting the TypeScript lint rule set without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd43cfdc7d93c0d1451c39b32ec0e2392afd65fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->