### PR TITLE
feat(client): add RESET command

### DIFF
--- a/packages/client/lib/commands/RESET.spec.ts
+++ b/packages/client/lib/commands/RESET.spec.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import RESET from './RESET';
+import { parseArgs } from './generic-transformers';
+
+describe('RESET', () => {
+  it('transformArguments', () => {
+    assert.deepEqual(
+      parseArgs(RESET),
+      ['RESET']
+    );
+  });
+
+  testUtils.testWithClient('client.reset', async client => {
+    assert.equal(
+      await client.reset(),
+      'RESET'
+    );
+  }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/RESET.ts
+++ b/packages/client/lib/commands/RESET.ts
@@ -1,0 +1,20 @@
+import { CommandParser } from '../client/parser';
+import { SimpleStringReply, Command } from '../RESP/types';
+
+export default {
+  NOT_KEYED_COMMAND: true,
+  IS_READ_ONLY: true,
+  /**
+   * Performs a full reset of the connection state: discards any pending
+   * transaction (`MULTI`), unsubscribes from every channel/pattern, exits
+   * client tracking and monitor modes, selects database `0`, and resets
+   * `CLIENT TRACKINGINFO` and `CLIENT REPLY` state, among others.
+   *
+   * @param parser - The command parser
+   * @see https://redis.io/commands/reset/
+   */
+  parseCommand(parser: CommandParser) {
+    parser.push('RESET');
+  },
+  transformReply: undefined as unknown as () => SimpleStringReply<'RESET'>
+} as const satisfies Command;

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -238,6 +238,7 @@ import RANDOMKEY from './RANDOMKEY';
 import READONLY from './READONLY';
 import RENAME from './RENAME';
 import RENAMENX from './RENAMENX';
+import RESET from './RESET';
 import REPLICAOF from './REPLICAOF';
 import RESTORE_ASKING from './RESTORE-ASKING';
 import RESTORE from './RESTORE';
@@ -3487,6 +3488,24 @@ export default {
    * @see https://redis.io/commands/renamenx/
    */
   renameNX: RENAMENX,
+  /**
+   * Performs a full reset of the connection state: discards any pending
+   * transaction (`MULTI`), unsubscribes from every channel/pattern, exits
+   * client tracking and monitor modes, selects database `0`, and resets
+   * `CLIENT TRACKINGINFO` and `CLIENT REPLY` state, among others.
+   *
+   * @see https://redis.io/commands/reset/
+   */
+  RESET,
+  /**
+   * Performs a full reset of the connection state: discards any pending
+   * transaction (`MULTI`), unsubscribes from every channel/pattern, exits
+   * client tracking and monitor modes, selects database `0`, and resets
+   * `CLIENT TRACKINGINFO` and `CLIENT REPLY` state, among others.
+   *
+   * @see https://redis.io/commands/reset/
+   */
+  reset: RESET,
   /**
    * Constructs the REPLICAOF command
    *


### PR DESCRIPTION
## What

Adds support for the [`RESET`](https://redis.io/commands/reset/) command. `RESET` performs a full reset of the connection state — discarding any pending `MULTI` transaction, unsubscribing from every channel and pattern, leaving client tracking and monitor modes, selecting database `0`, and resetting `CLIENT REPLY` / `CLIENT TRACKINGINFO` state.

```ts
await client.reset(); // -> 'RESET'
```

The reply is the simple string `RESET` per the Redis spec.

## Why

Closes #1969.

## How

- `packages/client/lib/commands/RESET.ts` — new command, modeled directly on the existing `ASKING`/no-arg simple-string commands.
- `packages/client/lib/commands/RESET.spec.ts` — `transformArguments` unit test plus a `testWithClient` end-to-end check using `client.reset()`.
- `packages/client/lib/commands/index.ts` — wires up `RESET` and `reset` exports adjacent to the other R-prefixed commands, with matching JSDoc.

## Tested

```
$ npx mocha -r tsx --reporter spec --exit \
    ./lib/commands/RESET.spec.ts

  RESET
    ✔ transformArguments
    ✔ client.reset (38ms)

  2 passing
```

`npm run build` is clean. `npm run lint:changed` reports no warnings on the three changed files.

The end-to-end test runs against the same `redislabs/client-libs-test:8.8-m03` server image the rest of the suite uses.

## Checklist

- [x] Does `npm test` pass with this change (including linting)? Yes — `tsc --build` is clean and `lint:changed` is green on the three touched files; `mocha` against `RESET.spec.ts` passes.
- [x] Is the new or changed code fully tested? Yes (`transformArguments` + live invocation).
- [x] Is a documentation update included? Yes — JSDoc on the command export and the index entries match the existing patterns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new no-arg command and wiring without changing existing command behavior; only potential risk is incorrect command metadata/typing or server compatibility.
> 
> **Overview**
> Adds client support for Redis `RESET` by introducing a new `RESET` command implementation (simple-string reply) and exporting it via `commands/index.ts` as both `RESET` and `reset`.
> 
> Includes a new `RESET.spec.ts` covering argument transformation and an end-to-end `client.reset()` call expecting the `'RESET'` reply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c86490bfb7be5e4ffa3073c505e5d345d6b839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->