### PR TITLE
test(client): add hash field subkey notifications test

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -9,6 +9,7 @@ import { MATH_FUNCTION, loadMathFunction } from '../commands/FUNCTION_LOAD.spec'
 import { RESP_TYPES } from '../RESP/decoder';
 import { BlobStringReply, NumberReply } from '../RESP/types';
 import { SortedSetMember } from '../commands/generic-transformers';
+import { HASH_EXPIRATION } from '../commands/HEXPIRE';
 import { CommandParser } from './parser';
 import { RedisSocketOptions } from './socket';
 import { getFreePortNumber } from '@redis/test-utils/lib/proxy/redis-proxy';
@@ -973,6 +974,94 @@ describe('Client', () => {
 
       assert.equal(client.isOpen, false);
     }, GLOBAL.SERVERS.OPEN);
+
+    testUtils.testWithClientIfVersionWithinRange([[8, 8], 'LATEST'],
+      'should receive hash field subkey notifications',
+      async client => {
+        const subscriber = await client.duplicate().connect();
+        try {
+          const previousNotifyConfig =
+            (await client.configGet('notify-keyspace-events'))['notify-keyspace-events'];
+          await client.configSet('notify-keyspace-events', 'STIVh');
+
+          try {
+            const HASH_KEY = 'skn:hash';
+            const FIELD = 'field-alpha';
+            const HEXPIRE_CHANNEL = '__subkeyevent@0__:hexpire';
+            const EXPIRED_CHANNEL = '__subkeyevent@0__:hexpired';
+            const SUBKEYSPACEITEM_CHANNEL = `__subkeyspaceitem@0__:${HASH_KEY}\n${FIELD}`;
+            const SUBKEYSPACEEVENT_HEXPIRE_CHANNEL = `__subkeyspaceevent@0__:hexpire|${HASH_KEY}`;
+            const SUBKEYSPACEEVENT_EXPIRED_CHANNEL = `__subkeyspaceevent@0__:hexpired|${HASH_KEY}`;
+            const SUBKEYEVENT_PAYLOAD = '8:skn:hash|11:field-alpha';
+            const SUBKEYSPACEEVENT_PAYLOAD = '11:field-alpha';
+
+            await client.del(HASH_KEY);
+
+            const expected = new Map<string, Set<string>>([
+              [HEXPIRE_CHANNEL, new Set([SUBKEYEVENT_PAYLOAD])],
+              [EXPIRED_CHANNEL, new Set([SUBKEYEVENT_PAYLOAD])],
+              [SUBKEYSPACEITEM_CHANNEL, new Set(['hexpire', 'hexpired'])],
+              [SUBKEYSPACEEVENT_HEXPIRE_CHANNEL, new Set([SUBKEYSPACEEVENT_PAYLOAD])],
+              [SUBKEYSPACEEVENT_EXPIRED_CHANNEL, new Set([SUBKEYSPACEEVENT_PAYLOAD])]
+            ]);
+            const received = new Map<string, Set<string>>();
+            const totalExpected = [...expected.values()].reduce((n, s) => n + s.size, 0);
+            let totalReceived = 0;
+
+            let resolveAll!: () => void;
+            let rejectAll!: (err: Error) => void;
+            const allReceived = new Promise<void>((resolve, reject) => {
+              resolveAll = resolve;
+              rejectAll = reject;
+            });
+            const timer = setTimeout(
+              () => rejectAll(new Error('Timed out waiting for hash subkey notifications')),
+              10_000
+            );
+
+            const listener = (message: string, channel: string) => {
+              const expectedForChannel = expected.get(channel);
+              if (!expectedForChannel || !expectedForChannel.has(message)) return;
+              let bucket = received.get(channel);
+              if (!bucket) {
+                bucket = new Set();
+                received.set(channel, bucket);
+              }
+              if (bucket.has(message)) return;
+              bucket.add(message);
+              totalReceived++;
+              if (totalReceived === totalExpected) {
+                clearTimeout(timer);
+                resolveAll();
+              }
+            };
+
+            await Promise.all([
+              subscriber.subscribe(HEXPIRE_CHANNEL, listener),
+              subscriber.subscribe(EXPIRED_CHANNEL, listener),
+              subscriber.subscribe(SUBKEYSPACEITEM_CHANNEL, listener),
+              subscriber.subscribe(SUBKEYSPACEEVENT_HEXPIRE_CHANNEL, listener),
+              subscriber.subscribe(SUBKEYSPACEEVENT_EXPIRED_CHANNEL, listener)
+            ]);
+
+            await client.hSet(HASH_KEY, FIELD, 'value');
+            assert.deepEqual(
+              await client.hpExpire(HASH_KEY, [FIELD], 50),
+              [HASH_EXPIRATION.UPDATED]
+            );
+
+            await allReceived;
+
+            for (const [channel, payloads] of expected) {
+              assert.deepEqual(received.get(channel), payloads, `mismatch on ${channel}`);
+            }
+          } finally {
+            await client.configSet('notify-keyspace-events', previousNotifyConfig);
+          }
+        } finally {
+          subscriber.destroy();
+        }
+      }, GLOBAL.SERVERS.OPEN);
   });
 
   testUtils.testWithClient('ConnectionTimeoutError', async client => {

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -85,8 +85,8 @@ describe('Client', () => {
       };
 
       // Compare everything except the credentials function
-      const { credentialsProvider: resultCredProvider, ...resultRest } = result;
-      const { credentialsProvider: expectedCredProvider, ...expectedRest } = expected;
+      const { credentialsProvider: _resultCredProvider, ...resultRest } = result;
+      const { credentialsProvider: _expectedCredProvider, ...expectedRest } = expected;
 
       // Compare non-function properties
       assert.deepEqual(resultRest, expectedRest);
@@ -488,7 +488,8 @@ describe('Client', () => {
 
     testUtils.testWithClient('undefined and null should not break the client', async client => {
       await assert.rejects(
-        client.sendCommand([null as any, undefined as any]),
+        // @ts-expect-error testing invalid inputs
+        client.sendCommand([null, undefined]),
         TypeError
       );
 
@@ -625,7 +626,7 @@ describe('Client', () => {
           assert.equal(err.replies.length, 2);
           assert.deepEqual(err.errorIndexes, [1]);
           assert.ok(err.replies[1] instanceof ErrorReply);
-          // @ts-ignore TS2802
+          // @ts-expect-error its fine
           assert.deepEqual([...err.errors()], [err.replies[1]]);
           return true;
         }
@@ -716,8 +717,8 @@ describe('Client', () => {
   });
 
   async function killClient(
-    client: RedisClientType<any, any, any, any, any>,
-    errorClient: RedisClientType<any, any, any, any, any> = client
+    client: RedisClientType<{}, {}, {}, 2, {}>,
+    errorClient: RedisClientType<{}, {}, {}, 2, {}> = client
   ): Promise<void> {
     const onceErrorPromise = once(errorClient, 'error');
     await client.sendCommand(['QUIT']);
@@ -1005,7 +1006,8 @@ describe('Client', () => {
               [SUBKEYSPACEEVENT_EXPIRED_CHANNEL, new Set([SUBKEYSPACEEVENT_PAYLOAD])]
             ]);
             const received = new Map<string, Set<string>>();
-            const totalExpected = [...expected.values()].reduce((n, s) => n + s.size, 0);
+            let totalExpected = 0;
+            expected.forEach(s => totalExpected += s.size);
             let totalReceived = 0;
 
             let resolveAll!: () => void;
@@ -1308,7 +1310,7 @@ describe('Client', () => {
  * This blocks setImmediate callbacks from executing
  */
 async function blockSetImmediate(fn: () => Promise<unknown>) {
-  let setImmediateStub: any;
+  let setImmediateStub: ReturnType<typeof stub> | undefined;
 
   try {
     setImmediateStub = stub(global, 'setImmediate');


### PR DESCRIPTION
Verify that hash field expiration emits the expected subkey-level keyspace and keyevent notifications (hexpire/hexpired) on Redis 8.8+.

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add a Redis 8.8+ PubSub/CONFIG-based integration test; minimal product risk, with the main risk being potential CI flakiness due to timing/event ordering.
> 
> **Overview**
> Adds an integration test (Redis **8.8+ only**) that verifies `HPEXPIRE` on a hash field emits the expected *subkey-level* keyspace/keyevent PubSub notifications (`hexpire`/`hexpired`) across the various `__subkey*__` channels, temporarily toggling `notify-keyspace-events` and asserting received payloads.
> 
> Also tightens a few TypeScript expectations/types in the client tests (e.g., explicit `@ts-expect-error`, more specific `RedisClientType` generics, and a typed `sinon.stub` handle) without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17fc01d205d08d016ee0ea5b05f9b9a0bc5b111f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->