### PR TITLE
feat(client): add CLIENT UNBLOCK command

### DIFF
--- a/packages/client/index.ts
+++ b/packages/client/index.ts
@@ -35,7 +35,7 @@ export const createSentinel = RedisSentinel.create;
 export { GEO_REPLY_WITH, GeoReplyWith } from './lib/commands/GEOSEARCH_WITH';
 
 
-export { SetOptions, CLIENT_KILL_FILTERS, FAILOVER_MODES, CLUSTER_SLOT_STATES, COMMAND_LIST_FILTER_BY, REDIS_FLUSH_MODES } from './lib/commands'
+export { SetOptions, CLIENT_KILL_FILTERS, CLIENT_UNBLOCK_MODES, FAILOVER_MODES, CLUSTER_SLOT_STATES, COMMAND_LIST_FILTER_BY, REDIS_FLUSH_MODES } from './lib/commands'
 
 export { BasicClientSideCache, BasicPooledClientSideCache } from './lib/client/cache';
 export { OpenTelemetry } from './lib/opentelemetry';

--- a/packages/client/lib/commands/CLIENT_UNBLOCK.spec.ts
+++ b/packages/client/lib/commands/CLIENT_UNBLOCK.spec.ts
@@ -1,0 +1,28 @@
+import { strict as assert } from 'node:assert';
+import CLIENT_UNBLOCK, { CLIENT_UNBLOCK_MODES } from './CLIENT_UNBLOCK';
+import { parseArgs } from './generic-transformers';
+
+describe('CLIENT UNBLOCK', () => {
+  describe('transformArguments', () => {
+    it('simple', () => {
+      assert.deepEqual(
+        parseArgs(CLIENT_UNBLOCK, 1),
+        ['CLIENT', 'UNBLOCK', '1']
+      );
+    });
+
+    it('with string client id', () => {
+      assert.deepEqual(
+        parseArgs(CLIENT_UNBLOCK, '1'),
+        ['CLIENT', 'UNBLOCK', '1']
+      );
+    });
+
+    it('with mode', () => {
+      assert.deepEqual(
+        parseArgs(CLIENT_UNBLOCK, 1, CLIENT_UNBLOCK_MODES.ERROR),
+        ['CLIENT', 'UNBLOCK', '1', 'ERROR']
+      );
+    });
+  });
+});

--- a/packages/client/lib/commands/CLIENT_UNBLOCK.ts
+++ b/packages/client/lib/commands/CLIENT_UNBLOCK.ts
@@ -1,0 +1,26 @@
+import { CommandParser } from '../client/parser';
+import { NumberReply, Command } from '../RESP/types';
+
+export const CLIENT_UNBLOCK_MODES = {
+  TIMEOUT: 'TIMEOUT',
+  ERROR: 'ERROR'
+} as const;
+
+export type ClientUnblockMode = typeof CLIENT_UNBLOCK_MODES[keyof typeof CLIENT_UNBLOCK_MODES];
+
+export default {
+  NOT_KEYED_COMMAND: true,
+  IS_READ_ONLY: true,
+  parseCommand(parser: CommandParser, clientId: number | `${number}`, mode?: ClientUnblockMode) {
+    parser.push(
+      'CLIENT',
+      'UNBLOCK',
+      typeof clientId === 'number' ? clientId.toString() : clientId
+    );
+
+    if (mode) {
+      parser.push(mode);
+    }
+  },
+  transformReply: undefined as unknown as () => NumberReply
+} as const satisfies Command;

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -43,6 +43,7 @@ import CLIENT_PAUSE from './CLIENT_PAUSE';
 import CLIENT_SETNAME from './CLIENT_SETNAME';
 import CLIENT_TRACKING from './CLIENT_TRACKING';
 import CLIENT_TRACKINGINFO from './CLIENT_TRACKINGINFO';
+import CLIENT_UNBLOCK, { CLIENT_UNBLOCK_MODES } from './CLIENT_UNBLOCK';
 import CLIENT_UNPAUSE from './CLIENT_UNPAUSE';
 import CLUSTER_ADDSLOTS from './CLUSTER_ADDSLOTS';
 import CLUSTER_ADDSLOTSRANGE from './CLUSTER_ADDSLOTSRANGE';
@@ -376,6 +377,7 @@ import LATENCY_HISTOGRAM from './LATENCY_HISTOGRAM';
 
 export {
   CLIENT_KILL_FILTERS,
+  CLIENT_UNBLOCK_MODES,
   FAILOVER_MODES,
   CLUSTER_SLOT_STATES,
   COMMAND_LIST_FILTER_BY,
@@ -863,6 +865,18 @@ export default {
    * Returns information about the current connection's key tracking state
    */
   clientTrackingInfo: CLIENT_TRACKINGINFO,
+  /**
+   * Unblocks a client blocked by a blocking command from a different connection
+   * @param clientId - The ID of the client to unblock
+   * @param mode - Optional unblock mode: 'TIMEOUT' or 'ERROR'
+   */
+  CLIENT_UNBLOCK,
+  /**
+   * Unblocks a client blocked by a blocking command from a different connection
+   * @param clientId - The ID of the client to unblock
+   * @param mode - Optional unblock mode: 'TIMEOUT' or 'ERROR'
+   */
+  clientUnblock: CLIENT_UNBLOCK,
   /**
    * Resumes processing of client commands after a CLIENT PAUSE
    */


### PR DESCRIPTION
Closes #1916.

Adds support for the Redis `CLIENT UNBLOCK` command in `@redis/client`.

What changed:
- adds `CLIENT_UNBLOCK` and `clientUnblock`
- supports numeric and string client IDs
- supports optional `TIMEOUT` / `ERROR` modes via `CLIENT_UNBLOCK_MODES`
- exports `CLIENT_UNBLOCK_MODES` from the client package
- adds parse-argument coverage

Validation:
- `$env:TS_NODE_PROJECT='./packages/test-utils/tsconfig.json'; .\node_modules\.bin\mocha.cmd --require ts-node/register/transpile-only packages/client/lib/commands/CLIENT_UNBLOCK.spec.ts`
- `npm run build`
- `npm run lint:changed`

Note: `npm ci` did not run in this Windows/npm setup because the upstream lockfile is not in sync for optional platform packages; I used `npm install --ignore-scripts` for local validation and did not commit dependency metadata changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Redis command wrapper and related exports/tests without changing existing command behavior.
> 
> **Overview**
> Adds support for Redis `CLIENT UNBLOCK` to `@redis/client`, including new `CLIENT_UNBLOCK`/`clientUnblock` command entries and an exported `CLIENT_UNBLOCK_MODES` enum for `TIMEOUT`/`ERROR`.
> 
> The command implementation accepts numeric or numeric-string client IDs, conditionally appends the mode argument, and includes a new unit test covering argument parsing and mode handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671c4b3d2aa5d394d446b569d2d59ed957ba3951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->