### PR TITLE
fix(client): preserve type mapping for sendCommand proxies

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -406,6 +406,17 @@ describe('Client', () => {
       assert.equal(await client.sendCommand(['PING']), 'PONG');
     }, GLOBAL.SERVERS.OPEN);
 
+    testUtils.testWithClient('should respect type mapping proxy', async client => {
+      await client.set('key', 'value');
+
+      const reply = await client.withTypeMapping({
+        [RESP_TYPES.BLOB_STRING]: Buffer
+      }).sendCommand(['GET', 'key']);
+
+      assert.ok(reply instanceof Buffer);
+      assert.equal(reply.toString(), 'value');
+    }, GLOBAL.SERVERS.OPEN);
+
     testUtils.testWithClient('Unactivated AbortController should not abort', async client => {
       await client.sendCommand(['PING'], {
         abortSignal: new AbortController().signal

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -255,7 +255,10 @@ export type RedisClientType<
     RedisClientExtensions<M, F, S, RESP, TYPE_MAPPING>
   );
 
-type ProxyClient = RedisClient<any, any, any, any, any>;
+type ProxyClient = RedisClient<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>;
+type ProxyClientConstructor = new (
+  options?: RedisClientOptions<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>
+) => ProxyClient;
 
 type NamespaceProxyClient = { _self: ProxyClient };
 
@@ -320,7 +323,10 @@ export default class RedisClient<
     }
   }
 
-  static #SingleEntryCache = new SingleEntryCache<any, any>()
+  static #SingleEntryCache = new SingleEntryCache<
+    CommanderConfig<RedisModules, RedisFunctions, RedisScripts, RespVersions> | undefined,
+    ProxyClientConstructor
+  >()
 
   static factory<
     M extends RedisModules = {},
@@ -340,18 +346,20 @@ export default class RedisClient<
         createFunctionCommand: RedisClient.#createFunctionCommand,
         createScriptCommand: RedisClient.#createScriptCommand,
         config
-      });
+      }) as ProxyClientConstructor;
 
       Client.prototype.Multi = RedisClientMultiCommand.extend(config);
 
       RedisClient.#SingleEntryCache.set(config, Client);
     }
 
+    const ClientConstructor = Client;
+
     return <TYPE_MAPPING extends TypeMapping = {}>(
       options?: Omit<RedisClientOptions<M, F, S, RESP, TYPE_MAPPING>, keyof Exclude<typeof config, undefined>>
     ) => {
       // returning a "proxy" to prevent the namespaces._self to leak between "proxies"
-      return Object.create(new Client(options)) as RedisClientType<M, F, S, RESP, TYPE_MAPPING>;
+      return Object.create(new ClientConstructor(options)) as RedisClientType<M, F, S, RESP, TYPE_MAPPING>;
     };
   }
 
@@ -598,11 +606,11 @@ export default class RedisClient<
         const cscConfig = this.#options.clientSideCache;
         this.#clientSideCache = new BasicClientSideCache(cscConfig);
       }
-      this.#queue.addPushHandler((push: Array<any>): boolean => {
-        if (push[0].toString() !== 'invalidate') return false;
+      this.#queue.addPushHandler((push: Array<unknown>): boolean => {
+        if (String(push[0]) !== 'invalidate') return false;
 
         if (push[1] !== null) {
-          for (const key of push[1]) {
+          for (const key of push[1] as Iterable<RedisArgument>) {
             this.#clientSideCache?.invalidate(key)
           }
         } else {
@@ -612,11 +620,11 @@ export default class RedisClient<
         return true
       });
     } else if (options?.emitInvalidate) {
-      this.#queue.addPushHandler((push: Array<any>): boolean => {
-        if (push[0].toString() !== 'invalidate') return false;
+      this.#queue.addPushHandler((push: Array<unknown>): boolean => {
+        if (String(push[0]) !== 'invalidate') return false;
 
         if (push[1] !== null) {
-          for (const key of push[1]) {
+          for (const key of push[1] as Iterable<RedisArgument>) {
             this.emit('invalidate', key);
           }
         } else {
@@ -1057,7 +1065,7 @@ export default class RedisClient<
    */
    _ejectSocket(): RedisSocket {
      const socket = this._self.#socket;
-     // @ts-ignore
+     // @ts-expect-error allow temporarily clearing the socket during internal socket replacement
      this._self.#socket = null;
      socket.removeAllListeners();
      return socket;
@@ -1183,7 +1191,7 @@ export default class RedisClient<
 
         // Merge global options with provided options
         const opts = {
-          ...this._self._commandOptions,
+          ...this._commandOptions,
           ...options,
         };
 
@@ -1524,7 +1532,7 @@ export default class RedisClient<
 
   MULTI<isTyped extends MultiMode = MULTI_MODE['TYPED']>() {
     type Multi = new (...args: ConstructorParameters<typeof RedisClientMultiCommand>) => RedisClientMultiCommandType<isTyped, [], M, F, S, RESP, TYPE_MAPPING>;
-    return new ((this as any).Multi as Multi)(
+    return new ((this as unknown as { Multi: Multi }).Multi)(
       this._executeMulti.bind(this),
       this._executePipeline.bind(this),
       this._commandOptions?.typeMapping


### PR DESCRIPTION
## Summary

Fixes #3055.

`withTypeMapping(...).sendCommand(...)` currently loses the proxy's command options because `sendCommand()` merges options from the root client (`this._self._commandOptions`) instead of the receiver proxy. This makes direct `sendCommand()` calls ignore mappings such as `{ [RESP_TYPES.BLOB_STRING]: Buffer }`.

This changes `sendCommand()` to merge `this._commandOptions`, matching the existing command wrapper paths, and adds regression coverage for `withTypeMapping(...).sendCommand(['GET', key])` returning a `Buffer`.

Because this repo now lints complete changed files, this also removes the touched file's blocking lint errors without changing runtime behavior.

## Validation

- `.\node_modules\.bin\tsc.cmd --build packages/client --force --verbose`
- `npm run lint:changed`
- `npm run build`
- `git diff --check`

Note: the focused Redis-backed mocha test could not run locally because Docker is not installed in this Windows environment (`spawn docker ENOENT`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `sendCommand` option merging in the core client path, which can affect how command options (timeouts, abort signals, type mappings) are applied across all direct `sendCommand` calls. Scope is small and covered by a new regression test, but it touches a central execution method.
> 
> **Overview**
> Fixes proxied `sendCommand()` calls (e.g. `client.withTypeMapping(...).sendCommand(...)`) to respect the receiver proxy’s `_commandOptions` when merging per-call options, restoring correct RESP type-mapping behavior.
> 
> Adds a regression test asserting `withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer }).sendCommand(['GET', ...])` returns a `Buffer`, and includes minor TypeScript/lint cleanups (stronger typing for cached factory constructors, safer push handler types, and replacing `@ts-ignore` with `@ts-expect-error`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b73a749759dd5361eea5a76739fafd1cfa75f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->