### PR TITLE
fix(search): support exact match with params

### DIFF
--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+
 import testUtils, { GLOBAL } from '../test-utils';
 import SEARCH from './SEARCH';
 import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
@@ -260,7 +261,9 @@ describe('FT.SEARCH', () => {
             number: 1
           }
         }),
-        ['FT.SEARCH', 'index', 'query', 'PARAMS', '6', 'string', 'string', 'buffer', Buffer.from('buffer'), 'number', '1', 'DIALECT', DEFAULT_DIALECT]
+
+        ['FT.SEARCH', 'index', 'query', 'PARAMS', '3', 'string', 'string', 'buffer', Buffer.from('buffer'), 'number', '1', 'DIALECT', DEFAULT_DIALECT]
+
       );
     });
 

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -8,23 +8,36 @@ import { getMapValue, mapLikeToObject, mapLikeValues, parseDocumentValue, parseS
 export type FtSearchParams = Record<string, RedisArgument | number>;
 
 export function parseParamsArgument(parser: CommandParser, params?: FtSearchParams) {
-  if (params) {
-    parser.push('PARAMS');
+  if (!params) return;
 
-    const args: Array<RedisArgument> = [];
-    for (const key in params) {
-      if (!Object.hasOwn(params, key)) continue;
+  parser.push('PARAMS');
 
-      const value = params[key];
-      args.push(
-        key,
-        typeof value === 'number' ? value.toString() : value
-      );
-    }
+  // FT.SEARCH expects: PARAMS <num-args> <k1> <v1> <k2> <v2> ...
+  // Where <num-args> is the *number of pairs*.
+  //
+  // The previous implementation incorrectly used `pushVariadicWithLength(args)`
+  // which sets the length to the number of *arguments*, not the required
+  // number of pairs. This causes exact-match queries like `@field:"$x"`
+  // to bind parameters incorrectly on some Redis Stack/FT versions.
+  const pairArgs: Array<RedisArgument> = [];
+  let pairs = 0;
 
-    parser.pushVariadicWithLength(args);
+  for (const key in params) {
+    if (!Object.hasOwn(params, key)) continue;
+
+    const value = params[key];
+    pairArgs.push(
+      key,
+      typeof value === 'number' ? value.toString() : value
+    );
+    pairs++;
   }
+
+  // <num-args> is the number of pairs, so it must be `pairs`.
+  parser.push(pairs.toString());
+  parser.pushVariadic(pairArgs);
 }
+
 
 export interface FtSearchOptions {
   VERBATIM?: boolean;


### PR DESCRIPTION
### Description

Fix `FT.SEARCH` when using `PARAMS` with exact-match queries (e.g. `@field:"$param"`).

Previously, the command serialization sent an incorrect `<num>` after `PARAMS`, which could break parameter binding for exact-match cases.

### Changes
- Fix `PARAMS` argument count serialization in `FT.SEARCH`
- Update regression test for `FT.SEARCH` argument building

Closes #2922

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, protocol-correct serialization fix in search command building with a unit test update; behavior change only fixes incorrect Redis wire format.
> 
> **Overview**
> Fixes **`FT.SEARCH`** (and **`FT.AGGREGATE`**, which reuse `parseParamsArgument`) so the value after `PARAMS` is the **number of key/value pairs**, not the total argument count.
> 
> Redis expects `PARAMS <num-pairs> <k1> <v1> …`. The client previously used `pushVariadicWithLength`, which emitted `6` for three pairs instead of `3`, breaking parameter binding for queries such as exact-match `@field:"$param"`. Serialization now pushes `pairs` explicitly, then the variadic key/value args.
> 
> The **`with PARAMS`** transform test expectation changes from `'6'` to `'3'` for the same three-param example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a3f64379f459155b6709261a66f25e4d7164e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->