### PR TITLE
feat(sentinel): add scan iterator

### DIFF
--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { CommandArguments, RedisFunctions, RedisModules, RedisScripts, ReplyUnion, RespVersions, TypeMapping } from '../RESP/types';
+import { CommandArguments, RedisArgument, RedisFunctions, RedisModules, RedisScripts, ReplyUnion, RespVersions, TypeMapping } from '../RESP/types';
 import RedisClient, { RedisClientOptions, RedisClientType } from '../client';
 import { CommandOptions } from '../client/commands-queue';
 import { attachConfig } from '../commander';
@@ -18,9 +18,14 @@ import { TcpNetConnectOpts } from 'node:net';
 import { RedisTcpSocketOptions } from '../client/socket';
 import { BasicPooledClientSideCache, PooledClientSideCacheProvider } from '../client/cache';
 import { ClientIdentity, ClientRole, generateClientId } from '../client/identity';
+import { ScanOptions } from '../commands/SCAN';
 
 interface ClientInfo {
   id: number;
+}
+
+interface ScanIteratorOptions {
+  cursor?: RedisArgument;
 }
 
 export class RedisSentinelClient<
@@ -158,6 +163,18 @@ export class RedisSentinelClient<
    */
   withTypeMapping<TYPE_MAPPING extends TypeMapping>(typeMapping: TYPE_MAPPING) {
     return this._commandOptionsProxy('typeMapping', typeMapping);
+  }
+
+  async* scanIterator(
+    this: RedisSentinelClientType<M, F, S, RESP, TYPE_MAPPING>,
+    options?: ScanOptions & ScanIteratorOptions
+  ) {
+    let cursor = options?.cursor ?? '0';
+    do {
+      const reply = await this.scan(cursor, options);
+      cursor = reply.cursor;
+      yield reply.keys;
+    } while (cursor.toString() !== '0');
   }
 
   async _execute<T>(
@@ -423,6 +440,18 @@ export default class RedisSentinel<
    */
   withTypeMapping<TYPE_MAPPING extends TypeMapping>(typeMapping: TYPE_MAPPING) {
     return this._commandOptionsProxy('typeMapping', typeMapping);
+  }
+
+  async* scanIterator(
+    this: RedisSentinelType<M, F, S, RESP, TYPE_MAPPING>,
+    options?: ScanOptions & ScanIteratorOptions
+  ) {
+    let cursor = options?.cursor ?? '0';
+    do {
+      const reply = await this.use(client => client.scan(cursor, options));
+      cursor = reply.cursor;
+      yield reply.keys;
+    } while (cursor.toString() !== '0');
   }
 
   duplicate<

--- a/packages/client/lib/sentinel/scan-iterator.spec.ts
+++ b/packages/client/lib/sentinel/scan-iterator.spec.ts
@@ -1,0 +1,63 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+
+describe('RedisSentinel scanIterator', () => {
+  for (const testOptions of [GLOBAL.SENTINEL.OPEN, GLOBAL.SENTINEL.PASSWORD]) {
+    const passIndex = testOptions.serverArguments.indexOf('--requirepass') + 1;
+    const password = passIndex === 0 ? undefined : testOptions.serverArguments[passIndex];
+
+    describe(`test with password - ${password}`, () => {
+      testUtils.testWithClientSentinel('scanIterator', async sentinel => {
+        await Promise.all([
+          sentinel.set('scan:1', '1'),
+          sentinel.set('scan:2', '2')
+        ]);
+
+        const results = new Set<string>();
+        for await (const keys of sentinel.scanIterator({ MATCH: 'scan:*', COUNT: 1 })) {
+          for (const key of keys) {
+            results.add(key);
+          }
+        }
+
+        assert.deepEqual(results, new Set(['scan:1', 'scan:2']));
+      }, testOptions);
+
+      testUtils.testWithClientSentinel('leased client scanIterator', async sentinel => {
+        await Promise.all([
+          sentinel.set('lease-scan:1', '1'),
+          sentinel.set('lease-scan:2', '2')
+        ]);
+
+        const client = await sentinel.acquire();
+        try {
+          const results = new Set<string>();
+          for await (const keys of client.scanIterator({ MATCH: 'lease-scan:*', COUNT: 1 })) {
+            for (const key of keys) {
+              results.add(key);
+            }
+          }
+
+          assert.deepEqual(results, new Set(['lease-scan:1', 'lease-scan:2']));
+        } finally {
+          const release = client.release();
+          if (release) await release;
+        }
+      }, testOptions);
+    });
+  }
+
+  testUtils.testWithClientSentinel('scanIterator releases master lease before yielding', async sentinel => {
+    await sentinel.set('scan-deadlock:1', '1');
+
+    let didScan = false;
+    for await (const keys of sentinel.scanIterator({ MATCH: 'scan-deadlock:*', COUNT: 1 })) {
+      didScan = true;
+      assert.ok(keys.length > 0);
+      await sentinel.set('scan-deadlock:seen', '1');
+    }
+
+    assert.equal(didScan, true);
+    assert.equal(await sentinel.get('scan-deadlock:seen'), '1');
+  }, GLOBAL.SENTINEL.WITH_REPLICA_POOL_SIZE_1);
+});


### PR DESCRIPTION
## Summary
- add `scanIterator()` to `RedisSentinel`
- add `scanIterator()` to acquired `RedisSentinelClient` leases
- release the Sentinel facade's master lease before yielding each SCAN page to avoid starving a one-client master pool
- add Sentinel scan iterator coverage, including a no-deadlock regression

Closes #2999

## Validation
- `npm run lint:changed`
- `npm run build`

Sentinel integration tests were not run locally because Docker is not installed in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new async-iterator API around `SCAN` on Sentinel and leased clients, touching pooled lease usage and iteration control flow; risk is mainly around potential pool starvation/performance/regression in edge cursor/type cases.
> 
> **Overview**
> Adds `scanIterator()` to both the `RedisSentinel` facade and acquired `RedisSentinelClient` leases, providing an async generator that pages through `SCAN` results (with optional starting `cursor`) and yields key batches until completion.
> 
> Includes new Sentinel integration tests covering password/no-password setups, iteration via both the facade and leased clients, and a regression case ensuring iteration doesn’t deadlock when the master pool is size 1 (by releasing the per-page lease before yielding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c51cb664ee5e39a0a675e55810e9f9d0183af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->