### PR TITLE
feat(sentinel): emit lifecycle events

### DIFF
--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -446,6 +446,9 @@ export default class RedisSentinel<
       this._self.#reservedClientInfo = await this._self.#internal.getClientLease();
     }
 
+    this.emit('connect');
+    this.emit('ready');
+
     return this as unknown as RedisSentinelType<M, F, S, RESP, TYPE_MAPPING>;
   }
 
@@ -537,11 +540,19 @@ export default class RedisSentinel<
   multi = this.MULTI;
 
   async close() {
-    return this._self.#internal.close();
+    const wasOpen = this._self.isOpen;
+    await this._self.#internal.close();
+    if (wasOpen) {
+      this.emit('end');
+    }
   }
 
-  destroy() {
-    return this._self.#internal.destroy();
+  async destroy() {
+    const wasOpen = this._self.isOpen;
+    await this._self.#internal.destroy();
+    if (wasOpen) {
+      this.emit('end');
+    }
   }
 
   async SUBSCRIBE<T extends boolean = false>(

--- a/packages/client/lib/sentinel/lifecycle-events.spec.ts
+++ b/packages/client/lib/sentinel/lifecycle-events.spec.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from 'node:assert';
+import { once } from 'node:events';
+import testUtils, { GLOBAL } from '../test-utils';
+
+describe('RedisSentinel lifecycle events', () => {
+  testUtils.testWithClientSentinel('should emit connect, ready and end events', async sentinel => {
+    const events: string[] = [];
+
+    sentinel
+      .on('connect', () => events.push('connect'))
+      .on('ready', () => events.push('ready'))
+      .on('end', () => events.push('end'));
+
+    await sentinel.connect();
+    assert.deepEqual(events, ['connect', 'ready']);
+
+    const endPromise = once(sentinel, 'end');
+    await sentinel.close();
+    await endPromise;
+
+    assert.deepEqual(events, ['connect', 'ready', 'end']);
+  }, {
+    ...GLOBAL.SENTINEL.OPEN,
+    disableClientSetup: true
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3012.

`createSentinel()` exposes `isOpen` and `isReady`, but it did not emit the lifecycle events that standalone clients expose. This adds `connect` and `ready` emissions after Sentinel finishes connecting, and emits `end` after closing or destroying an instance that was open.

The change is additive and keeps the event ordering aligned with the state a Sentinel consumer can observe.

## Validation

- `.\node_modules\.bin\tsc.cmd --build packages/client --force --verbose`
- `npm run lint:changed`
- `git diff --check`

Note: the focused Sentinel mocha test could not run locally because Docker is not installed in this Windows environment (`spawn docker ENOENT`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive behavior change: emits `connect`/`ready` after successful `RedisSentinel.connect()` and emits `end` on `close()`/`destroy()` when previously open; could affect consumers that assume no events or different ordering.
> 
> **Overview**
> `RedisSentinel` now emits lifecycle events consistent with standalone clients: `connect` and `ready` are emitted after `connect()` completes, and `end` is emitted after `close()` or `destroy()` when the instance was previously open.
> 
> Adds a focused sentinel test (`lifecycle-events.spec.ts`) asserting the `connect` → `ready` → `end` event sequence and that `end` is observable via `once()` after shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffdc7b508bb6e9b8ec8ffd6fc1885f68877d28c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->