### PR TITLE
feat(client): add zRevRankWithScore command

### DIFF
--- a/packages/client/lib/commands/ZREVRANK_WITHSCORE.spec.ts
+++ b/packages/client/lib/commands/ZREVRANK_WITHSCORE.spec.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { parseArgs } from './generic-transformers';
+import ZREVRANK_WITHSCORE from './ZREVRANK_WITHSCORE';
+
+describe('ZREVRANK WITHSCORE', () => {
+  testUtils.isVersionGreaterThanHook([7, 2]);
+
+  it('transformArguments', () => {
+    assert.deepEqual(
+      parseArgs(ZREVRANK_WITHSCORE, 'key', 'member'),
+      ['ZREVRANK', 'key', 'member', 'WITHSCORE']
+    );
+  });
+
+  testUtils.testAll('zRevRankWithScore - null', async client => {
+    assert.equal(
+      await client.zRevRankWithScore('key', 'member'),
+      null
+    );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('zRevRankWithScore - with member', async client => {
+    const members = [{
+      value: '1',
+      score: 1
+    }, {
+      value: '2',
+      score: 2
+    }];
+
+    const [, reply] = await Promise.all([
+      client.zAdd('key', members),
+      client.zRevRankWithScore('key', members[0].value)
+    ]);
+    assert.deepEqual(
+      reply,
+      {
+        rank: 1,
+        score: 1
+      }
+    );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/ZREVRANK_WITHSCORE.ts
+++ b/packages/client/lib/commands/ZREVRANK_WITHSCORE.ts
@@ -1,0 +1,15 @@
+import ZRANK_WITHSCORE from './ZRANK_WITHSCORE';
+import ZREVRANK from './ZREVRANK';
+import { Command } from '../RESP/types';
+
+export default {
+  CACHEABLE: ZREVRANK.CACHEABLE,
+  IS_READ_ONLY: ZREVRANK.IS_READ_ONLY,
+  parseCommand(...args: Parameters<typeof ZREVRANK.parseCommand>) {
+    const parser = args[0];
+
+    ZREVRANK.parseCommand(...args);
+    parser.push('WITHSCORE');
+  },
+  transformReply: ZRANK_WITHSCORE.transformReply
+} as const satisfies Command;

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -352,6 +352,7 @@ import ZRANK from './ZRANK';
 import ZREM from './ZREM';
 import ZREMRANGEBYLEX from './ZREMRANGEBYLEX';
 import ZREMRANGEBYRANK from './ZREMRANGEBYRANK';
+import ZREVRANK_WITHSCORE from './ZREVRANK_WITHSCORE';
 import ZREVRANK from './ZREVRANK';
 import ZSCAN from './ZSCAN';
 import ZSCORE from './ZSCORE';
@@ -5303,6 +5304,16 @@ export default {
    * @param max - Maximum score.
    */
   zRemRangeByScore: ZREMRANGEBYSCORE,
+  /**
+   * Returns the reverse rank of a member in the sorted set with its score.
+   * @param args - Same parameters as the ZREVRANK command.
+   */
+  ZREVRANK_WITHSCORE,
+  /**
+   * Returns the reverse rank of a member in the sorted set with its score.
+   * @param args - Same parameters as the ZREVRANK command.
+   */
+  zRevRankWithScore: ZREVRANK_WITHSCORE,
   /**
    * Returns the rank of a member in the sorted set, with scores ordered from high to low.
    * @param key - Key of the sorted set.


### PR DESCRIPTION
## Summary

Adds `ZREVRANK_WITHSCORE` / `zRevRankWithScore` for Redis 7.2's `ZREVRANK key member WITHSCORE` form.

This mirrors the existing `ZRANK_WITHSCORE` implementation and keeps `zRevRank` itself unchanged, so existing callers keep the current `number | null` return type while callers that need the score can opt into the new command.

Closes #2464.

Redis command reference: https://redis.io/docs/latest/commands/zrevrank/

## Validation

- `node -r ts-node/register/transpile-only` direct parse/transform check for `ZREVRANK_WITHSCORE`
- `npm run lint:changed`
- `npm run check:command-jsdoc`
- `npm run build`
- `git diff --cached --check`

I also attempted a grep-limited Mocha run for `ZREVRANK_WITHSCORE.spec.ts`, but this repo starts its Docker-backed Redis test environment in the global hooks before the grep-selected test runs. It failed locally at `spawn docker ENOENT` because Docker is not installed in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only command wrapper with no changes to existing APIs; risk is mainly using it against Redis versions before 7.2.
> 
> **Overview**
> Adds client support for Redis 7.2 **`ZREVRANK … WITHSCORE`**, exposed as **`ZREVRANK_WITHSCORE`** / **`zRevRankWithScore`**, so callers can get a member’s reverse rank and score in one read without changing existing **`zRevRank`** (`number | null`).
> 
> The new command module follows the same pattern as **`ZRANK_WITHSCORE`**: it reuses **`ZREVRANK`** argument parsing and appends **`WITHSCORE`**, and maps replies to `{ rank, score }` or `null` via **`ZRANK_WITHSCORE.transformReply`**. It is wired into the public commands export in **`index.ts`**, with tests for argument encoding and integration behavior (gated to Redis ≥ 7.2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21934d44d7b138da1a0c3851db8d4469a1a779e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->