### PR TITLE
ci: bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -26,13 +26,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
         fetch-depth: 1
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
     - name: Update npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,6 +69,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,11 +10,11 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
       - name: Install Packages
         run: npm ci
       - name: Build Packages

--- a/.github/workflows/jsdoc-check.yml
+++ b/.github/workflows/jsdoc-check.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/release-drafter-bloom.yml
+++ b/.github/workflows/release-drafter-bloom.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter/bloom-config.yml

--- a/.github/workflows/release-drafter-entraid.yml
+++ b/.github/workflows/release-drafter-entraid.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter/entraid-config.yml

--- a/.github/workflows/release-drafter-json.yml
+++ b/.github/workflows/release-drafter-json.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter/json-config.yml

--- a/.github/workflows/release-drafter-search.yml
+++ b/.github/workflows/release-drafter-search.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter/search-config.yml

--- a/.github/workflows/release-drafter-time-series.yml
+++ b/.github/workflows/release-drafter-time-series.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter/time-series-config.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.RELEASE_KEY }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # First step: Handle regular issues (excluding needs-information)
       - name: Mark regular issues as stale
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -64,7 +64,7 @@ jobs:
 
       # Second step: Handle needs-information issues with accelerated timeline
       - name: Mark needs-information issues as stale
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,11 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Install Packages
@@ -48,7 +48,7 @@ jobs:
           - tag: "custom-26235535976-debian"
             version: "8.8"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Run tests


### PR DESCRIPTION
## Summary
- GitHub Actions runners start defaulting to Node 24 on **2026-06-16**; JS actions still on Node 20 will fail after that date.
- Bumps all JS-based actions in this repo to majors that run on Node 24.

### Version bumps
- \`actions/checkout\` v4 → v6
- \`actions/setup-node\` v3/v4 → v6
- \`actions/stale\` v9 → v10
- \`github/codeql-action/{init,autobuild,analyze}\` v2 → v4
- \`release-drafter/release-drafter\` v5 → v7

\`redis-developer/cae-otel-ci-visibility@v2\` is intentionally left unchanged (internal action, separate ownership).

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Test plan
- [ ] Tests workflow runs green on this PR
- [ ] JSDoc check workflow runs green on this PR
- [ ] CodeQL workflow runs green on this PR
- [ ] Lint job runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency pin updates with no runtime or product code changes; main risk is CI behavior regressions from newer action majors.
> 
> **Overview**
> Updates GitHub Actions workflows and the composite **run-tests** action so JavaScript-based actions use majors that run on **Node 24**, ahead of the runner default switch that breaks actions still on Node 20.
> 
> **`actions/checkout`** moves from v4 to **v6** everywhere it appears (tests, lint, release, CodeQL, docs, JSDoc, composite tests). **`actions/setup-node`** is unified on **v6** (from v3/v4), including documentation and release jobs. **CodeQL** init, autobuild, and analyze steps go from v2 to **v4**. **Release drafter** workflows for bloom, entraid, json, search, and time-series use **v7** instead of v5. **Stale** issue management uses **v10** instead of v9 for both stale steps.
> 
> No application or library code changes; **`redis-developer/cae-otel-ci-visibility@v2`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e09119c7fe22c0de4a636e92fed50c6be8b0b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->