### PR TITLE
ci: lint changed files against PR merge base

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:

--- a/scripts/lint-changed.mjs
+++ b/scripts/lint-changed.mjs
@@ -5,11 +5,12 @@ import { fileURLToPath } from 'node:url';
 /**
  * Incremental lint gate for this monorepo.
  *
- * CI runs this on pull requests and lints only files changed against the PR's
- * base commit, so we can enforce linting on new work without fixing the whole
- * repository at once. Local runs lint staged, unstaged, and untracked files.
+ * CI runs this on pull requests and lints only files changed by the PR, so we
+ * can enforce linting on new work without fixing the whole repository at once.
+ * Local runs lint staged, unstaged, and untracked files.
  *
- * Use `--base <sha-or-ref> [--head <sha-or-ref>]` to reproduce a CI-style diff.
+ * Use `--base <sha-or-ref> [--head <sha-or-ref>]` to reproduce a CI-style
+ * merge-base diff.
  */
 const lintableFilePattern = /\.(?:cjs|js|mjs|ts)$/u;
 const ignoredPathPattern = /(^|\/)(coverage|dist|documentation|junit-results|node_modules)\//u;
@@ -86,15 +87,14 @@ function uniqueLines(output) {
 }
 
 function changedFilesBetween(base, head) {
-  // actions/checkout uses a shallow checkout, so the PR base commit often is
-  // not present locally even though GitHub exposes the SHA in the event JSON.
   ensureCommitAvailable(base);
+  ensureCommitAvailable(head);
+
   return uniqueLines(git([
     'diff',
     '--name-only',
     '--diff-filter=ACMR',
-    base,
-    head
+    `${base}...${head}`
   ]));
 }
 
@@ -112,13 +112,15 @@ function getCandidateFiles(options) {
   }
 
   if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
-    const baseSha = getGitHubEvent().pull_request?.base?.sha;
+    const pullRequest = getGitHubEvent().pull_request;
+    const baseSha = pullRequest?.base?.sha;
+    const headSha = pullRequest?.head?.sha;
 
-    if (!baseSha) {
-      throw new Error('Unable to determine pull request base SHA');
+    if (!baseSha || !headSha) {
+      throw new Error('Unable to determine pull request base and head SHAs');
     }
 
-    return changedFilesBetween(baseSha, options.head);
+    return changedFilesBetween(baseSha, headSha);
   }
 
   return changedFilesInWorkingTree();


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI scripting change; main impact is which files get linted on PRs and it could fail if PR SHAs or git history aren’t available as expected.
> 
> **Overview**
> Updates the PR lint job to use a full git checkout (`fetch-depth: 0`) so merge-base comparisons can be computed reliably.
> 
> Changes `scripts/lint-changed.mjs` to determine changed files on PRs using the GitHub event’s *base and head SHAs* and a merge-base diff (`base...head`), ensuring only PR-introduced files are linted; it also now ensures both commits are present locally before diffing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6fbc01a868def507b4afa26154c5b9ab5027868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->