### PR TITLE
feat(search): add COLLECT reducer to FT.AGGREGATE

### DIFF
--- a/packages/search/lib/commands/AGGREGATE.spec.ts
+++ b/packages/search/lib/commands/AGGREGATE.spec.ts
@@ -377,6 +377,162 @@ describe('AGGREGATE', () => {
             ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '0', 'REDUCE', 'RANDOM_SAMPLE', '2', '@property', '1', 'DIALECT', DEFAULT_DIALECT]
           );
         });
+
+        describe('COLLECT', () => {
+          it('FIELDS *', () => {
+            assert.deepEqual(
+              parseArgs(AGGREGATE, 'index', '*', {
+                STEPS: [{
+                  type: 'GROUPBY',
+                  REDUCE: {
+                    type: 'COLLECT',
+                    FIELDS: '*'
+                  }
+                }]
+              }),
+              ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '0', 'REDUCE', 'COLLECT', '2', 'FIELDS', '*', 'DIALECT', DEFAULT_DIALECT]
+            );
+          });
+
+          it('FIELDS single field', () => {
+            assert.deepEqual(
+              parseArgs(AGGREGATE, 'index', '*', {
+                STEPS: [{
+                  type: 'GROUPBY',
+                  REDUCE: {
+                    type: 'COLLECT',
+                    FIELDS: '@field'
+                  }
+                }]
+              }),
+              ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '0', 'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@field', 'DIALECT', DEFAULT_DIALECT]
+            );
+          });
+
+          it('FIELDS array', () => {
+            assert.deepEqual(
+              parseArgs(AGGREGATE, 'index', '*', {
+                STEPS: [{
+                  type: 'GROUPBY',
+                  REDUCE: {
+                    type: 'COLLECT',
+                    FIELDS: ['@a', '@b']
+                  }
+                }]
+              }),
+              ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '0', 'REDUCE', 'COLLECT', '4', 'FIELDS', '2', '@a', '@b', 'DIALECT', DEFAULT_DIALECT]
+            );
+          });
+
+          it('with DISTINCT', () => {
+            assert.deepEqual(
+              parseArgs(AGGREGATE, 'index', '*', {
+                STEPS: [{
+                  type: 'GROUPBY',
+                  REDUCE: {
+                    type: 'COLLECT',
+                    FIELDS: '*',
+                    DISTINCT: true
+                  }
+                }]
+              }),
+              ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '0', 'REDUCE', 'COLLECT', '3', 'FIELDS', '*', 'DISTINCT', 'DIALECT', DEFAULT_DIALECT]
+            );
+          });
+
+          it('with SORTBY string', () => {
+            assert.deepEqual(
+              parseArgs(AGGREGATE, 'index', '*', {
+                STEPS: [{
+                  type: 'GROUPBY',
+                  REDUCE: {
+                    type: 'COLLECT',
+                    FIELDS: '*',
+                    SORTBY: '@field'
+                  }
+                }]
+              }),
+              ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '0', 'REDUCE', 'COLLECT', '5', 'FIELDS', '*', 'SORTBY', '1', '@field', 'DIALECT', DEFAULT_DIALECT]
+            );
+          });
+
+          it('with SORTBY array and directions', () => {
+            assert.deepEqual(
+              parseArgs(AGGREGATE, 'index', '*', {
+                STEPS: [{
+                  type: 'GROUPBY',
+                  REDUCE: {
+                    type: 'COLLECT',
+                    FIELDS: '*',
+                    SORTBY: [
+                      { BY: '@target', DIRECTION: 'DESC' },
+                      { BY: '@bestByDate', DIRECTION: 'ASC' }
+                    ]
+                  }
+                }]
+              }),
+              ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '0', 'REDUCE', 'COLLECT', '8', 'FIELDS', '*', 'SORTBY', '4', '@target', 'DESC', '@bestByDate', 'ASC', 'DIALECT', DEFAULT_DIALECT]
+            );
+          });
+
+          it('with LIMIT', () => {
+            assert.deepEqual(
+              parseArgs(AGGREGATE, 'index', '*', {
+                STEPS: [{
+                  type: 'GROUPBY',
+                  REDUCE: {
+                    type: 'COLLECT',
+                    FIELDS: '*',
+                    LIMIT: { from: 0, size: 5 }
+                  }
+                }]
+              }),
+              ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '0', 'REDUCE', 'COLLECT', '5', 'FIELDS', '*', 'LIMIT', '0', '5', 'DIALECT', DEFAULT_DIALECT]
+            );
+          });
+
+          it('movies-by-genre example (narg 9)', () => {
+            assert.deepEqual(
+              parseArgs(AGGREGATE, 'index', '*', {
+                STEPS: [{
+                  type: 'GROUPBY',
+                  properties: '@genre',
+                  REDUCE: {
+                    type: 'COLLECT',
+                    FIELDS: '*',
+                    SORTBY: { BY: '@rating', DIRECTION: 'DESC' },
+                    LIMIT: { from: 0, size: 5 },
+                    AS: 'top_movies'
+                  }
+                }]
+              }),
+              ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '1', '@genre', 'REDUCE', 'COLLECT', '9', 'FIELDS', '*', 'SORTBY', '2', '@rating', 'DESC', 'LIMIT', '0', '5', 'AS', 'top_movies', 'DIALECT', DEFAULT_DIALECT]
+            );
+          });
+
+          it('relationships example (narg 12, DISTINCT)', () => {
+            assert.deepEqual(
+              parseArgs(AGGREGATE, 'index', '*', {
+                STEPS: [{
+                  type: 'GROUPBY',
+                  properties: '@relationshipName',
+                  REDUCE: {
+                    type: 'COLLECT',
+                    FIELDS: '*',
+                    DISTINCT: true,
+                    SORTBY: [
+                      { BY: '@target', DIRECTION: 'DESC' },
+                      { BY: '@bestByDate', DIRECTION: 'ASC' }
+                    ],
+                    LIMIT: { from: 0, size: 3 },
+                    AS: 'all_distinct_docs'
+                  }
+                }]
+              }),
+              ['FT.AGGREGATE', 'index', '*', 'GROUPBY', '1', '@relationshipName', 'REDUCE', 'COLLECT', '12', 'FIELDS', '*', 'DISTINCT', 'SORTBY', '4', '@target', 'DESC', '@bestByDate', 'ASC', 'LIMIT', '0', '3', 'AS', 'all_distinct_docs', 'DIALECT', DEFAULT_DIALECT]
+            );
+          });
+        });
       });
 
       describe('SORTBY', () => {
@@ -602,4 +758,38 @@ describe('AGGREGATE', () => {
       }
     }
   });
