### PR TITLE
fix: embed sources in emitted sourcemaps

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     
     "composite": true,
     "sourceMap": true,
+    "inlineSources": true,
     "declaration": true,
     "declarationMap": true,
     "allowJs": true,


### PR DESCRIPTION
## Summary

Fixes #3147.

This updates the shared TypeScript build configuration to emit `sourcesContent` in generated source maps. The current generated maps include paths like `../index.ts`, but the published package does not include those source files, so debugger tooling cannot resolve the original TypeScript sources from the installed package alone.

## Validation

- `.\node_modules\.bin\tsc.cmd --build packages/client --force --verbose`
- Inspected `packages/client/dist/index.js.map` and confirmed `sourcesContent` is present
- `npm run build`
- `npm run lint:changed`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change that only affects TypeScript build outputs by embedding `sourcesContent` in generated source maps.
> 
> **Overview**
> Enables debuggers to resolve original TypeScript sources from installed packages by setting `inlineSources: true` in `tsconfig.base.json`, causing generated `.map` files to include `sourcesContent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 098cad6c343fd8b8f0025e4608b37cd70099756b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->