### PR TITLE
chore: add min-release-age cooldown to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1


### PR DESCRIPTION
Set a 1-day cooldown on new dependency versions as a low-cost defense against supply-chain attacks. Requires npm CLI 11.10.0+.

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects how npm resolves/installs newly released package versions; potential impact is slower uptake of fresh releases in CI/developer installs.
> 
> **Overview**
> Adds an `.npmrc` setting `min-release-age=1` to enforce a 1-day delay before newly published dependency versions are eligible for install, as a supply-chain hardening measure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc797df815adebb50e5430300eec260f05480d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->