+
+  testUtils.testWithClient('client.ft.aggregate with COLLECT reducer', async client => {
+    await client.ft.create('index', {
+      genre: 'TAG',
+      rating: 'NUMERIC'
+    });
+    await client.hSet('movie:1', { genre: 'action', rating: '8' });
+    await client.hSet('movie:2', { genre: 'action', rating: '9' });
+    await client.hSet('movie:3', { genre: 'drama', rating: '7' });
+
+    const reply = await client.ft.aggregate('index', '*', {
+      LOAD: '*',
+      STEPS: [{
+        type: 'GROUPBY',
+        properties: '@genre',
+        REDUCE: {
+          type: 'COLLECT',
+          FIELDS: '*',
+          SORTBY: { BY: '@rating', DIRECTION: 'DESC' },
+          LIMIT: { from: 0, size: 5 },
+          AS: 'top_movies'
+        }
+      }]
+    });
+
+    assert.ok(reply !== null && typeof reply === 'object');
+    assert.ok(Array.isArray(reply.results));
+    assert.ok(reply.results.length > 0);
+    // Each group exposes the COLLECT alias holding an array of per-document maps
+    for (const group of reply.results) {
+      assert.ok('top_movies' in group);
+      assert.ok(Array.isArray((group as Record<string, unknown>).top_movies));
+    }
+  }, GLOBAL.SERVERS.OPEN_UNSTABLE);
 });

