### PR TITLE
chore(tests): bump default docker test image to 8.8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
             version: "8.2"
           - tag: "8.4.0"
             version: "8.4"
-          - tag: "custom-26235535976-debian"
+          - tag: "8.8.0"
             version: "8.8"
     steps:
       - uses: actions/checkout@v4

--- a/packages/bloom/lib/test-utils.ts
+++ b/packages/bloom/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default  TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-26235535976-debian', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
 });
 
 export const GLOBAL = {

--- a/packages/client/lib/sentinel/test-util.ts
+++ b/packages/client/lib/sentinel/test-util.ts
@@ -175,7 +175,7 @@ export class SentinelFramework extends DockerBase {
       dockerImageName: 'redislabs/client-libs-test',
       dockerImageTagArgument: 'redis-tag',
       dockerImageVersionArgument: 'redis-version',
-      defaultDockerVersion: { tag: 'custom-26235535976-debian', version: '8.8' }
+      defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
     });
     this.#nodeMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelNodes']>>>>();
     this.#sentinelMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelSentinels']>>>>();

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -10,7 +10,7 @@ const utils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-26235535976-debian', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
 });
 
 export default utils;

--- a/packages/entraid/lib/test-utils.ts
+++ b/packages/entraid/lib/test-utils.ts
@@ -7,7 +7,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-26235535976-debian', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
 });
 
 const DEBUG_MODE_ARGS = testUtils.isVersionGreaterThan([7]) ?

--- a/packages/json/lib/test-utils.ts
+++ b/packages/json/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-26235535976-debian', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
 });
 
 export const GLOBAL = {

--- a/packages/search/lib/test-utils.ts
+++ b/packages/search/lib/test-utils.ts
@@ -6,7 +6,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-26235535976-debian', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
 });
 
 export const GLOBAL = {

--- a/packages/test-utils/lib/test-utils.ts
+++ b/packages/test-utils/lib/test-utils.ts
@@ -4,7 +4,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-26235535976-debian', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
 });
 
 

--- a/packages/time-series/lib/test-utils.ts
+++ b/packages/time-series/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-26235535976-debian', version: '8.8' }
+  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
 });
 
 export const GLOBAL = {


### PR DESCRIPTION
## Summary
- Bump default docker test image from `custom-26235535976-debian` to `8.8.0` (official 8.8 GA tag on `redislabs/client-libs-test`)
- Update CI matrix entry for 8.8 accordingly

## Test plan
- [ ] CI green across node 20/22 × redis 7.4/8.2/8.4/8.8 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI configuration only; no runtime library or application behavior changes.
> 
> **Overview**
> Switches Redis **8.8** integration testing from a one-off **`custom-26235535976-debian`** image to the published **`8.8.0`** tag on **`redislabs/client-libs-test`**.
> 
> The GitHub Actions test matrix uses **`8.8.0`** for the 8.8 row, and every package **`TestUtils.createFromConfig`** default (`defaultDockerVersion.tag`) is updated the same way (bloom, client, sentinel, entraid, json, search, test-utils, time-series).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc2b70782580410c447389f9c8c6e0758a9d17d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->