### PR TITLE
docs(migration): document Node.js 20 minimum version requirement

### DIFF
--- a/docs/v5-to-v6.md
+++ b/docs/v5-to-v6.md
@@ -1,5 +1,10 @@
 # v5 to v6 migration guide
 
+## Node.js minimum version
+
+v6 requires Node.js `>= 20.0.0` (v5 required `>= 18.19.0`). The bump came in with `@azure/msal-node` 5.x, which the `entraid` package upgraded to in order to drop a vulnerable transitive `uuid` (CVE-2026-41907); msal-node 5.x itself requires Node 20. Node 18 is no longer tested in CI, and `npm install` will reject the install on Node 18.
+
+
 ## RESP3 is now the default protocol
 
 In v5, Node-Redis defaulted to `RESP: 2` unless you explicitly configured `RESP: 3`.


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the migration guide; no runtime or API behavior is modified.
> 
> **Overview**
> Adds a new **Node.js minimum version** section at the top of `docs/v5-to-v6.md`, before the existing RESP3 migration content.
> 
> The section states that v6 requires **Node `>= 20.0.0`** (up from v5’s `>= 18.19.0`), ties the bump to **`@azure/msal-node` 5.x** via the **`entraid`** package (CVE-2026-41907 / transitive `uuid`), and notes that **Node 18 is dropped from CI** and **`npm install` fails on Node 18**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f6b0d70b4184250b5e6e097967c56731dcd84a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->