--- a/packages/search/lib/commands/AGGREGATE.spec.ts
+++ b/packages/search/lib/commands/AGGREGATE.spec.ts
@@ -791,5 +791,38 @@ describe('AGGREGATE', () => {
       assert.ok('top_movies' in group);
       assert.ok(Array.isArray((group as Record<string, unknown>).top_movies));
     }
-  }, { ...GLOBAL.SERVERS.OPEN_UNSTABLE, minimumDockerVersion: [8, 8] });
+  }, { ...GLOBAL.SERVERS.OPEN_UNSTABLE, minimumDockerVersion: [8, 10] });
+
+  testUtils.testWithClient('client.ft.aggregate with COLLECT DISTINCT reducer', async client => {
+    await client.ft.create('index', {
+      genre: 'TAG',
+      rating: 'NUMERIC'
+    });
+    // Two action movies share rating 8 - DISTINCT collapses the duplicate.
+    await client.hSet('movie:1', { genre: 'action', rating: '8' });
+    await client.hSet('movie:2', { genre: 'action', rating: '8' });
+    await client.hSet('movie:3', { genre: 'action', rating: '9' });
+
+    const reply = await client.ft.aggregate('index', '@genre:{action}', {
+      LOAD: '*',
+      STEPS: [{
+        type: 'GROUPBY',
+        properties: '@genre',
+        REDUCE: {
+          type: 'COLLECT',
+          FIELDS: '@rating',
+          DISTINCT: true,
+          AS: 'ratings'
+        }
+      }]
+    });
+
+    assert.ok(reply !== null && typeof reply === 'object');
+    assert.ok(Array.isArray(reply.results));
+    assert.strictEqual(reply.results.length, 1);
+    const collected = (reply.results[0] as Record<string, unknown>).ratings;
+    assert.ok(Array.isArray(collected));
+    // Three docs, two duplicate ratings - DISTINCT yields two entries.
+    assert.strictEqual(collected.length, 2);
+  }, { ...GLOBAL.SERVERS.OPEN_UNSTABLE, minimumDockerVersion: [8, 10] });
 });

--- a/packages/search/lib/commands/AGGREGATE.spec.ts
+++ b/packages/search/lib/commands/AGGREGATE.spec.ts
@@ -791,5 +791,5 @@ describe('AGGREGATE', () => {
       assert.ok('top_movies' in group);
       assert.ok(Array.isArray((group as Record<string, unknown>).top_movies));
     }
-  }, GLOBAL.SERVERS.OPEN_UNSTABLE);
+  }, { ...GLOBAL.SERVERS.OPEN_UNSTABLE, minimumDockerVersion: [8, 8] });
 });

--- a/packages/search/lib/commands/AGGREGATE.ts
+++ b/packages/search/lib/commands/AGGREGATE.ts
@@ -40,7 +40,8 @@ export const FT_AGGREGATE_GROUP_BY_REDUCERS = {
   QUANTILE: 'QUANTILE',
   TOLIST: 'TOLIST',
   FIRST_VALUE: 'FIRST_VALUE',
-  RANDOM_SAMPLE: 'RANDOM_SAMPLE'
+  RANDOM_SAMPLE: 'RANDOM_SAMPLE',
+  COLLECT: 'COLLECT'
 } as const;
 
 type FT_AGGREGATE_GROUP_BY_REDUCERS = typeof FT_AGGREGATE_GROUP_BY_REDUCERS;
@@ -89,7 +90,17 @@ interface RandomSampleReducer extends GroupByReducerWithProperty<FT_AGGREGATE_GR
   sampleSize: number;
 }
 
