### PR TITLE
fix: expose stack modules on pool type

### DIFF
--- a/packages/redis/index.ts
+++ b/packages/redis/index.ts
@@ -45,6 +45,14 @@ export type RedisClientType<
   TYPE_MAPPING extends TypeMapping = {}
 > = GenericRedisClientType<M, F, S, RESP, TYPE_MAPPING>;
 
+export type RedisClientPoolType<
+  M extends RedisModules = RedisDefaultModules,
+  F extends RedisFunctions = {},
+  S extends RedisScripts = {},
+  RESP extends RespVersions = 2,
+  TYPE_MAPPING extends TypeMapping = {}
+> = GenericRedisClientPoolType<M, F, S, RESP, TYPE_MAPPING>;
+
 export function createClient<
   M extends RedisModules,
   F extends RedisFunctions,


### PR DESCRIPTION
## Summary

`createClientPool()` from the `redis` package already injects the default Redis Stack modules, but the package only re-exported `RedisClientPoolType` from `@redis/client`, whose default module set is empty. That meant code annotating a pool as `RedisClientPoolType` lost the `json` and `ft` namespaces.

This adds a `redis` package-level `RedisClientPoolType` alias with the same default module set as `RedisClientType` and `createClientPool()`.

Fixes #3149.

## Validation

- `npm run build`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --lib ES2023 --strict --skipLibCheck --esModuleInterop .tmp-pool-type-test.ts`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only change that adjusts exported typings for `RedisClientPoolType` to match actual module injection behavior; no runtime logic changes.
> 
> **Overview**
> Aligns the `redis` package’s pool typings with `createClientPool()` behavior by adding a package-level `RedisClientPoolType` alias whose default generic module set includes the Redis Stack modules (e.g. `json`, `ft`, `ts`, Bloom).
> 
> This prevents type annotations using `RedisClientPoolType` from losing the Stack module namespaces compared to the existing `RedisClientType`/`createClientPool()` defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a5f0bf47118779494144d3cc42cb8c95bd6375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->