### PR TITLE
test(client): fix three flaky tests around socket/connect lifecycle

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -1244,8 +1244,13 @@ describe('Client', () => {
     const promise = assert.rejects(client.connect(), ConnectionTimeoutError),
       start = process.hrtime.bigint();
 
-    while (process.hrtime.bigint() - start < 1_000_000) {
-      // block the event loop for 1ms, to make sure the connection will timeout
+    // Block the event loop for well over `connectTimeout` so the underlying
+    // socket's idle timer is guaranteed to have expired by the time the
+    // event loop runs again. With a 1ms block and a 1ms timeout the two race
+    // and on a fast host the TCP `connect` event can be processed before the
+    // timeout callback, leaving the test with a successful connection.
+    while (process.hrtime.bigint() - start < 50_000_000) {
+      // block the event loop for 50ms, to make sure the connection will timeout
     }
 
     await promise;

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -1099,6 +1099,18 @@ describe('Client', () => {
       const subscriber = await publisher.duplicate().connect();
 
       try {
+        // The forced reconnect below can emit `error` more than once
+        // (e.g. SocketClosedUnexpectedlyError followed by a transient
+        // ECONNREFUSED while the server tears the connection down). A
+        // permanent listener swallows the extras so they never surface as
+        // uncaught; a one-shot promise gate lets us still await the first
+        // error deterministically.
+        let resolveFirstError!: () => void;
+        const firstError = new Promise<void>(resolve => {
+          resolveFirstError = resolve;
+        });
+        subscriber.on('error', () => resolveFirstError());
+
         const channelListener = spy();
         await subscriber.subscribe('channel', channelListener);
 
@@ -1106,7 +1118,7 @@ describe('Client', () => {
         await subscriber.pSubscribe('channe*', patternListener);
 
         await Promise.all([
-          once(subscriber, 'error'),
+          firstError,
           publisher.clientKill({
             filter: 'SKIPME',
             skipMe: true

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -240,39 +240,50 @@ describe('Socket', () => {
   });
 
   describe('socketTimeout', () => {
-    const timeout = 50;
+    const timeout = 200;
     testUtils.testWithClient(
       'should timeout with positive socketTimeout values',
       async client => {
-        let timedOut = false;
-
-        assert.equal(client.isReady, true, 'client.isReady');
-        assert.equal(client.isOpen, true, 'client.isOpen');
-
+        // Attach a permanent error listener before connecting so the timeout
+        // event can never surface as an uncaught error — neither during the
+        // handshake nor in the idle window afterwards. `reconnectStrategy:
+        // false` makes the run deterministic and causes the client to emit
+        // `error` twice, so a permanent listener (not `once`) is required.
+        const errors: Error[] = [];
+        let resolveFirstError!: (err: Error) => void;
+        const firstError = new Promise<Error>(resolve => {
+          resolveFirstError = resolve;
+        });
         client.on('error', err => {
+          errors.push(err);
+          resolveFirstError(err);
+        });
+
+        try {
+          await client.connect();
+          assert.equal(client.isReady, true, 'client.isReady');
+          assert.equal(client.isOpen, true, 'client.isOpen');
+
+          const err = await firstError;
           assert.equal(
             err.message,
             `Socket timeout timeout. Expecting data, but didn't receive any in ${timeout}ms.`
           );
-
           assert.equal(client.isReady, false, 'client.isReady');
-
-          // This is actually a bug with the onSocketError implementation,
-          // the client should be closed before the error is emitted
-          process.nextTick(() => {
-            assert.equal(client.isOpen, false, 'client.isOpen');
-          });
-
-          timedOut = true;
-        });
-        await setTimeout(timeout * 2);
-        if (!timedOut) assert.fail('Should have timed out by now');
+          // `reconnectStrategy: false` closes the client synchronously after
+          // emitting the error.
+          assert.equal(client.isOpen, false, 'client.isOpen');
+        } finally {
+          if (client.isOpen) client.destroy();
+        }
       },
       {
         ...GLOBAL.SERVERS.OPEN,
+        disableClientSetup: true,
         clientOptions: {
           socket: {
-            socketTimeout: timeout
+            socketTimeout: timeout,
+            reconnectStrategy: false
           }
         }
       }

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -249,22 +249,17 @@ describe('Socket', () => {
         // handshake nor in the idle window afterwards. `reconnectStrategy:
         // false` makes the run deterministic and causes the client to emit
         // `error` twice, so a permanent listener (not `once`) is required.
-        const errors: Error[] = [];
-        let resolveFirstError!: (err: Error) => void;
-        const firstError = new Promise<Error>(resolve => {
-          resolveFirstError = resolve;
+        client.on('error', () => {
+          // keep a permanent listener for any later error emission
         });
-        client.on('error', err => {
-          errors.push(err);
-          resolveFirstError(err);
-        });
+        const firstError = once(client, 'error') as Promise<[Error]>;
 
         try {
           await client.connect();
           assert.equal(client.isReady, true, 'client.isReady');
           assert.equal(client.isOpen, true, 'client.isOpen');
 
-          const err = await firstError;
+          const [err] = await firstError;
           assert.equal(
             err.message,
             `Socket timeout timeout. Expecting data, but didn't receive any in ${timeout}ms.`


### PR DESCRIPTION
## Summary

Three flaky tests in `packages/client` consolidated into one branch, one commit each:

- **`Socket > socketTimeout > should timeout with positive socketTimeout values`** — listener attachment race let the socket-timeout error surface as uncaught on slow CI.
- **`Client > ConnectionTimeoutError`** — `connectTimeout: 1` raced a 1ms event-loop block; on fast hardware the `connect` event landed before the timeout callback and the connection succeeded.
- **`Client > PubSub > should resubscribe`** — `once(subscriber, 'error')` removed itself after the first emit, leaving the second (transient) error during the forced reconnect uncaught.

All three are wired up via the same root-cause shape: relying on a one-shot `once` listener for an event source that can fire more than once. The fix in each case is a permanent listener plus a one-shot promise gate to keep the test deterministic.

The `ConnectionTimeoutError` case is purely a timing margin bump.

## Test plan

- [x] `should timeout with positive socketTimeout values` × 10 runs locally — all pass
- [x] `ConnectionTimeoutError` × 5 runs locally — all pass
- [x] `should resubscribe` × 10 runs locally — all pass
- [x] Full Socket spec — 11/11 pass
- [x] Full PubSub spec — 5/5 pass
- [ ] CI on Node 18, 20, 22, 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test harness changes in spec files; no production client or socket behavior is modified.
> 
> **Overview**
> Stabilizes three flaky **client** integration tests that were racing socket/connect lifecycle timing and mishandling **multiple `error` emissions**.
> 
> For **Pub/Sub resubscribe** and **socketTimeout**, tests no longer rely on `once(..., 'error')` alone: they add a **permanent `error` listener** plus a **one-shot promise** to await the first error while swallowing follow-up errors (e.g. after `CLIENT KILL` or with `reconnectStrategy: false`).
> 
> The **socketTimeout** case also **connects explicitly** (`disableClientSetup`), bumps the timeout to **200ms**, sets **`reconnectStrategy: false`**, and asserts **`isOpen` synchronously** instead of deferring via `nextTick`.
> 
> The **ConnectionTimeoutError** test **blocks the event loop for ~50ms** (was ~1ms) so a **1ms `connectTimeout`** reliably fires before a successful connect on fast hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5fdc1925d7f3f7e0379691affa17677cbb4f8cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->