### PR TITLE
fix(client): default RESP to RESP2

### DIFF
--- a/packages/client/lib/client/enterprise-maintenance-manager.ts
+++ b/packages/client/lib/client/enterprise-maintenance-manager.ts
@@ -6,10 +6,8 @@ import assert from "node:assert";
 import { setTimeout } from "node:timers/promises";
 import { RedisTcpSocketOptions } from "./socket";
 import diagnostics_channel from "node:diagnostics_channel";
-import { RedisArgument } from "../RESP/types";
+import { RedisArgument, RedisFunctions, RedisModules, RedisScripts, RespVersions, TypeMapping } from "../RESP/types";
 import { publish, CHANNELS } from "./tracing";
-
-type RedisType = RedisClient<any, any, any, any, any>;
 
 export const SMIGRATED_EVENT = "__SMIGRATED";
 
@@ -72,13 +70,25 @@ export interface MaintenanceUpdate {
   relaxedSocketTimeout?: number;
 }
 
-export default class EnterpriseMaintenanceManager {
+export default class EnterpriseMaintenanceManager<
+  M extends RedisModules = RedisModules,
+  F extends RedisFunctions = RedisFunctions,
+  S extends RedisScripts = RedisScripts,
+  RESP extends RespVersions = RespVersions,
+  TYPE_MAPPING extends TypeMapping = TypeMapping
+> {
   #commandsQueue: RedisCommandsQueue;
-  #options: RedisClientOptions;
+  #options: RedisClientOptions<M, F, S, RESP, TYPE_MAPPING, RedisTcpSocketOptions>;
   #isMaintenance = 0;
-  #client: RedisType;
+  #client: RedisClient<M, F, S, RESP, TYPE_MAPPING>;
 
-  static setupDefaultMaintOptions(options: RedisClientOptions) {
+  static setupDefaultMaintOptions<
+    M extends RedisModules,
+    F extends RedisFunctions,
+    S extends RedisScripts,
+    RESP extends RespVersions = RespVersions,
+    TYPE_MAPPING extends TypeMapping = TypeMapping
+  >(options: RedisClientOptions<M, F, S, RESP, TYPE_MAPPING, RedisTcpSocketOptions>) {
     if (options.maintNotifications === undefined) {
       options.maintNotifications =
         options?.RESP === 3 ? "auto" : "disabled";
@@ -94,8 +104,14 @@ export default class EnterpriseMaintenanceManager {
     }
   }
 
-  static async getHandshakeCommand(
-    options: RedisClientOptions,
+  static async getHandshakeCommand<
+    M extends RedisModules = RedisModules,
+    F extends RedisFunctions = RedisFunctions,
+    S extends RedisScripts = RedisScripts,
+    RESP extends RespVersions = RespVersions,
+    TYPE_MAPPING extends TypeMapping = TypeMapping
+  >(
+    options: RedisClientOptions<M, F, S, RESP, TYPE_MAPPING, RedisTcpSocketOptions>,
     clientId: string,
   ): Promise<
     | { cmd: Array<RedisArgument>; errorHandler: (error: Error) => void }
@@ -140,8 +156,8 @@ export default class EnterpriseMaintenanceManager {
 
   constructor(
     commandsQueue: RedisCommandsQueue,
-    client: RedisType,
-    options: RedisClientOptions,
+    client: RedisClient<M, F, S, RESP, TYPE_MAPPING>,
+    options: RedisClientOptions<M, F, S, RESP, TYPE_MAPPING, RedisTcpSocketOptions>,
   ) {
     this.#commandsQueue = commandsQueue;
     this.#options = options;
@@ -465,7 +481,7 @@ function isPrivateIP(ip: string): boolean {
 async function determineEndpoint(
   tlsEnabled: boolean,
   host: string,
-  options: RedisClientOptions,
+  options: RedisClientOptions<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping, RedisTcpSocketOptions>,
 ): Promise<MovingEndpointType> {
   assert(options.maintEndpointType !== undefined);
   if (options.maintEndpointType !== "auto") {

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -31,7 +31,7 @@ export interface RedisClientOptions<
   M extends RedisModules = RedisModules,
   F extends RedisFunctions = RedisFunctions,
   S extends RedisScripts = RedisScripts,
-  RESP extends RespVersions = RespVersions,
+  RESP extends RespVersions = 2,
   TYPE_MAPPING extends TypeMapping = TypeMapping,
   SocketOptions extends RedisSocketOptions = RedisSocketOptions
 > extends CommanderConfig<M, F, S, RESP> {
@@ -365,7 +365,13 @@ export default class RedisClient<
     return RedisClient.factory(options)(options);
   }
 
-  static parseOptions<O extends RedisClientOptions>(options: O): O {
+  static parseOptions<
+    M extends RedisModules = RedisModules,
+    F extends RedisFunctions = RedisFunctions,
+    S extends RedisScripts = RedisScripts,
+    RESP extends RespVersions = RespVersions,
+    TYPE_MAPPING extends TypeMapping = TypeMapping
+  >(options: RedisClientOptions<M, F, S, RESP, TYPE_MAPPING>): RedisClientOptions<M, F, S, RESP, TYPE_MAPPING> {
     if (options?.url) {
       const parsed = RedisClient.parseURL(options.url);
       if (options.socket) {
@@ -380,15 +386,15 @@ export default class RedisClient<
     return options;
   }
 
-  static parseURL(url: string): RedisClientOptions & {
-    socket: Exclude<RedisClientOptions['socket'], undefined> & {
+  static parseURL(url: string): RedisClientOptions<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping, RedisSocketOptions> & {
+    socket: Exclude<RedisClientOptions<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping, RedisSocketOptions>['socket'], undefined> & {
       tls: boolean
     }
   } {
     // https://www.iana.org/assignments/uri-schemes/prov/redis
     const { hostname, port, protocol, username, password, pathname } = new URL(url),
-      parsed: RedisClientOptions & {
-        socket: Exclude<RedisClientOptions['socket'], undefined> & {
+      parsed: RedisClientOptions<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping, RedisSocketOptions> & {
+        socket: Exclude<RedisClientOptions<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping, RedisSocketOptions>['socket'], undefined> & {
           tls: boolean
         }
       } = {

--- a/packages/client/lib/commands/XINFO_GROUPS.spec.ts
+++ b/packages/client/lib/commands/XINFO_GROUPS.spec.ts
@@ -11,6 +11,44 @@ describe('XINFO GROUPS', () => {
     );
   });
 
+  it('transformReply', () => {
+    assert.deepEqual(
+      XINFO_GROUPS.transformReply[2]([[
+        'name', 'group',
+        'consumers', 0,
+        'pending', 0,
+        'last-delivered-id', '0-0'
+      ]]),
+      [Object.assign(Object.create(null), {
+        name: 'group',
+        consumers: 0,
+        pending: 0,
+        'last-delivered-id': '0-0'
+      })]
+    );
+  });
+
+  it('transformReply - Redis 7 fields', () => {
+    assert.deepEqual(
+      XINFO_GROUPS.transformReply[2]([[
+        'name', 'group',
+        'consumers', 0,
+        'pending', 0,
+        'last-delivered-id', '0-0',
+        'entries-read', null,
+        'lag', null
+      ]]),
+      [Object.assign(Object.create(null), {
+        name: 'group',
+        consumers: 0,
+        pending: 0,
+        'last-delivered-id': '0-0',
+        'entries-read': null,
+        lag: null
+      })]
+    );
+  });
+
   testUtils.testAll('xInfoGroups', async client => {
     const [, reply] = await Promise.all([
       client.xGroupCreate('key', 'group', '$', {

--- a/packages/client/lib/commands/XINFO_GROUPS.ts
+++ b/packages/client/lib/commands/XINFO_GROUPS.ts
@@ -1,5 +1,6 @@
 import { CommandParser } from '../client/parser';
-import { RedisArgument, ArrayReply, TuplesToMapReply, BlobStringReply, NumberReply, NullReply, UnwrapReply, Resp2Reply, Command } from '../RESP/types';
+import { RedisArgument, ArrayReply, TuplesToMapReply, BlobStringReply, NumberReply, NullReply, Command } from '../RESP/types';
+import { transformTuplesReply } from './generic-transformers';
 
 /**
  * Reply structure for XINFO GROUPS command containing information about consumer groups
@@ -8,11 +9,11 @@ export type XInfoGroupsReply = ArrayReply<TuplesToMapReply<[
   [BlobStringReply<'name'>, BlobStringReply],
   [BlobStringReply<'consumers'>, NumberReply],
   [BlobStringReply<'pending'>, NumberReply],
-  [BlobStringReply<'last-delivered-id'>, NumberReply],
+  [BlobStringReply<'last-delivered-id'>, BlobStringReply],
   /** added in 7.0 */
   [BlobStringReply<'entries-read'>, NumberReply | NullReply],
   /** added in 7.0 */
-  [BlobStringReply<'lag'>, NumberReply],
+  [BlobStringReply<'lag'>, NumberReply | NullReply],
 ]>>;
 
 export default {
@@ -34,19 +35,8 @@ export default {
      *          entries-read - Number of entries read in the group (Redis 7.0+)
      *          lag - Number of entries not read by the group (Redis 7.0+)
      */
-    2: (reply: UnwrapReply<Resp2Reply<XInfoGroupsReply>>) => {
-      return reply.map(group => {
-        const unwrapped = group as unknown as UnwrapReply<typeof group>;
-        return {
-          name: unwrapped[1],
-          consumers: unwrapped[3],
-          pending: unwrapped[5],
-          'last-delivered-id': unwrapped[7],
-          'entries-read': unwrapped[9],
-          lag: unwrapped[11]
-        };
-      });
-    },
+    2: (reply: Array<Array<BlobStringReply | NumberReply | NullReply>>) =>
+      reply.map(group => transformTuplesReply(group as unknown as ArrayReply<BlobStringReply>)) as unknown as XInfoGroupsReply['DEFAULT'],
     3: undefined as unknown as () => XInfoGroupsReply
   }
 } as const satisfies Command;

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -19,6 +19,8 @@ import { RedisTcpSocketOptions } from '../client/socket';
 import { BasicPooledClientSideCache, PooledClientSideCacheProvider } from '../client/cache';
 import { ClientIdentity, ClientRole, generateClientId } from '../client/identity';
 
+type BroadSentinelClient = RedisClientType<any, any, any, 2 | 3, any>;
+
 interface ClientInfo {
   id: number;
 }
@@ -162,7 +164,7 @@ export class RedisSentinelClient<
 
   async _execute<T>(
     isReadonly: boolean | undefined,
-    fn: (client: RedisClient<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>) => Promise<T>
+    fn: (client: BroadSentinelClient) => Promise<T>
   ): Promise<T> {
     if (this._self.#clientInfo === undefined) {
       throw new Error("Attempted execution on released RedisSentinelClient lease");
@@ -675,7 +677,7 @@ export class RedisSentinelInternal<
   readonly #name: string;
   readonly #sentinelClientId: string;
   readonly #nodeClientOptions: RedisClientOptions<M, F, S, RESP, TYPE_MAPPING, RedisTcpSocketOptions>;
-  readonly #sentinelClientOptions: RedisClientOptions<typeof RedisSentinelModule, RedisFunctions, RedisScripts, RespVersions, TypeMapping, RedisTcpSocketOptions>;
+  readonly #sentinelClientOptions: RedisClientOptions<typeof RedisSentinelModule, RedisFunctions, RedisScripts, RESP, TYPE_MAPPING, RedisTcpSocketOptions>;
   readonly #nodeAddressMap?: NodeAddressMap;
   readonly #scanInterval: number;
   readonly #passthroughClientErrorEvents: boolean;
@@ -686,13 +688,13 @@ export class RedisSentinelInternal<
   readonly #sentinelSeedNodes: Array<RedisNode>;
 
   #sentinelRootNodes: Array<RedisNode>;
-  #sentinelClient?: RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>;
+  #sentinelClient?: BroadSentinelClient;
 
-  #masterClients: Array<RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>> = [];
+  #masterClients: Array<BroadSentinelClient> = [];
   #masterClientQueue: WaitQueue<number>;
   readonly #masterPoolSize: number;
 
-  #replicaClients: Array<RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>> = [];
+  #replicaClients: Array<BroadSentinelClient> = [];
   #replicaClientsIdx: number = 0;
   readonly #replicaPoolSize: number;
 
@@ -702,7 +704,7 @@ export class RedisSentinelInternal<
 
   #connectPromise?: Promise<void>;
   #maxCommandRediscovers: number;
-  readonly #pubSubProxy: PubSubProxy;
+  readonly #pubSubProxy: PubSubProxy<RESP>;
 
   #scanTimer?: NodeJS.Timeout
 
@@ -767,13 +769,23 @@ export class RedisSentinelInternal<
     }
 
     /* persistent object for life of sentinel object */
-    this.#pubSubProxy = new PubSubProxy(
+    this.#pubSubProxy = new PubSubProxy<RESP>(
       this.#nodeClientOptions,
       err => this.emit('error', err)
     );
   }
 
-  #createClient(node: RedisNode, clientOptions: RedisClientOptions, reconnectStrategy?: false) {
+  #createClient<
+    _M extends RedisModules,
+    _F extends RedisFunctions,
+    _S extends RedisScripts,
+    _RESP extends RespVersions,
+    _TYPE_MAPPING extends TypeMapping
+  >(
+    node: RedisNode,
+    clientOptions: RedisClientOptions<_M, _F, _S, _RESP, _TYPE_MAPPING, RedisTcpSocketOptions>,
+    reconnectStrategy?: false
+  ): RedisClientType<_M, _F, _S, 2 | 3, _TYPE_MAPPING> {
     const socket = getMappedNode(node.host, node.port, this.#nodeAddressMap);
     const client = RedisClient.create({
       //first take the globally set RESP
@@ -887,7 +899,7 @@ export class RedisSentinelInternal<
   }
 
   async execute<T>(
-    fn: (client: RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>) => Promise<T>,
+    fn: (client: BroadSentinelClient) => Promise<T>,
     clientInfo?: ClientInfo
   ): Promise<T> {
     let iter = 0;
@@ -937,7 +949,7 @@ export class RedisSentinelInternal<
     }
   }
 
-  async #createPubSub(client: RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>) {
+  async #createPubSub(client: BroadSentinelClient) {
     /* Whenever sentinels or slaves get added, or when slave configuration changes, reconfigure */
     await client.pSubscribe(['switch-master', '[-+]sdown', '+slave', '+sentinel', '[-+]odown', '+slave-reconf-done'], (message, channel) => {
       this.#handlePubSubControlChannel(channel, message);
@@ -952,7 +964,7 @@ export class RedisSentinelInternal<
   }
 
   // if clientInfo is defined, it corresponds to a master client in the #masterClients array, otherwise loop around replicaClients
-  #getClient(clientInfo?: ClientInfo): RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping> {
+  #getClient(clientInfo?: ClientInfo): BroadSentinelClient {
     if (clientInfo !== undefined) {
       return this.#masterClients[clientInfo.id];
     }
@@ -1380,7 +1392,7 @@ export class RedisSentinelInternal<
       replicaCloseSet.add(str);
     }
 
-    const newClientList: Array<RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>> = [];
+    const newClientList: Array<BroadSentinelClient> = [];
     const removedSet = new Set<string>();
 
     for (const replica of this.#replicaClients) {

--- a/packages/client/lib/sentinel/pub-sub-proxy.ts
+++ b/packages/client/lib/sentinel/pub-sub-proxy.ts
@@ -4,12 +4,13 @@ import { RedisClientOptions } from '../client';
 import { PUBSUB_TYPE, PubSubListener, PubSubTypeListeners } from '../client/pub-sub';
 import { RedisNode } from './types';
 import RedisClient from '../client';
+import { RedisTcpSocketOptions } from '../client/socket';
 
-type Client = RedisClient<
+type Client<RESP extends RespVersions> = RedisClient<
   RedisModules,
   RedisFunctions,
   RedisScripts,
-  RespVersions,
+  RESP,
   TypeMapping
 >;
 
@@ -18,22 +19,22 @@ type Subscriptions = Record<
   PubSubTypeListeners
 >;
 
-type PubSubState = {
-  client: Client;
-  connectPromise: Promise<Client | undefined> | undefined;
+type PubSubState<RESP extends RespVersions> = {
+  client: Client<RESP>;
+  connectPromise: Promise<Client<RESP> | undefined> | undefined;
 };
 
 type OnError = (err: unknown) => unknown;
 
-export class PubSubProxy extends EventEmitter {
+export class PubSubProxy<RESP extends RespVersions = RespVersions> extends EventEmitter {
   #clientOptions;
   #onError;
 
   #node?: RedisNode;
-  #state?: PubSubState;
+  #state?: PubSubState<RESP>;
   #subscriptions?: Subscriptions;
 
-  constructor(clientOptions: RedisClientOptions, onError: OnError) {
+  constructor(clientOptions: RedisClientOptions<RedisModules, RedisFunctions, RedisScripts, RESP, TypeMapping, RedisTcpSocketOptions>, onError: OnError) {
     super();
 
     this.#clientOptions = clientOptions;
@@ -127,7 +128,7 @@ export class PubSubProxy extends EventEmitter {
     await this.#initiatePubSubClient(true);
   }
 
-  #executeCommand<T>(fn: (client: Client) => T) {
+  #executeCommand<T>(fn: (client: Client<RESP>) => T) {
     const client = this.#getPubSubClient();
     if (client instanceof RedisClient) {
       return fn(client);
@@ -158,7 +159,7 @@ export class PubSubProxy extends EventEmitter {
     );
   }
 
-  #unsubscribe<T>(fn: (client: Client) => Promise<T>) {
+  #unsubscribe<T>(fn: (client: Client<RESP>) => Promise<T>) {
     return this.#executeCommand(async client => {
       const reply = await fn(client);
 

--- a/packages/test-utils/lib/index.ts
+++ b/packages/test-utils/lib/index.ts
@@ -264,7 +264,13 @@ export default class TestUtils {
   /**
    * Cleans up non-default ACL users using a temporary client connection
    */
-  static async cleanupAclUsers(port: number, clientOptions?: Partial<RedisClientOptions>): Promise<void> {
+  static async cleanupAclUsers<
+    M extends RedisModules = RedisModules,
+    F extends RedisFunctions = RedisFunctions,
+    S extends RedisScripts = RedisScripts,
+    RESP extends RespVersions = RespVersions,
+    TYPE_MAPPING extends TypeMapping = TypeMapping
+  >(port: number, clientOptions?: Partial<RedisClientOptions<M, F, S, RESP, TYPE_MAPPING>>): Promise<void> {
     const cleanupClient = createClient({
       ...clientOptions,
       socket: {


### PR DESCRIPTION
## Summary
- Set RedisClientOptions default RESP from \RespVersions\ to \2\.
- Updated internal maintenance manager, sentinel pub-sub, sentinel internals, and test utils typings so RESP 2/3 are preserved correctly and avoid forcing a defaulted RESP in internal call paths.

## Validation
- 
pm run build
- 
pm run lint (changed files)

Note: lint:changed reports existing lint issues in these files (not introduced by this change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly TypeScript defaults and RESP2 reply shaping; runtime wire behavior for typical clients should stay RESP2 unless callers opt into RESP3.
> 
> **Overview**
> **Default protocol version:** `RedisClientOptions` now defaults the `RESP` generic to **`2`** instead of the full `RespVersions` union, matching runtime behavior (`RESP ?? 2` on the command queue).
> 
> **Typing follow-through:** `parseOptions` / `parseURL`, **Enterprise Maintenance Manager**, and **Sentinel** (`BroadSentinelClient`, `PubSubProxy<RESP>`, pooled clients) are updated so internal code does not widen or mis-infer RESP when options omit an explicit version.
> 
> **Streams:** `XINFO GROUPS` RESP2 parsing now uses `transformTuplesReply`; reply types treat `last-delivered-id` as a string and Redis 7 `lag` as nullable, with new unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c322ae5f6fe032f4d8b2c6b4433bcc6909910f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->