### PR TITLE
fix(client): swallow synchronous EPIPE from writeAfterFIN (#3282)

### DIFF
--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { spy } from 'sinon';
 import { once } from 'node:events';
+import net from 'node:net';
 import RedisSocket, { RedisSocketOptions } from './socket';
 import testUtils, { GLOBAL } from '../test-utils';
 import { setTimeout } from 'timers/promises';
@@ -83,6 +84,90 @@ describe('Socket', () => {
       await assert.rejects(socket.connect());
 
       assert.equal(socket.isOpen, false);
+    });
+  });
+
+  describe('write', () => {
+    function captureUnderlyingSocket() {
+      const original = net.createConnection;
+      const captured: { socket?: net.Socket } = {};
+      (net as any).createConnection = (...args: any[]) => {
+        const s = (original as any).apply(net, args);
+        captured.socket = s;
+        return s;
+      };
+      return {
+        captured,
+        restore() {
+          (net as any).createConnection = original;
+        }
+      };
+    }
+
+    async function withConnectedSocket(
+      fn: (socket: RedisSocket, underlying: net.Socket) => Promise<void>
+    ) {
+      const server = net.createServer();
+      server.on('connection', conn => conn.on('error', () => { /* ignore */ }));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address() as net.AddressInfo;
+
+      const capture = captureUnderlyingSocket();
+      try {
+        const socket = createSocket({
+          host: '127.0.0.1',
+          port,
+          reconnectStrategy: false
+        });
+
+        await socket.connect();
+        assert.ok(capture.captured.socket, 'captured underlying socket');
+
+        await fn(socket, capture.captured.socket!);
+      } finally {
+        capture.restore();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    }
+
+    it('should short-circuit when the underlying socket is no longer writable (#3282)', async () => {
+      await withConnectedSocket(async (socket, underlying) => {
+        Object.defineProperty(underlying, 'writable', {
+          value: false,
+          configurable: true
+        });
+
+        const writeSpy = spy(underlying, 'write');
+        socket.write([[Buffer.from('PING\r\n')]]);
+        assert.equal(writeSpy.callCount, 0, 'must not call write on a non-writable socket');
+      });
+    });
+
+    it('should swallow synchronous EPIPE from net.Socket.write (#3282)', async () => {
+      await withConnectedSocket(async (socket, underlying) => {
+        underlying.write = (() => {
+          const err: NodeJS.ErrnoException = new Error('write EPIPE');
+          err.code = 'EPIPE';
+          throw err;
+        }) as net.Socket['write'];
+
+        assert.doesNotThrow(() =>
+          socket.write([[Buffer.from('PING\r\n')]])
+        );
+      });
+    });
+
+    it('should rethrow non-EPIPE errors from net.Socket.write', async () => {
+      await withConnectedSocket(async (socket, underlying) => {
+        underlying.write = (() => {
+          throw new Error('boom');
+        }) as net.Socket['write'];
+
+        assert.throws(
+          () => socket.write([[Buffer.from('PING\r\n')]]),
+          /boom/
+        );
+      });
     });
   });
 

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -124,7 +124,12 @@ describe('Socket', () => {
         await socket.connect();
         assert.ok(capture.captured.socket, 'captured underlying socket');
 
-        await fn(socket, capture.captured.socket!);
+        try {
+          await fn(socket, capture.captured.socket!);
+        } finally {
+          // Tear down the connection so server.close() doesn't wait for it.
+          capture.captured.socket?.destroy();
+        }
       } finally {
         capture.restore();
         await new Promise<void>(resolve => server.close(() => resolve()));

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -91,15 +91,16 @@ describe('Socket', () => {
     function captureUnderlyingSocket() {
       const original = net.createConnection;
       const captured: { socket?: net.Socket } = {};
-      (net as any).createConnection = (...args: any[]) => {
-        const s = (original as any).apply(net, args);
+      const target = net as unknown as { createConnection: unknown };
+      target.createConnection = (...args: unknown[]) => {
+        const s = (original as unknown as (...a: unknown[]) => net.Socket).apply(net, args);
         captured.socket = s;
         return s;
       };
       return {
         captured,
         restore() {
-          (net as any).createConnection = original;
+          target.createConnection = original;
         }
       };
     }
@@ -217,7 +218,7 @@ describe('Socket', () => {
         assert.equal(client.isReady, true, 'client.isReady');
         assert.equal(client.isOpen, true, 'client.isOpen');
 
-        client.on('error', err => {
+        client.on('error', _err => {
           assert.fail('Should not have timed out or errored in any way');
         });
         await setTimeout(100);

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -381,17 +381,28 @@ export default class RedisSocket extends EventEmitter {
 
 
   write(iterable: Iterable<ReadonlyArray<RedisArgument>>) {
-    if (!this.#socket) return;
+    if (!this.#socket || !this.#socket.writable) return;
 
     this.#socket.cork();
-    for (const args of iterable) {
-      for (const toWrite of args) {
-        this.#socket.write(toWrite);
-      }
+    try {
+      for (const args of iterable) {
+        for (const toWrite of args) {
+          this.#socket.write(toWrite);
+        }
 
-      if (this.#socket.writableNeedDrain) break;
+        if (this.#socket.writableNeedDrain) break;
+      }
+    } catch (err) {
+      // net.Socket.write can throw synchronously on a half-closed socket
+      // (writeAfterFIN -> EPIPE) before the 'close' event fires. The pending
+      // command has already been moved to #waitingForReply by the queue's
+      // generator, so the close handler will reject it on reconnect.
+      if (!err || (err as NodeJS.ErrnoException).code !== 'EPIPE') {
+        throw err;
+      }
+    } finally {
+      this.#socket.uncork();
     }
-    this.#socket.uncork();
   }
 
   async quit<T>(fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
net.Socket.write can throw synchronously with code 'EPIPE' on a half-closed socket, before the 'close' event fires. The throw escaped RedisSocket.write from a setImmediate flush and crashed the process. Preflight `writable`, wrap the cork/write loop in try/finally so uncork always runs, and narrowly swallow EPIPE — the close handler will reject the pending command via #waitingForReply.

Fixes #3282

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes low-level socket write behavior and error handling; mistakes could hide real network failures or affect backpressure/flush behavior under load.
> 
> **Overview**
> Prevents process crashes when `net.Socket.write` throws synchronously on half-closed connections by guarding `RedisSocket.write` with a `writable` check, ensuring `uncork()` always runs via `try/finally`, and swallowing only `EPIPE` while rethrowing other errors.
> 
> Adds targeted unit tests that capture the underlying `net.Socket` to verify: no writes occur when the socket is not writable, synchronous `EPIPE` is ignored, and non-`EPIPE` errors still surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1452cacaa2575366610c50de27f4617bae0b2b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->