### PR TITLE
feat(client): add WAITAOF command

### DIFF
--- a/packages/client/lib/commands/WAITAOF.spec.ts
+++ b/packages/client/lib/commands/WAITAOF.spec.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import WAITAOF from './WAITAOF';
+import { parseArgs } from './generic-transformers';
+
+describe('WAITAOF', () => {
+  it('transformArguments', () => {
+    assert.deepEqual(
+      parseArgs(WAITAOF, 0, 0, 1),
+      ['WAITAOF', '0', '0', '1']
+    );
+  });
+
+  testUtils.testWithClient('client.waitAof', async client => {
+    assert.deepEqual(
+      await client.waitAof(0, 0, 1),
+      [0, 0]
+    );
+  }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/WAITAOF.ts
+++ b/packages/client/lib/commands/WAITAOF.ts
@@ -1,0 +1,22 @@
+import { CommandParser } from '../client/parser';
+import { ArrayReply, NumberReply, Command } from '../RESP/types';
+
+export default {
+  NOT_KEYED_COMMAND: true,
+  IS_READ_ONLY: true,
+  /**
+   * Blocks the current client until all previous write commands have been
+   * acknowledged by the local Append-Only File and/or the specified number
+   * of replicas, or until the given timeout (in milliseconds) is reached.
+   *
+   * @param parser - The command parser
+   * @param numLocal - Number of local AOF fsyncs to wait for (`0` or `1`)
+   * @param numReplicas - Number of replica AOF fsyncs to wait for
+   * @param timeout - Maximum time to wait in milliseconds (`0` for no timeout)
+   * @see https://redis.io/commands/waitaof/
+   */
+  parseCommand(parser: CommandParser, numLocal: number, numReplicas: number, timeout: number) {
+    parser.push('WAITAOF', numLocal.toString(), numReplicas.toString(), timeout.toString());
+  },
+  transformReply: undefined as unknown as () => ArrayReply<NumberReply>
+} as const satisfies Command;

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -289,6 +289,7 @@ import TTL from './TTL';
 import TYPE from './TYPE';
 import UNLINK from './UNLINK';
 import WAIT from './WAIT';
+import WAITAOF from './WAITAOF';
 import XACK from './XACK';
 import XACKDEL from './XACKDEL';
 import XADD_NOMKSTREAM from './XADD_NOMKSTREAM';
@@ -4271,6 +4272,16 @@ export default {
    */
   WAIT,
   /**
+   * Constructs the WAITAOF command to synchronize with the Append-Only File on the local Redis instance and replicas
+   *
+   * @param numLocal - Number of local AOF fsyncs to wait for (`0` or `1`)
+   * @param numReplicas - Number of replica AOF fsyncs to wait for
+   * @param timeout - Maximum time to wait in milliseconds (`0` for no timeout)
+   * @returns A two-element array `[numLocalSynced, numReplicasSynced]`
+   * @see https://redis.io/commands/waitaof/
+   */
+  WAITAOF,
+  /**
    * Constructs the WAIT command to synchronize with replicas
    *
    * @param numberOfReplicas - Number of replicas that must acknowledge the write
@@ -4279,6 +4290,16 @@ export default {
    * @see https://redis.io/commands/wait/
    */
   wait: WAIT,
+  /**
+   * Constructs the WAITAOF command to synchronize with the Append-Only File on the local Redis instance and replicas
+   *
+   * @param numLocal - Number of local AOF fsyncs to wait for (`0` or `1`)
+   * @param numReplicas - Number of replica AOF fsyncs to wait for
+   * @param timeout - Maximum time to wait in milliseconds (`0` for no timeout)
+   * @returns A two-element array `[numLocalSynced, numReplicasSynced]`
+   * @see https://redis.io/commands/waitaof/
+   */
+  waitAof: WAITAOF,
   /**
    * Constructs the XACK command to acknowledge the processing of stream messages in a consumer group
    *


### PR DESCRIPTION
## What

Adds support for the [`WAITAOF`](https://redis.io/commands/waitaof/) command (introduced in Redis 7.2). `WAITAOF` blocks the current client until the specified number of local and replica AOF fsyncs have been performed, or the given timeout (in milliseconds) is reached.

```ts
const [local, replicas] = await client.waitAof(0, 0, 1);
```

The reply is a two-element array `[numLocalSynced, numReplicasSynced]` matching the Redis spec.

## Why

Closes #2458.

## How

- `packages/client/lib/commands/WAITAOF.ts` — new command, modeled directly on `WAIT.ts` for consistency.
- `packages/client/lib/commands/WAITAOF.spec.ts` — unit test for `transformArguments` plus a `testWithClient` end-to-end check that mirrors the existing `WAIT.spec.ts`.
- `packages/client/lib/commands/index.ts` — wires up `WAITAOF` and `waitAof` exports next to `WAIT` / `wait`, with matching JSDoc.

## Tested

```
$ npx mocha -r tsx --reporter spec --exit \
    ./lib/commands/WAITAOF.spec.ts ./lib/commands/WAIT.spec.ts

  WAITAOF
    ✔ transformArguments
    ✔ client.waitAof (50ms)

  WAIT
    ✔ transformArguments
    ✔ client.wait

  4 passing (8s)
```

`npm run build` is clean. `npm run lint:changed` reports no warnings on the three changed files.

The end-to-end test uses the same `redislabs/client-libs-test:8.8-m03` server image the rest of the suite already pulls.

## Checklist

- [x] Does `npm test` pass with this change (including linting)? Yes — built `tsc --build` cleanly and `lint:changed` is green on the three touched files; `mocha` against `WAITAOF.spec.ts` and `WAIT.spec.ts` passes.
- [x] Is the new or changed code fully tested? Yes (transformArguments + live client invocation).
- [x] Is a documentation update included? Yes — JSDoc on the command export and the index entries follow the same pattern as `WAIT`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new client command and wiring with a small surface area; risk is limited to argument/reply typing and export naming (`waitAof`) without affecting existing command behavior.
> 
> **Overview**
> Adds Redis 7.2+ `WAITAOF` support to the client, including a new command implementation that serializes `WAITAOF <numLocal> <numReplicas> <timeout>` and returns a two-number array reply.
> 
> Exposes the command via `index.ts` as both `WAITAOF` and the convenience alias `waitAof`, and adds a mocha spec that validates argument transformation and an end-to-end `client.waitAof` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a3916a53c565ce925888effcb5c5d2b8621486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->