### PR TITLE
fix(client): parse xInfoGroups replies by field

### DIFF
--- a/packages/client/lib/commands/XINFO_GROUPS.spec.ts
+++ b/packages/client/lib/commands/XINFO_GROUPS.spec.ts
@@ -11,6 +11,44 @@ describe('XINFO GROUPS', () => {
     );
   });
 
+  it('transformReply', () => {
+    assert.deepEqual(
+      XINFO_GROUPS.transformReply[2]([[
+        'name', 'group',
+        'consumers', 0,
+        'pending', 0,
+        'last-delivered-id', '0-0'
+      ]]),
+      [Object.assign(Object.create(null), {
+        name: 'group',
+        consumers: 0,
+        pending: 0,
+        'last-delivered-id': '0-0'
+      })]
+    );
+  });
+
+  it('transformReply - Redis 7 fields', () => {
+    assert.deepEqual(
+      XINFO_GROUPS.transformReply[2]([[
+        'name', 'group',
+        'consumers', 0,
+        'pending', 0,
+        'last-delivered-id', '0-0',
+        'entries-read', null,
+        'lag', null
+      ]]),
+      [Object.assign(Object.create(null), {
+        name: 'group',
+        consumers: 0,
+        pending: 0,
+        'last-delivered-id': '0-0',
+        'entries-read': null,
+        lag: null
+      })]
+    );
+  });
+
   testUtils.testAll('xInfoGroups', async client => {
     const [, reply] = await Promise.all([
       client.xGroupCreate('key', 'group', '$', {

--- a/packages/client/lib/commands/XINFO_GROUPS.ts
+++ b/packages/client/lib/commands/XINFO_GROUPS.ts
@@ -1,5 +1,6 @@
 import { CommandParser } from '../client/parser';
-import { RedisArgument, ArrayReply, TuplesToMapReply, BlobStringReply, NumberReply, NullReply, UnwrapReply, Resp2Reply, Command } from '../RESP/types';
+import { RedisArgument, ArrayReply, TuplesToMapReply, BlobStringReply, NumberReply, NullReply, Command } from '../RESP/types';
+import { transformTuplesReply } from './generic-transformers';
 
 /**
  * Reply structure for XINFO GROUPS command containing information about consumer groups
@@ -8,11 +9,11 @@ export type XInfoGroupsReply = ArrayReply<TuplesToMapReply<[
   [BlobStringReply<'name'>, BlobStringReply],
   [BlobStringReply<'consumers'>, NumberReply],
   [BlobStringReply<'pending'>, NumberReply],
-  [BlobStringReply<'last-delivered-id'>, NumberReply],
+  [BlobStringReply<'last-delivered-id'>, BlobStringReply],
   /** added in 7.0 */
   [BlobStringReply<'entries-read'>, NumberReply | NullReply],
   /** added in 7.0 */
-  [BlobStringReply<'lag'>, NumberReply],
+  [BlobStringReply<'lag'>, NumberReply | NullReply],
 ]>>;
 
 export default {
@@ -34,19 +35,8 @@ export default {
      *          entries-read - Number of entries read in the group (Redis 7.0+)
      *          lag - Number of entries not read by the group (Redis 7.0+)
      */
-    2: (reply: UnwrapReply<Resp2Reply<XInfoGroupsReply>>) => {
-      return reply.map(group => {
-        const unwrapped = group as unknown as UnwrapReply<typeof group>;
-        return {
-          name: unwrapped[1],
-          consumers: unwrapped[3],
-          pending: unwrapped[5],
-          'last-delivered-id': unwrapped[7],
-          'entries-read': unwrapped[9],
-          lag: unwrapped[11]
-        };
-      });
-    },
+    2: (reply: Array<Array<BlobStringReply | NumberReply | NullReply>>) =>
+      reply.map(group => transformTuplesReply(group as unknown as ArrayReply<BlobStringReply>)) as unknown as XInfoGroupsReply['DEFAULT'],
     3: undefined as unknown as () => XInfoGroupsReply
   }
 } as const satisfies Command;


### PR DESCRIPTION
## Summary

Updates the RESP2 `XINFO GROUPS` transformer to build each group from the returned field names instead of fixed array positions.

This keeps existing fields working, preserves Redis 7's `entries-read` and `lag` fields, and makes the transformer tolerate nullable lag values as documented by Redis. It also corrects the reply type for `last-delivered-id` to a blob string and allows `lag` to be null.

Closes #2388.

Redis command reference: https://redis.io/docs/latest/commands/xinfo-groups/

## Validation

- direct `node -r ts-node/register/transpile-only` transformer check for Redis 7 `entries-read`/`lag` fields
- `npm run lint:changed`
- `npm run build`
- `git diff --check`

I also attempted `npx mocha --require ts-node/register/transpile-only packages/client/lib/commands/XINFO_GROUPS.spec.ts --grep transformReply`, but this repo starts its Docker-backed Redis test environment in global hooks before grep-selected tests run. It failed locally at `spawn docker ENOENT` because Docker is not installed in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the RESP2 reply transformer and types for `XINFO GROUPS`, which can affect downstream consumers that rely on the previous shape/typing or on positional parsing; behavior should improve but touches command decoding logic.
> 
> **Overview**
> Updates `XINFO GROUPS` RESP2 reply handling to build each group object by *field name* using `transformTuplesReply`, instead of reading fixed tuple positions.
> 
> Adjusts the reply typing to match Redis behavior (`last-delivered-id` as a blob string; `lag` nullable) and adds unit tests covering both pre-Redis-7 and Redis-7+ fields (`entries-read`, `lag`) including null values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311dbc6a3569308cb828f0a6cd20143477afd7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->