### PR TITLE
chore: widen @redis/client peer-dep to allow 6.x for major release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9293,7 +9293,7 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.12.1"
+        "@redis/client": "^5.12.1 || ^6.0.0"
       }
     },
     "packages/client": {
@@ -9349,7 +9349,7 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.12.1"
+        "@redis/client": "^5.12.1 || ^6.0.0"
       }
     },
     "packages/entraid/node_modules/@types/node": {
@@ -9395,7 +9395,7 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.12.1"
+        "@redis/client": "^5.12.1 || ^6.0.0"
       }
     },
     "packages/redis": {
@@ -9423,7 +9423,7 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.12.1"
+        "@redis/client": "^5.12.1 || ^6.0.0"
       }
     },
     "packages/test-utils": {
@@ -9501,7 +9501,7 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.12.1"
+        "@redis/client": "^5.12.1 || ^6.0.0"
       }
     }
   }

--- a/packages/bloom/package.json
+++ b/packages/bloom/package.json
@@ -13,7 +13,7 @@
     "release": "release-it"
   },
   "peerDependencies": {
-    "@redis/client": "^5.12.1"
+    "@redis/client": "^5.12.1 || ^6.0.0"
   },
   "devDependencies": {
     "@redis/test-utils": "*"

--- a/packages/entraid/package.json
+++ b/packages/entraid/package.json
@@ -23,7 +23,7 @@
     "@azure/msal-node": "^5.1.5"
   },
   "peerDependencies": {
-    "@redis/client": "^5.12.1"
+    "@redis/client": "^5.12.1 || ^6.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -13,7 +13,7 @@
     "release": "release-it"
   },
   "peerDependencies": {
-    "@redis/client": "^5.12.1"
+    "@redis/client": "^5.12.1 || ^6.0.0"
   },
   "devDependencies": {
     "@redis/test-utils": "*"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -14,7 +14,7 @@
     "release": "release-it"
   },
   "peerDependencies": {
-    "@redis/client": "^5.12.1"
+    "@redis/client": "^5.12.1 || ^6.0.0"
   },
   "devDependencies": {
     "@redis/test-utils": "*"

--- a/packages/time-series/package.json
+++ b/packages/time-series/package.json
@@ -13,7 +13,7 @@
     "release": "release-it"
   },
   "peerDependencies": {
-    "@redis/client": "^5.12.1"
+    "@redis/client": "^5.12.1 || ^6.0.0"
   },
   "devDependencies": {
     "@redis/test-utils": "*"


### PR DESCRIPTION
Sibling packages' peerDependencies."@redis/client" was "^5.12.1", which excludes the upcoming 6.0.0 client version. During a major release-it run, the very first per-workspace step (bumping @redis/client to 6.0.0) triggers npm version's workspace resolve, which then ERESOLVEs against those sibling peer-deps and aborts before any commit. Widen the range to "^5.12.1 || ^6.0.0" so the resolve passes in both pre- and post-bump states. Each sibling's bumper plugin will overwrite the range with the strict "^<newmajor>.0.0" form as part of its own release commit, so the union is transient and never ships in any published artifact.

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only peer dependency and lockfile updates with no application or API logic changes.
> 
> **Overview**
> Widens the **`@redis/client`** `peerDependencies` range from **`^5.12.1`** to **`^5.12.1 || ^6.0.0`** on sibling packages (`@redis/bloom`, `@redis/json`, `@redis/search`, `@redis/time-series`, `@redis/entraid`) and updates **`package-lock.json`** to match.
> 
> This is a **release-workflow** change so npm workspace resolution does not **ERESOLVE** when `@redis/client` is bumped to **6.x** during a major `release-it` run; it does not change runtime library code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e449fcf2b382b76e79d702f432e241e964ad17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->