-export type GroupByReducers = CountReducer | CountDistinctReducer | CountDistinctishReducer | SumReducer | MinReducer | MaxReducer | AvgReducer | StdDevReducer | QuantileReducer | ToListReducer | FirstValueReducer | RandomSampleReducer;
+interface CollectReducer extends GroupByReducer<FT_AGGREGATE_GROUP_BY_REDUCERS['COLLECT']> {
+  FIELDS: '*' | RediSearchProperty | Array<RediSearchProperty>;
+  DISTINCT?: boolean;
+  SORTBY?: SortByProperty | Array<SortByProperty>;
+  LIMIT?: {
+    from: number;
+    size: number;
+  };
+}
+
+export type GroupByReducers = CountReducer | CountDistinctReducer | CountDistinctishReducer | SumReducer | MinReducer | MaxReducer | AvgReducer | StdDevReducer | QuantileReducer | ToListReducer | FirstValueReducer | RandomSampleReducer | CollectReducer;
 
 interface GroupByStep extends AggregateStep<FT_AGGREGATE_STEPS['GROUPBY']> {
   properties?: RediSearchProperty | Array<RediSearchProperty>;
@@ -365,6 +376,39 @@ export function parseGroupByReducer(parser: CommandParser, reducer: GroupByReduc
     case FT_AGGREGATE_GROUP_BY_REDUCERS.RANDOM_SAMPLE:
       parser.push('2', reducer.property, reducer.sampleSize.toString());
       break;
+
+    case FT_AGGREGATE_GROUP_BY_REDUCERS.COLLECT: {
+      const args: Array<RedisArgument> = ['FIELDS'];
+
+      // Wildcard is a bare token (`FIELDS *`); an explicit list is count-prefixed
+      // (`FIELDS <num> field ...`).
+      if (reducer.FIELDS === '*') {
+        args.push('*');
+      } else {
+        const fields = Array.isArray(reducer.FIELDS) ? reducer.FIELDS : [reducer.FIELDS];
+        args.push(fields.length.toString(), ...fields);
+      }
+
+      if (reducer.DISTINCT) {
+        args.push('DISTINCT');
+      }
+
+      if (reducer.SORTBY) {
+        const sortBys = Array.isArray(reducer.SORTBY) ? reducer.SORTBY : [reducer.SORTBY];
+        const sortArgs: Array<RedisArgument> = [];
+        for (const sortBy of sortBys) {
+          pushSortByProperty(sortArgs, sortBy);
+        }
+        args.push('SORTBY', sortArgs.length.toString(), ...sortArgs);
+      }
+
+      if (reducer.LIMIT) {
+        args.push('LIMIT', reducer.LIMIT.from.toString(), reducer.LIMIT.size.toString());
+      }
+
+      parser.pushVariadicWithLength(args);
+      break;
+    }
   }
 
   if (reducer.AS) {

--- a/packages/search/lib/test-utils.ts
+++ b/packages/search/lib/test-utils.ts
@@ -28,6 +28,15 @@ export const GLOBAL = {
           ft: RediSearch
         }
       }
+    },
+    OPEN_UNSTABLE: {
+      serverArguments: ['--search-enable-unstable-features', 'yes'],
+      clientOptions: {
+        RESP: 3 as const,
+        modules: {
+          ft: RediSearch
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
Support the experimental COLLECT reducer (Redis Search 8.8), which fetches whole documents or projected fields within each GROUPBY group, with optional DISTINCT, in-group SORTBY, and LIMIT.

- FIELDS '*' emits a bare wildcard token; an explicit list is count-prefixed
- nargs is computed dynamically via pushVariadicWithLength (unlike the fixed-narg reducers), covering FIELDS/DISTINCT/SORTBY/LIMIT
- reuses pushSortByProperty for the nested SORTBY clause
- HYBRID picks up COLLECT automatically (shared parseGroupByReducer)



### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and command encoding for an optional reducer; existing reducers unchanged, with coverage focused on argument transformation and opt-in unstable server tests.
> 
> **Overview**
> Adds client support for the experimental **COLLECT** `GROUPBY` reducer on `FT.AGGREGATE`, so callers can gather full documents or selected fields per group with optional **DISTINCT**, in-group **SORTBY**, **LIMIT**, and **AS** aliases.
> 
> `parseGroupByReducer` now serializes COLLECT with dynamic nargs via `pushVariadicWithLength` (wildcard `FIELDS *` vs count-prefixed field lists, plus optional clauses). **HYBRID** inherits COLLECT through the shared reducer parser. Tests add transform coverage and integration runs against **`OPEN_UNSTABLE`** (Redis 8.10+ with unstable search features).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86098fad85e242338a5ed1e81b43a73a8169f53b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->