### PR TITLE
feat: add key prefixing (fixes #2982)

### DIFF
--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -20,6 +20,7 @@
 | password                     |                                          | ACL password or the old "--requirepass" password                                                                                                                                                                                                    |
 | name                         |                                          | Client name ([see `CLIENT SETNAME`](https://redis.io/commands/client-setname))                                                                                                                                                                      |
 | database                     |                                          | Redis database number (see [`SELECT`](https://redis.io/commands/select) command)                                                                                                                                                                    |
+| keyPrefix                    |                                          | Prefix prepended to every key sent to Redis (ioredis-compatible). See [Key Prefixing](#key-prefixing).                                                                                                                                              |
 | modules                      |                                          | Included [Redis Modules](../README.md#packages)                                                                                                                                                                                                     |
 | scripts                      |                                          | Script definitions (see [Lua Scripts](../README.md#lua-scripts))                                                                                                                                                                                    |
 | functions                    |                                          | Function definitions (see [Functions](../README.md#functions))                                                                                                                                                                                      |
@@ -90,6 +91,36 @@ createClient({
   }
 });
 ```
+## Key Prefixing
+
+The `keyPrefix` option prepends a prefix to **every key** sent to Redis. It is an ioredis-compatible
+way to isolate keyspaces — for example to isolate tests in CI, or to separate the keys of different
+parts of an application (web app, background workers, …) that share a single Redis instance.
+
+```javascript
+const client = createClient({ keyPrefix: 'app:' });
+await client.connect();
+
+await client.set('key', 'value'); // actually stores 'app:key'
+await client.get('key');          // reads 'app:key' -> 'value'
+```
+
+The prefix is applied uniformly across the standard client, [cluster](./clustering.md),
+[sentinel](./sentinel.md), [pool](./pool.md), and inside [transactions and pipelines](./transactions.md).
+In cluster mode the slot is computed from the prefixed key, so routing remains correct.
+
+### Semantics (matching ioredis)
+
+- Only keys **sent** to Redis are prefixed. Keys **returned** by Redis are **not** un-prefixed — e.g.
+  `KEYS *`, `SCAN`, and `RANDOMKEY` return keys that still include the prefix.
+- `SCAN`/`KEYS`/`HSCAN`/… `MATCH` patterns are **not** auto-prefixed. Include the prefix in the
+  pattern yourself if required (e.g. `client.scan('0', { MATCH: 'app:user:*' })`).
+- Pub/Sub channels are **not** prefixed (this includes sharded `SPUBLISH`/`SSUBSCRIBE`), since
+  channels are a separate namespace from keys.
+- The deprecated `parseArgs`/`transformArguments` helper does not apply `keyPrefix`.
+
+`keyPrefix` may be a `string` or a `Buffer`.
+
 ## Connection Pooling
 
 In most cases, a single Redis connection is sufficient, as the node-redis client efficiently handles commands using an underlying socket. Unlike traditional databases, Redis does not require connection pooling for optimal performance.

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -113,6 +113,10 @@ In cluster mode the slot is computed from the prefixed key, so routing remains c
 
 - Only keys **sent** to Redis are prefixed. Keys **returned** by Redis are **not** un-prefixed — e.g.
   `KEYS *`, `SCAN`, and `RANDOMKEY` return keys that still include the prefix.
+- Because returned keys keep the prefix, **`scanIterator` yields already-prefixed keys**. Feeding
+  them straight back into a key-prefixing command double-prefixes them — e.g. with `keyPrefix: 'app:'`,
+  a yielded `'app:foo'` passed to `client.mGet(...)` becomes `'app:app:foo'`. Strip the prefix first,
+  or use a client without a `keyPrefix`. See [Scan Iterators](./scan-iterators.md).
 - `SCAN`/`KEYS`/`HSCAN`/… `MATCH` patterns are **not** auto-prefixed. Include the prefix in the
   pattern yourself if required (e.g. `client.scan('0', { MATCH: 'app:user:*' })`).
 - Pub/Sub channels are **not** prefixed (this includes sharded `SPUBLISH`/`SSUBSCRIBE`), since

--- a/docs/scan-iterators.md
+++ b/docs/scan-iterators.md
@@ -10,6 +10,8 @@ for await (const keys of client.scanIterator()) {
 }
 ```
 
+> :warning: **`keyPrefix` gotcha:** When the client is configured with a [`keyPrefix`](./client-configuration.md#key-prefixing), `scanIterator` yields the **already-prefixed** keys as stored on the server (replies are never un-prefixed). Passing them straight back into a key-prefixing command — like the `mGet(keys)` above — prefixes them a **second** time. For example, with `keyPrefix: 'app:'` a yielded `'app:foo'` becomes `'app:app:foo'`, so the `mGet` silently reads the wrong keys. Strip the prefix before reusing the keys, or read them with a separate client that has no `keyPrefix`. (This affects only `scanIterator`; `HSCAN`/`SSCAN`/`ZSCAN` yield fields/members, which are not keys.)
+
 This works with `HSCAN`, `SSCAN`, and `ZSCAN` too:
 
 ```javascript

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -1643,6 +1643,25 @@ export default class RedisClient<
 
   multi = this.MULTI;
 
+  /**
+   * Async iterator over the keyspace, issuing paged `SCAN` calls and yielding one array
+   * of keys per page until the cursor returns to `0`.
+   *
+   * @remarks
+   * With a configured {@link RedisClientOptions.keyPrefix}, the yielded keys are the
+   * **already-prefixed** keys as stored on the server — replies are never un-prefixed.
+   * Passing them straight back into a key-prefixed command prefixes them a second time
+   * (e.g. with `keyPrefix: 'app:'`, a yielded `'app:foo'` becomes `'app:app:foo'`):
+   *
+   * ```js
+   * for await (const keys of client.scanIterator()) {
+   *   await client.mGet(keys); // ⚠️ double-prefixes -> reads 'app:app:foo'
+   * }
+   * ```
+   *
+   * Strip the prefix before reusing the keys, or read them with a client that has no
+   * `keyPrefix`.
+   */
   async* scanIterator(
     this: RedisClientType<M, F, S, RESP, TYPE_MAPPING>,
     options?: ScanOptions & ScanIteratorOptions

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -69,6 +69,24 @@ export interface RedisClientOptions<
    */
   database?: number;
   /**
+   * Prefix prepended to every key sent to Redis (ioredis-compatible `keyPrefix`).
+   *
+   * Useful for isolating keyspaces — for example per-test isolation in CI, or
+   * separating an application's components (web app vs. background workers) within a
+   * single Redis instance.
+   *
+   * Matches ioredis semantics: only keys *sent* to Redis are prefixed. Keys *returned*
+   * by Redis (e.g. `KEYS`, `SCAN`, `RANDOMKEY`) are NOT un-prefixed, `SCAN`/`KEYS`
+   * `MATCH` patterns are NOT auto-prefixed, and Pub/Sub channels are NOT prefixed.
+   *
+   * @example
+   * ```
+   * const client = createClient({ keyPrefix: 'app:' });
+   * await client.set('key', 'value'); // stored as 'app:key'
+   * ```
+   */
+  keyPrefix?: RedisArgument;
+  /**
    * Maximum length of the client's internal command queue
    */
   commandsQueueMaxLength?: number;
@@ -291,7 +309,7 @@ export default class RedisClient<
     const transformReply = getTransformReply(command, resp);
 
     return async function (this: ProxyClient, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       command.parseCommand(parser, ...args);
 
       return this._self._executeCommand(command, parser, this._commandOptions, transformReply);
@@ -302,7 +320,7 @@ export default class RedisClient<
     const transformReply = getTransformReply(command, resp);
 
     return async function (this: NamespaceProxyClient, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       command.parseCommand(parser, ...args);
 
       return this._self._executeCommand(command, parser, this._self._commandOptions, transformReply);
@@ -314,7 +332,7 @@ export default class RedisClient<
     const transformReply = getTransformReply(fn, resp);
 
     return async function (this: NamespaceProxyClient, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       parser.push(...prefix);
       fn.parseCommand(parser, ...args);
 
@@ -327,7 +345,7 @@ export default class RedisClient<
     const transformReply = getTransformReply(script, resp);
 
     return async function (this: ProxyClient, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       parser.push(...prefix);
       script.parseCommand(parser, ...args)
 
@@ -546,6 +564,14 @@ export default class RedisClient<
 
   get options(): RedisClientOptions<M, F, S, RESP> {
     return this._self.#options;
+  }
+
+  /**
+   * The configured key prefix (see {@link RedisClientOptions.keyPrefix}), if any.
+   * @internal
+   */
+  get _keyPrefix(): RedisArgument | undefined {
+    return this._self.#options.keyPrefix;
   }
 
   /**
@@ -1606,7 +1632,8 @@ export default class RedisClient<
     return new ((this as unknown as { Multi: Multi }).Multi)(
       this._executeMulti.bind(this),
       this._executePipeline.bind(this),
-      this._commandOptions?.typeMapping
+      this._commandOptions?.typeMapping,
+      this._self._keyPrefix
     );
   }
 

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -15,9 +15,9 @@ import HELLO, { HelloOptions } from '../commands/HELLO';
 import { ScanOptions, ScanCommonOptions } from '../commands/SCAN';
 import { RedisLegacyClient, RedisLegacyClientType } from './legacy-mode';
 import { RedisPoolOptions, RedisClientPool } from './pool';
-import { RedisVariadicArgument, parseArgs, pushVariadicArguments } from '../commands/generic-transformers';
+import { RedisVariadicArgument, parseArgs } from '../commands/generic-transformers';
 import { BasicClientSideCache, ClientSideCacheConfig, ClientSideCacheProvider } from './cache';
-import { BasicCommandParser, CommandParser } from './parser';
+import { BasicCommandParser, CommandParser, prefixKeys } from './parser';
 import SingleEntryCache from '../single-entry-cache';
 import { version } from '../../package.json'
 import EnterpriseMaintenanceManager, { MaintenanceUpdate, MovingEndpointType, SMIGRATED_EVENT, SMigratedEvent } from './enterprise-maintenance-manager';
@@ -1438,8 +1438,12 @@ export default class RedisClient<
   sUnsubscribe = this.SUNSUBSCRIBE;
 
   async WATCH(key: RedisVariadicArgument) {
+    // WATCH builds its arguments outside of the command parser, so the configured
+    // `keyPrefix` must be applied here too — otherwise WATCH would guard the unprefixed
+    // key while the transaction operates on the prefixed one, silently breaking the
+    // optimistic lock.
     const reply = await this._self.sendCommand(
-      pushVariadicArguments(['WATCH'], key)
+      ['WATCH', ...prefixKeys(this._self._keyPrefix, key)]
     );
     this._self.#watchEpoch ??= this._self.socketEpoch;
     return reply as unknown as ReplyWithTypeMapping<SimpleStringReply<'OK'>, TYPE_MAPPING>;

--- a/packages/client/lib/client/key-prefix.spec.ts
+++ b/packages/client/lib/client/key-prefix.spec.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL } from '../test-utils';
+import { WatchError } from '../errors';
 
 const PREFIX = 'test-prefix:';
 
@@ -87,6 +88,27 @@ describe('keyPrefix', () => {
     assert.deepEqual(await client.keys('*'), [`${PREFIX}key`]);
   }, OPTIONS);
 
+  testUtils.testWithClient('WATCH guards the prefixed key', async client => {
+    await client.set('key', 'value');
+    await client.watch('key');
+
+    // Modify the watched (prefixed) key from another prefixed connection.
+    const other = await client.duplicate().connect();
+    try {
+      await other.set('key', 'changed');
+    } finally {
+      other.destroy();
+    }
+
+    // The transaction must abort: WATCH must have guarded the *prefixed* key.
+    // (With the bug, WATCH guards the unprefixed key, the write above is not seen,
+    // and EXEC would NOT abort.)
+    await assert.rejects(
+      client.multi().get('key').exec(),
+      WatchError
+    );
+  }, OPTIONS);
+
   testUtils.testWithClient('does not prefix Pub/Sub channels', async publisher => {
     const subscriber = publisher.duplicate();
     await subscriber.connect();
@@ -158,6 +180,22 @@ describe('keyPrefix', () => {
     clusterConfiguration: { keyPrefix: PREFIX }
   });
 
+  testUtils.testWithCluster('prefixes an explicit routing key passed to multi()', async cluster => {
+    // The explicit routing key must be prefixed so it hashes to the same slot as the
+    // (prefixed) keys the commands operate on. With the bug, the transaction routes on
+    // the unprefixed key and fails with CROSSSLOT/MOVED.
+    const replies = await cluster.multi('key')
+      .set('key', 'value')
+      .get('key')
+      .exec();
+
+    assert.deepEqual(replies, ['OK', 'value']);
+    assert.equal(await cluster.get('key'), 'value');
+  }, {
+    ...GLOBAL.CLUSTERS.OPEN,
+    clusterConfiguration: { keyPrefix: PREFIX }
+  });
+
   testUtils.testWithClientSentinel('applies keyPrefix to commands sent through sentinel', async sentinel => {
     await sentinel.set('key', 'value');
 
@@ -171,6 +209,22 @@ describe('keyPrefix', () => {
     assert.deepEqual(replies, ['value']);
   }, {
     ...GLOBAL.SENTINEL.OPEN,
+    sentinelOptions: { keyPrefix: PREFIX }
+  });
+
+  testUtils.testWithClientSentinel('WATCH guards the prefixed key through sentinel', async sentinel => {
+    const promise = sentinel.use(async client => {
+      await client.set('key', '1');
+      await client.watch('key');
+      // concurrent write to the same (prefixed) key from another connection
+      await sentinel.set('key', '2');
+      return client.multi().get('key').exec();
+    });
+
+    // The transaction must abort: WATCH must have guarded the *prefixed* key.
+    await assert.rejects(promise, WatchError);
+  }, {
+    ...GLOBAL.SENTINEL.WITH_MASTER_POOL_SIZE_2,
     sentinelOptions: { keyPrefix: PREFIX }
   });
 });

--- a/packages/client/lib/client/key-prefix.spec.ts
+++ b/packages/client/lib/client/key-prefix.spec.ts
@@ -1,0 +1,176 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+
+const PREFIX = 'test-prefix:';
+
+/**
+ * End-to-end coverage for the `keyPrefix` option. Because replies are NOT un-prefixed
+ * (ioredis parity), `KEYS *` reveals the raw keys stored on the server and is used here
+ * to assert that the prefix was actually applied on the wire.
+ */
+describe('keyPrefix', () => {
+  const OPTIONS = {
+    ...GLOBAL.SERVERS.OPEN,
+    clientOptions: { keyPrefix: PREFIX }
+  };
+
+  testUtils.testWithClient('prefixes keys sent to the server and round-trips transparently', async client => {
+    await client.set('key', 'value');
+
+    // the value is readable through the (prefixed) client
+    assert.equal(await client.get('key'), 'value');
+    // ...and the key is actually stored prefixed on the server
+    assert.deepEqual(await client.keys('*'), [`${PREFIX}key`]);
+  }, OPTIONS);
+
+  testUtils.testWithClient('does not un-prefix keys returned by the server', async client => {
+    await client.set('key', 'value');
+    const keys = await client.keys('*');
+    // ioredis parity: returned keys keep the prefix
+    assert.deepEqual(keys, [`${PREFIX}key`]);
+    assert.notDeepEqual(keys, ['key']);
+  }, OPTIONS);
+
+  testUtils.testWithClient('prefixes every key of a multi-key command', async client => {
+    await client.mSet([['a', '1'], ['b', '2']]);
+
+    assert.deepEqual(await client.mGet(['a', 'b']), ['1', '2']);
+    assert.deepEqual((await client.keys('*')).sort(), [`${PREFIX}a`, `${PREFIX}b`]);
+
+    assert.equal(await client.del(['a', 'b']), 2);
+  }, OPTIONS);
+
+  testUtils.testWithClient('prefixes both keys of a two-key command (COPY)', async client => {
+    await client.set('source', 'value');
+    await client.copy('source', 'destination');
+
+    assert.equal(await client.get('destination'), 'value');
+    assert.deepEqual((await client.keys('*')).sort(), [`${PREFIX}destination`, `${PREFIX}source`]);
+  }, OPTIONS);
+
+  testUtils.testWithClient('prefixes keys inside a transaction (MULTI/EXEC)', async client => {
+    const replies = await client.multi()
+      .set('key', 'value')
+      .get('key')
+      .exec();
+
+    assert.deepEqual(replies, ['OK', 'value']);
+    assert.deepEqual(await client.keys('*'), [`${PREFIX}key`]);
+  }, OPTIONS);
+
+  testUtils.testWithClient('prefixes the key of APPEND (regression for push vs pushKey)', async client => {
+    await client.append('key', 'foo');
+    await client.append('key', 'bar');
+
+    assert.equal(await client.get('key'), 'foobar');
+    assert.deepEqual(await client.keys('*'), [`${PREFIX}key`]);
+  }, OPTIONS);
+
+  testUtils.testWithClient('prefixes the STORE destination of SORT', async client => {
+    await client.rPush('list', ['3', '1', '2']);
+    await client.sortStore('list', 'sorted');
+
+    assert.deepEqual(await client.lRange('sorted', 0, -1), ['1', '2', '3']);
+    assert.deepEqual((await client.keys('*')).sort(), [`${PREFIX}list`, `${PREFIX}sorted`]);
+  }, OPTIONS);
+
+  testUtils.testWithClient('prefixes the KEYS of a script while keeping numkeys correct', async client => {
+    await client.eval(
+      "redis.call('SET', KEYS[1], ARGV[1]); return 1",
+      {
+        keys: ['key'],
+        arguments: ['value']
+      }
+    );
+
+    assert.equal(await client.get('key'), 'value');
+    assert.deepEqual(await client.keys('*'), [`${PREFIX}key`]);
+  }, OPTIONS);
+
+  testUtils.testWithClient('does not prefix Pub/Sub channels', async publisher => {
+    const subscriber = publisher.duplicate();
+    await subscriber.connect();
+
+    try {
+      let resolve!: (msg: string) => void;
+      const received = new Promise<string>(r => { resolve = r; });
+
+      await subscriber.subscribe('channel', message => resolve(message));
+      await publisher.publish('channel', 'hello');
+
+      assert.equal(await received, 'hello');
+    } finally {
+      subscriber.destroy();
+    }
+  }, OPTIONS);
+
+  testUtils.testWithClientPool('applies keyPrefix to commands sent through a pool', async pool => {
+    await pool.set('key', 'value');
+
+    assert.equal(await pool.get('key'), 'value');
+    assert.deepEqual(await pool.keys('*'), [`${PREFIX}key`]);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    clientOptions: { keyPrefix: PREFIX }
+  });
+
+  testUtils.testWithClientPool('applies keyPrefix inside a pool transaction', async pool => {
+    const replies = await pool.multi()
+      .set('key', 'value')
+      .get('key')
+      .exec();
+
+    assert.deepEqual(replies, ['OK', 'value']);
+    assert.deepEqual(await pool.keys('*'), [`${PREFIX}key`]);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    clientOptions: { keyPrefix: PREFIX }
+  });
+
+  testUtils.testWithCluster('applies keyPrefix and routes on the prefixed key', async cluster => {
+    await cluster.set('key', 'value');
+    assert.equal(await cluster.get('key'), 'value');
+
+    // Node clients are not prefixed, so reading them back reveals the raw stored key,
+    // proving the cluster applied the prefix and routed to the slot of the prefixed key.
+    const stored: Array<string> = [];
+    for (const master of cluster.masters) {
+      const node = await cluster.nodeClient(master);
+      stored.push(...(await node.keys('*')) as Array<string>);
+    }
+    assert.deepEqual(stored, [`${PREFIX}key`]);
+
+    assert.equal(await cluster.del('key'), 1);
+  }, {
+    ...GLOBAL.CLUSTERS.OPEN,
+    clusterConfiguration: { keyPrefix: PREFIX }
+  });
+
+  testUtils.testWithCluster('applies keyPrefix inside a cluster transaction', async cluster => {
+    const replies = await cluster.multi()
+      .set('key', 'value')
+      .get('key')
+      .exec();
+
+    assert.deepEqual(replies, ['OK', 'value']);
+  }, {
+    ...GLOBAL.CLUSTERS.OPEN,
+    clusterConfiguration: { keyPrefix: PREFIX }
+  });
+
+  testUtils.testWithClientSentinel('applies keyPrefix to commands sent through sentinel', async sentinel => {
+    await sentinel.set('key', 'value');
+
+    assert.equal(await sentinel.get('key'), 'value');
+    assert.deepEqual(await sentinel.keys('*'), [`${PREFIX}key`]);
+
+    // transactions go through a separate multi-command path
+    const replies = await sentinel.multi()
+      .get('key')
+      .exec();
+    assert.deepEqual(replies, ['value']);
+  }, {
+    ...GLOBAL.SENTINEL.OPEN,
+    sentinelOptions: { keyPrefix: PREFIX }
+  });
+});

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -108,7 +108,7 @@ export default class RedisClientMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(command, resp);
 
     return function (this: RedisClientMultiCommand, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this.#keyPrefix);
       command.parseCommand(parser, ...args);
 
       const redisArgs: CommandArguments = parser.redisArgs;
@@ -125,7 +125,7 @@ export default class RedisClientMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(command, resp);
 
     return function (this: { _self: RedisClientMultiCommand }, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self.#keyPrefix);
       command.parseCommand(parser, ...args);
 
       const redisArgs: CommandArguments = parser.redisArgs;
@@ -143,7 +143,7 @@ export default class RedisClientMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(fn, resp);
 
     return function (this: { _self: RedisClientMultiCommand }, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self.#keyPrefix);
       parser.push(...prefix);
       fn.parseCommand(parser, ...args);
 
@@ -161,7 +161,7 @@ export default class RedisClientMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(script, resp);
 
     return function (this: RedisClientMultiCommand, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this.#keyPrefix);
       script.parseCommand(parser, ...args);
 
       const redisArgs: CommandArguments = parser.redisArgs;
@@ -195,13 +195,15 @@ export default class RedisClientMultiCommand<REPLIES = []> {
   readonly #multi: RedisMultiCommand
   readonly #executeMulti: ExecuteMulti;
   readonly #executePipeline: ExecuteMulti;
+  readonly #keyPrefix?: RedisArgument;
 
   #selectedDB?: number;
 
-  constructor(executeMulti: ExecuteMulti, executePipeline: ExecuteMulti, typeMapping?: TypeMapping) {
+  constructor(executeMulti: ExecuteMulti, executePipeline: ExecuteMulti, typeMapping?: TypeMapping, keyPrefix?: RedisArgument) {
     this.#multi = new RedisMultiCommand(typeMapping);
     this.#executeMulti = executeMulti;
     this.#executePipeline = executePipeline;
+    this.#keyPrefix = keyPrefix;
   }
 
   SELECT(db: number, transformReply?: TransformReply): this {

--- a/packages/client/lib/client/parser.spec.ts
+++ b/packages/client/lib/client/parser.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { BasicCommandParser, prefixKey } from './parser';
+import { BasicCommandParser, prefixKey, prefixKeys } from './parser';
 
 describe('prefixKey', () => {
   it('returns the key unchanged when prefix is undefined', () => {
@@ -30,6 +30,21 @@ describe('prefixKey', () => {
     const result = prefixKey(Buffer.from('app:'), Buffer.from('key'));
     assert.ok(Buffer.isBuffer(result));
     assert.equal((result as Buffer).toString(), 'app:key');
+  });
+});
+
+describe('prefixKeys', () => {
+  it('prefixes a single key into a one-element array', () => {
+    assert.deepEqual(prefixKeys('app:', 'key'), ['app:key']);
+  });
+
+  it('prefixes every key of an array', () => {
+    assert.deepEqual(prefixKeys('app:', ['a', 'b']), ['app:a', 'app:b']);
+  });
+
+  it('returns the keys unchanged (as an array) when there is no prefix', () => {
+    assert.deepEqual(prefixKeys(undefined, 'key'), ['key']);
+    assert.deepEqual(prefixKeys(undefined, ['a', 'b']), ['a', 'b']);
   });
 });
 

--- a/packages/client/lib/client/parser.spec.ts
+++ b/packages/client/lib/client/parser.spec.ts
@@ -1,0 +1,148 @@
+import { strict as assert } from 'node:assert';
+import { BasicCommandParser, prefixKey } from './parser';
+
+describe('prefixKey', () => {
+  it('returns the key unchanged when prefix is undefined', () => {
+    assert.equal(prefixKey(undefined, 'key'), 'key');
+    const buf = Buffer.from('key');
+    assert.equal(prefixKey(undefined, buf), buf);
+  });
+
+  it('concatenates two strings into a string', () => {
+    const result = prefixKey('app:', 'key');
+    assert.equal(typeof result, 'string');
+    assert.equal(result, 'app:key');
+  });
+
+  it('returns a Buffer when the prefix is a Buffer', () => {
+    const result = prefixKey(Buffer.from('app:'), 'key');
+    assert.ok(Buffer.isBuffer(result));
+    assert.equal((result as Buffer).toString(), 'app:key');
+  });
+
+  it('returns a Buffer when the key is a Buffer', () => {
+    const result = prefixKey('app:', Buffer.from('key'));
+    assert.ok(Buffer.isBuffer(result));
+    assert.equal((result as Buffer).toString(), 'app:key');
+  });
+
+  it('returns a Buffer when both are Buffers', () => {
+    const result = prefixKey(Buffer.from('app:'), Buffer.from('key'));
+    assert.ok(Buffer.isBuffer(result));
+    assert.equal((result as Buffer).toString(), 'app:key');
+  });
+});
+
+describe('BasicCommandParser', () => {
+  describe('without a prefix', () => {
+    it('pushKey leaves keys untouched', () => {
+      const parser = new BasicCommandParser();
+      parser.push('GET');
+      parser.pushKey('key');
+      assert.deepEqual(parser.redisArgs, ['GET', 'key']);
+      assert.deepEqual(parser.keys, ['key']);
+      assert.equal(parser.firstKey, 'key');
+    });
+
+    it('pushKeys leaves keys untouched (array and single)', () => {
+      const array = new BasicCommandParser();
+      array.pushKeys(['a', 'b']);
+      assert.deepEqual(array.redisArgs, ['a', 'b']);
+      assert.deepEqual(array.keys, ['a', 'b']);
+
+      const single = new BasicCommandParser();
+      single.pushKeys('a');
+      assert.deepEqual(single.redisArgs, ['a']);
+      assert.deepEqual(single.keys, ['a']);
+    });
+
+    it('treats an empty-string prefix as no prefix', () => {
+      const parser = new BasicCommandParser('');
+      parser.pushKey('key');
+      assert.deepEqual(parser.redisArgs, ['key']);
+    });
+
+    it('treats an empty Buffer prefix as no prefix', () => {
+      const parser = new BasicCommandParser(Buffer.alloc(0));
+      parser.pushKey('key');
+      assert.deepEqual(parser.redisArgs, ['key']);
+    });
+  });
+
+  describe('with a prefix', () => {
+    it('prefixes a single key in both keys and redisArgs', () => {
+      const parser = new BasicCommandParser('app:');
+      parser.push('GET');
+      parser.pushKey('key');
+      assert.deepEqual(parser.redisArgs, ['GET', 'app:key']);
+      assert.deepEqual(parser.keys, ['app:key']);
+      assert.equal(parser.firstKey, 'app:key');
+    });
+
+    it('prefixes every key pushed via pushKeys', () => {
+      const array = new BasicCommandParser('app:');
+      array.push('MGET');
+      array.pushKeys(['a', 'b']);
+      assert.deepEqual(array.redisArgs, ['MGET', 'app:a', 'app:b']);
+      assert.deepEqual(array.keys, ['app:a', 'app:b']);
+
+      const single = new BasicCommandParser('app:');
+      single.pushKeys('a');
+      assert.deepEqual(single.keys, ['app:a']);
+    });
+
+    it('prefixes keys pushed via pushKeysLength but keeps the count unchanged', () => {
+      const parser = new BasicCommandParser('app:');
+      parser.push('LMPOP');
+      parser.pushKeysLength(['a', 'b']);
+      parser.push('LEFT');
+      assert.deepEqual(parser.redisArgs, ['LMPOP', '2', 'app:a', 'app:b', 'LEFT']);
+      assert.deepEqual(parser.keys, ['app:a', 'app:b']);
+    });
+
+    it('does not prefix non-key arguments (push / pushVariadic)', () => {
+      const parser = new BasicCommandParser('app:');
+      parser.push('SET');
+      parser.pushKey('key');
+      parser.push('value');
+      parser.pushVariadic(['EX', '10']);
+      assert.deepEqual(parser.redisArgs, ['SET', 'app:key', 'value', 'EX', '10']);
+      // only the key is tracked / prefixed
+      assert.deepEqual(parser.keys, ['app:key']);
+    });
+
+    it('does not prefix a routing key pushed with applyPrefix=false (e.g. SPUBLISH)', () => {
+      const parser = new BasicCommandParser('app:');
+      parser.push('SPUBLISH');
+      parser.pushKey('channel', false);
+      parser.push('message');
+      assert.deepEqual(parser.redisArgs, ['SPUBLISH', 'channel', 'message']);
+      // still tracked for routing, but on the raw value
+      assert.deepEqual(parser.keys, ['channel']);
+      assert.equal(parser.firstKey, 'channel');
+    });
+
+    it('prefixes Buffer keys', () => {
+      const parser = new BasicCommandParser('app:');
+      parser.pushKey(Buffer.from('key'));
+      const [key] = parser.keys;
+      assert.ok(Buffer.isBuffer(key));
+      assert.equal((key as Buffer).toString(), 'app:key');
+    });
+
+    it('invariant: every tracked key appears, prefixed, in redisArgs', () => {
+      const parser = new BasicCommandParser('app:');
+      parser.push('MSET');
+      parser.pushKey('a');
+      parser.push('1');
+      parser.pushKeys(['b', 'c']);
+      for (const key of parser.keys) {
+        assert.ok(
+          parser.redisArgs.includes(key),
+          `tracked key ${key.toString()} is missing from redisArgs`
+        );
+        assert.ok(key.toString().startsWith('app:'), `tracked key ${key.toString()} is not prefixed`);
+      }
+    });
+  });
+});

--- a/packages/client/lib/client/parser.ts
+++ b/packages/client/lib/client/parser.ts
@@ -21,6 +21,18 @@ export function prefixKey(keyPrefix: RedisArgument | undefined, key: RedisArgume
   ]);
 }
 
+/**
+ * Applies {@link prefixKey} to every key in a variadic argument, returning a new array.
+ *
+ * Used by the few commands that build their wire arguments outside of `parseCommand`
+ * (e.g. `WATCH`), so they still honor the configured `keyPrefix`.
+ */
+export function prefixKeys(keyPrefix: RedisArgument | undefined, keys: RedisVariadicArgument): Array<RedisArgument> {
+  return Array.isArray(keys)
+    ? keys.map(key => prefixKey(keyPrefix, key))
+    : [prefixKey(keyPrefix, keys)];
+}
+
 export interface CommandParser {
   redisArgs: ReadonlyArray<RedisArgument>;
   keys: ReadonlyArray<RedisArgument>;

--- a/packages/client/lib/client/parser.ts
+++ b/packages/client/lib/client/parser.ts
@@ -1,6 +1,26 @@
 import { RedisArgument } from '../RESP/types';
 import { RedisVariadicArgument } from '../commands/generic-transformers';
 
+/**
+ * Prepends `keyPrefix` to `key`.
+ *
+ * Returns `key` unchanged when `keyPrefix` is `undefined` (the no-prefix hot path).
+ * Uses a plain string concatenation when both sides are strings, and falls back to
+ * `Buffer.concat` when either side is a `Buffer`.
+ */
+export function prefixKey(keyPrefix: RedisArgument | undefined, key: RedisArgument): RedisArgument {
+  if (keyPrefix === undefined) return key;
+
+  if (typeof keyPrefix === 'string' && typeof key === 'string') {
+    return keyPrefix + key;
+  }
+
+  return Buffer.concat([
+    typeof keyPrefix === 'string' ? Buffer.from(keyPrefix) : keyPrefix,
+    typeof key === 'string' ? Buffer.from(key) : key
+  ]);
+}
+
 export interface CommandParser {
   redisArgs: ReadonlyArray<RedisArgument>;
   keys: ReadonlyArray<RedisArgument>;
@@ -11,7 +31,12 @@ export interface CommandParser {
   pushVariadic: (vals: RedisVariadicArgument) => unknown;
   pushVariadicWithLength: (vals: RedisVariadicArgument) => unknown;
   pushVariadicNumber: (vals: number | Array<number>) => unknown;
-  pushKey: (key: RedisArgument) => unknown; // normal push of keys
+  /**
+   * Push a key, applying the configured `keyPrefix` (if any).
+   * Pass `applyPrefix = false` to push a routing key that must NOT be prefixed
+   * (e.g. a sharded Pub/Sub channel in `SPUBLISH`).
+   */
+  pushKey: (key: RedisArgument, applyPrefix?: boolean) => unknown; // normal push of keys
   pushKeys: (keys: RedisVariadicArgument) => unknown; // push multiple keys at a time
   pushKeysLength: (keys: RedisVariadicArgument) => unknown; // push multiple keys at a time
 }
@@ -19,7 +44,16 @@ export interface CommandParser {
 export class BasicCommandParser implements CommandParser {
   #redisArgs: Array<RedisArgument> = [];
   #keys: Array<RedisArgument> = [];
+  readonly #keyPrefix: RedisArgument | undefined;
   preserve: unknown;
+
+  /**
+   * @param keyPrefix Optional prefix prepended to every key pushed via
+   * `pushKey`/`pushKeys`/`pushKeysLength`. Empty values are treated as "no prefix".
+   */
+  constructor(keyPrefix?: RedisArgument) {
+    this.#keyPrefix = keyPrefix === undefined || keyPrefix.length === 0 ? undefined : keyPrefix;
+  }
 
   get redisArgs() {
     return this.#redisArgs;
@@ -77,9 +111,18 @@ export class BasicCommandParser implements CommandParser {
     }
   }
 
-  pushKey(key: RedisArgument) {
-    this.#keys.push(key);
-    this.#redisArgs.push(key);
+  /**
+   * Registers a key as both a routing key (`keys`) and a wire argument (`redisArgs`),
+   * prepending `keyPrefix` when `applyPrefix` is true.
+   */
+  #addKey(key: RedisArgument, applyPrefix: boolean) {
+    const finalKey = applyPrefix ? prefixKey(this.#keyPrefix, key) : key;
+    this.#keys.push(finalKey);
+    this.#redisArgs.push(finalKey);
+  }
+
+  pushKey(key: RedisArgument, applyPrefix = true) {
+    this.#addKey(key, applyPrefix);
   }
 
   pushKeysLength(keys: RedisVariadicArgument) {
@@ -93,11 +136,11 @@ export class BasicCommandParser implements CommandParser {
 
   pushKeys(keys: RedisVariadicArgument) {
     if (Array.isArray(keys)) {
-      this.#keys.push(...keys);
-      this.#redisArgs.push(...keys);
+      for (const key of keys) {
+        this.#addKey(key, true);
+      }
     } else {
-      this.#keys.push(keys);
-      this.#redisArgs.push(keys);
+      this.#addKey(keys, true);
     }
   }
 }

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -119,7 +119,7 @@ export class RedisClientPool<
     const transformReply = getTransformReply(command, resp);
 
     return async function (this: ProxyPool, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       command.parseCommand(parser, ...args);
 
       return this.execute(client => client._executeCommand(command, parser, this._commandOptions, transformReply))
@@ -130,7 +130,7 @@ export class RedisClientPool<
     const transformReply = getTransformReply(command, resp);
 
     return async function (this: NamespaceProxyPool, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       command.parseCommand(parser, ...args);
 
       return this._self.execute(client => client._executeCommand(command, parser, this._self._commandOptions, transformReply))
@@ -142,7 +142,7 @@ export class RedisClientPool<
     const transformReply = getTransformReply(fn, resp);
 
     return async function (this: NamespaceProxyPool, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       parser.push(...prefix);
       fn.parseCommand(parser, ...args);
 
@@ -154,7 +154,7 @@ export class RedisClientPool<
     const transformReply = getTransformReply(script, resp);
 
     return async function (this: ProxyPool, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       parser.pushVariadic(prefix);
       script.parseCommand(parser, ...args);
 
@@ -324,12 +324,27 @@ export class RedisClientPool<
       }
     }
 
+    // Capture the key prefix for the pool's own parser construction, then strip it from
+    // the pooled clients' options: the pool builds the (already prefixed) parser and hands
+    // it to a pooled client, which never re-parses — so inner clients must not re-prefix.
+    this._keyPrefix = clientOptions?.keyPrefix;
+    if (clientOptions?.keyPrefix !== undefined) {
+      clientOptions = { ...clientOptions, keyPrefix: undefined };
+    }
+
     this.#clientFactory = RedisClient.factory(clientOptions).bind(undefined, clientOptions) as () => RedisClientType<M, F, S, RESP, TYPE_MAPPING>;
     this._commandOptions = clientOptions?.commandOptions as CommandOptions<TYPE_MAPPING> | undefined;
   }
 
   private _self = this;
   private _commandOptions?: CommandOptions<TYPE_MAPPING>;
+  /**
+   * The configured key prefix (see {@link RedisClientOptions.keyPrefix}), if any.
+   * The pool builds the (prefixed) parser itself, so it is stripped from the options
+   * handed to pooled clients to avoid double-prefixing.
+   * @internal
+   */
+  _keyPrefix?: RedisArgument;
 
   withCommandOptions<
     OPTIONS extends CommandOptions<TYPE_MAPPING>,
@@ -545,7 +560,8 @@ export class RedisClientPool<
     return new ((this as any).Multi as Multi)(
       (commands, selectedDB) => this.execute(client => client._executeMulti(commands, selectedDB)),
       commands => this.execute(client => client._executePipeline(commands)),
-      this._commandOptions?.typeMapping
+      this._commandOptions?.typeMapping,
+      this._self._keyPrefix
     );
   }
 

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -39,6 +39,18 @@ interface ClusterCommander<
   // POLICIES extends CommandPolicies
 > extends CommanderConfig<M, F, S, RESP> {
   commandOptions?: ClusterCommandOptions<TYPE_MAPPING/*, POLICIES*/>;
+  /**
+   * Prefix prepended to every key sent to Redis (ioredis-compatible `keyPrefix`).
+   *
+   * Applied by the cluster client itself; the slot of each command is computed from the
+   * prefixed key, so routing stays correct. It is intentionally a cluster-level option
+   * (not a per-node `rootNodes`/`defaults` option) so it is applied exactly once.
+   *
+   * Matches ioredis semantics: only keys *sent* to Redis are prefixed. Keys *returned*
+   * by Redis are NOT un-prefixed, `MATCH` patterns are NOT auto-prefixed, and Pub/Sub
+   * channels are NOT prefixed.
+   */
+  keyPrefix?: RedisArgument;
 }
 
 export type RedisClusterClientOptions = Omit<
@@ -165,7 +177,7 @@ export default class RedisCluster<
     const transformReply = getTransformReply(command, resp);
 
     return async function (this: ProxyCluster, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       command.parseCommand(parser, ...args);
 
       return this._self._execute(
@@ -181,7 +193,7 @@ export default class RedisCluster<
     const transformReply = getTransformReply(command, resp);
 
     return async function (this: NamespaceProxyCluster, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       command.parseCommand(parser, ...args);
 
       return this._self._execute(
@@ -198,7 +210,7 @@ export default class RedisCluster<
     const transformReply = getTransformReply(fn, resp);
 
     return async function (this: NamespaceProxyCluster, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       parser.push(...prefix);
       fn.parseCommand(parser, ...args);
 
@@ -216,7 +228,7 @@ export default class RedisCluster<
     const transformReply = getTransformReply(script, resp);
 
     return async function (this: ProxyCluster, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self._keyPrefix);
       parser.push(...prefix);
       script.parseCommand(parser, ...args);
 
@@ -293,6 +305,14 @@ export default class RedisCluster<
 
   get clientSideCache() {
     return this._self._slots.clientSideCache;
+  }
+
+  /**
+   * The configured key prefix (see {@link RedisClusterOptions.keyPrefix}), if any.
+   * @internal
+   */
+  get _keyPrefix(): RedisArgument | undefined {
+    return this._self._options.keyPrefix;
   }
 
   /**
@@ -555,7 +575,8 @@ export default class RedisCluster<
         return client._executePipeline(commands);
       },
       routing,
-      this._commandOptions?.typeMapping
+      this._commandOptions?.typeMapping,
+      this._self._keyPrefix
     );
   }
 

--- a/packages/client/lib/cluster/multi-command.spec.ts
+++ b/packages/client/lib/cluster/multi-command.spec.ts
@@ -1,0 +1,62 @@
+import { strict as assert } from 'node:assert';
+import RedisClusterMultiCommand from './multi-command';
+import { RedisArgument } from '../RESP/types';
+
+/**
+ * Deterministic (no-server) coverage for how `RedisClusterMultiCommand` chooses the
+ * routing key when a `keyPrefix` is configured. The routing key drives slot selection,
+ * so it must be prefixed to match the (prefixed) keys the commands operate on — otherwise
+ * the transaction routes to the wrong node (CROSSSLOT / MOVED).
+ */
+describe('RedisClusterMultiCommand keyPrefix routing', () => {
+  function setup(routing: RedisArgument | undefined, keyPrefix: RedisArgument | undefined) {
+    const routedKeys: Array<RedisArgument | undefined> = [];
+    const execute = (
+      firstKey: RedisArgument | undefined,
+      _isReadonly: boolean | undefined,
+      queue: Array<unknown>
+    ) => {
+      routedKeys.push(firstKey);
+      return Promise.resolve(queue.map(() => null));
+    };
+
+    const multi = new RedisClusterMultiCommand(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal execute stub
+      execute as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal execute stub
+      execute as any,
+      routing,
+      undefined,
+      keyPrefix
+    );
+
+    return { multi, routedKeys };
+  }
+
+  it('prefixes an explicit routing key so it matches the prefixed command keys', async () => {
+    const { multi, routedKeys } = setup('user', 'app:');
+    multi.addCommand('app:user', false, ['GET', 'app:user']);
+
+    await multi.exec();
+
+    assert.deepEqual(routedKeys, ['app:user']);
+  });
+
+  it('routes by the already-prefixed command key when no explicit routing is given', async () => {
+    const { multi, routedKeys } = setup(undefined, 'app:');
+    multi.addCommand('app:user', false, ['GET', 'app:user']);
+
+    await multi.exec();
+
+    assert.deepEqual(routedKeys, ['app:user']);
+  });
+
+  it('leaves the routing key untouched when no prefix is configured', async () => {
+    const { multi, routedKeys } = setup('user', undefined);
+    multi.addCommand('user', false, ['GET', 'user']);
+
+    await multi.exec();
+
+    assert.deepEqual(routedKeys, ['user']);
+  });
+});

--- a/packages/client/lib/cluster/multi-command.ts
+++ b/packages/client/lib/cluster/multi-command.ts
@@ -2,7 +2,7 @@ import { NON_STICKY_COMMANDS } from '../commands';
 import RedisMultiCommand, { MULTI_REPLY, MultiReply, MultiReplyType, RedisMultiQueuedCommand } from '../multi-command';
 import { ReplyWithTypeMapping, CommandReply, Command, CommandArguments, CommanderConfig, RedisFunctions, RedisModules, RedisScripts, RespVersions, TransformReply, RedisScript, RedisFunction, TypeMapping, RedisArgument } from '../RESP/types';
 import { attachConfig, functionArgumentsPrefix, getTransformReply } from '../commander';
-import { BasicCommandParser } from '../client/parser';
+import { BasicCommandParser, prefixKey } from '../client/parser';
 import { Tail } from '../commands/generic-transformers';
 
 type CommandSignature<
@@ -211,7 +211,9 @@ export default class RedisClusterMultiCommand<REPLIES = []> {
     this.#multi = new RedisMultiCommand(typeMapping);
     this.#executeMulti = executeMulti;
     this.#executePipeline = executePipeline;
-    this.#firstKey = routing;
+    // An explicit routing key must be prefixed too, so it hashes to the same slot as the
+    // (prefixed) keys the commands inside the transaction operate on.
+    this.#firstKey = routing === undefined ? undefined : prefixKey(keyPrefix, routing);
     this.#keyPrefix = keyPrefix;
   }
 

--- a/packages/client/lib/cluster/multi-command.ts
+++ b/packages/client/lib/cluster/multi-command.ts
@@ -97,7 +97,7 @@ export default class RedisClusterMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(command, resp);
 
     return function (this: RedisClusterMultiCommand, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this.#keyPrefix);
       command.parseCommand(parser, ...args);
 
       const redisArgs: CommandArguments = parser.redisArgs;
@@ -117,7 +117,7 @@ export default class RedisClusterMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(command, resp);
 
     return function (this: { _self: RedisClusterMultiCommand }, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self.#keyPrefix);
       command.parseCommand(parser, ...args);
 
       const redisArgs: CommandArguments = parser.redisArgs;
@@ -138,7 +138,7 @@ export default class RedisClusterMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(fn, resp);
 
     return function (this: { _self: RedisClusterMultiCommand }, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self.#keyPrefix);
       parser.push(...prefix);
       fn.parseCommand(parser, ...args);
 
@@ -159,7 +159,7 @@ export default class RedisClusterMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(script, resp);
 
     return function (this: RedisClusterMultiCommand, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this.#keyPrefix);
       script.parseCommand(parser, ...args);
 
       const scriptArgs: CommandArguments = parser.redisArgs;
@@ -199,17 +199,20 @@ export default class RedisClusterMultiCommand<REPLIES = []> {
   readonly #executePipeline: ClusterMultiExecute;
   #firstKey: RedisArgument | undefined;
   #isReadonly: boolean | undefined = true;
+  readonly #keyPrefix?: RedisArgument;
 
   constructor(
     executeMulti: ClusterMultiExecute,
     executePipeline: ClusterMultiExecute,
     routing: RedisArgument | undefined,
-    typeMapping?: TypeMapping
+    typeMapping?: TypeMapping,
+    keyPrefix?: RedisArgument
   ) {
     this.#multi = new RedisMultiCommand(typeMapping);
     this.#executeMulti = executeMulti;
     this.#executePipeline = executePipeline;
     this.#firstKey = routing;
+    this.#keyPrefix = keyPrefix;
   }
 
   #setState(

--- a/packages/client/lib/commands/APPEND.ts
+++ b/packages/client/lib/commands/APPEND.ts
@@ -4,7 +4,9 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 export default {
   IS_READ_ONLY: false,
   parseCommand(parser: CommandParser, key: RedisArgument, value: RedisArgument) {
-    parser.push('APPEND', key, value);
+    parser.push('APPEND');
+    parser.pushKey(key);
+    parser.push(value);
   },
 
   transformReply: undefined as unknown as () => NumberReply

--- a/packages/client/lib/commands/CLUSTER_KEYSLOT.spec.ts
+++ b/packages/client/lib/commands/CLUSTER_KEYSLOT.spec.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import CLUSTER_KEYSLOT from './CLUSTER_KEYSLOT';
 import { parseArgs } from './generic-transformers';
+import { BasicCommandParser } from '../client/parser';
 
 describe('CLUSTER KEYSLOT', () => {
   it('transformArguments', () => {
@@ -9,6 +10,12 @@ describe('CLUSTER KEYSLOT', () => {
       parseArgs(CLUSTER_KEYSLOT, 'key'),
       ['CLUSTER', 'KEYSLOT', 'key']
     );
+  });
+
+  it('applies keyPrefix to the reported key', () => {
+    const parser = new BasicCommandParser('prefix:');
+    CLUSTER_KEYSLOT.parseCommand(parser, 'key');
+    assert.deepEqual(parser.redisArgs, ['CLUSTER', 'KEYSLOT', 'prefix:key']);
   });
 
   testUtils.testWithCluster('clusterNode.clusterKeySlot', async cluster => {

--- a/packages/client/lib/commands/CLUSTER_KEYSLOT.ts
+++ b/packages/client/lib/commands/CLUSTER_KEYSLOT.ts
@@ -5,7 +5,11 @@ export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
   parseCommand(parser: CommandParser, key: RedisArgument) {
-    parser.push('CLUSTER', 'KEYSLOT', key);
+    parser.push('CLUSTER', 'KEYSLOT');
+    // Use pushKey so a configured `keyPrefix` is applied to the reported key: the returned
+    // slot then matches where prefixed commands for `key` are actually routed. The command
+    // stays NOT_KEYED_COMMAND because its result is identical on any node.
+    parser.pushKey(key);
   },
   transformReply: undefined as unknown as () => NumberReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/MIGRATE.ts
+++ b/packages/client/lib/commands/MIGRATE.ts
@@ -25,7 +25,7 @@ export default {
     if (isKeyArray) {
       parser.push('');
     } else {
-      parser.push(key);
+      parser.pushKey(key);
     }
   
     parser.push(
@@ -58,7 +58,7 @@ export default {
   
     if (isKeyArray) {
       parser.push('KEYS');
-      parser.pushVariadic(key);
+      parser.pushKeys(key);
     }
   },
   transformReply: undefined as unknown as () => SimpleStringReply<'OK'>

--- a/packages/client/lib/commands/SORT_STORE.ts
+++ b/packages/client/lib/commands/SORT_STORE.ts
@@ -6,7 +6,8 @@ export default {
   IS_READ_ONLY: false,
   parseCommand(parser: CommandParser, source: RedisArgument, destination: RedisArgument, options?: SortOptions) {
     SORT.parseCommand(parser, source, options);
-    parser.push('STORE', destination);
+    parser.push('STORE');
+    parser.pushKey(destination);
   },
   transformReply: undefined as unknown as () => NumberReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/SPUBLISH.ts
+++ b/packages/client/lib/commands/SPUBLISH.ts
@@ -5,7 +5,10 @@ export default {
   IS_READ_ONLY: true,
   parseCommand(parser: CommandParser, channel: RedisArgument, message: RedisArgument) {
     parser.push('SPUBLISH');
-    parser.pushKey(channel);
+    // The channel routes the command to the correct shard (like a key) but must NOT be
+    // prefixed: Pub/Sub channels are a separate namespace and the subscribe side
+    // (SSUBSCRIBE) does not apply `keyPrefix` either.
+    parser.pushKey(channel, false);
     parser.push(message);
   },
   transformReply: undefined as unknown as () => NumberReply,

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -68,6 +68,14 @@ export class RedisSentinelClient<
       : this._self.#commandOptions;
   }
 
+  /**
+   * The configured key prefix (see {@link RedisSentinelOptions.keyPrefix}), if any.
+   * @internal
+   */
+  get _keyPrefix(): RedisArgument | undefined {
+    return this._self.#internal.keyPrefix;
+  }
+
   #commandOptions?: CommandOptions<TYPE_MAPPING>;
   private _commandOptions?: CommandOptions<TYPE_MAPPING>;
 
@@ -325,6 +333,14 @@ export default class RedisSentinel<
 
   get clientSideCache() {
     return this._self.#internal.clientSideCache;
+  }
+
+  /**
+   * The configured key prefix (see {@link RedisSentinelOptions.keyPrefix}), if any.
+   * @internal
+   */
+  get _keyPrefix(): RedisArgument | undefined {
+    return this._self.#options.keyPrefix;
   }
 
   constructor(options: RedisSentinelOptions<M, F, S, RESP, TYPE_MAPPING>) {
@@ -759,6 +775,15 @@ export class RedisSentinelInternal<
   readonly #scanInterval: number;
   readonly #passthroughClientErrorEvents: boolean;
   readonly #RESP?: RespVersions;
+  readonly #keyPrefix?: RedisArgument;
+
+  /**
+   * The configured key prefix (see {@link RedisSentinelOptions.keyPrefix}), if any.
+   * @internal
+   */
+  get keyPrefix(): RedisArgument | undefined {
+    return this.#keyPrefix;
+  }
 
   #anotherReset = false;
 
@@ -809,6 +834,7 @@ export class RedisSentinelInternal<
     this.#sentinelClientId = sentinelClientId;
 
     this.#RESP = options.RESP;
+    this.#keyPrefix = options.keyPrefix;
     this.#sentinelSeedNodes = Array.from(options.sentinelRootNodes);
     this.#sentinelRootNodes = Array.from(this.#sentinelSeedNodes);
     this.#maxCommandRediscovers = options.maxCommandRediscovers ?? 16;

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -14,6 +14,7 @@ import { PubSubProxy } from './pub-sub-proxy';
 import { setTimeout } from 'node:timers/promises';
 import RedisSentinelModule from './module'
 import { RedisVariadicArgument } from '../commands/generic-transformers';
+import { prefixKeys } from '../client/parser';
 import { WaitQueue } from './wait-queue';
 import { TcpNetConnectOpts } from 'node:net';
 import { RedisTcpSocketOptions } from '../client/socket';
@@ -235,9 +236,13 @@ export class RedisSentinelClient<
       throw new Error("Attempted execution on released RedisSentinelClient lease");
     }
 
+    // Apply the sentinel's `keyPrefix` here: the underlying node client carries no
+    // prefix (it receives already-prefixed args for normal commands), so WATCH must be
+    // prefixed at this level to guard the same key the transaction operates on.
+    const watchKeys = prefixKeys(this._self._keyPrefix, key);
     return this._execute(
       false,
-      client => client.watch(key)
+      client => client.watch(watchKeys)
     )
   }
 

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -683,6 +683,13 @@ export default class RedisSentinel<
    * paged `SCAN` calls. Yields one array of keys per page until the SCAN cursor
    * returns to `0`.
    *
+   * @remarks
+   * With a configured `keyPrefix`, the yielded keys are the **already-prefixed** keys
+   * as stored on the server — replies are never un-prefixed. Passing them straight back
+   * into a key-prefixed command prefixes them a second time (e.g. with `keyPrefix: 'app:'`,
+   * a yielded `'app:foo'` becomes `'app:app:foo'`). Strip the prefix before reusing the
+   * keys, or read them with a client that has no `keyPrefix`.
+   *
    * The master client lease is acquired for the duration of each `SCAN` call
    * and released before yielding, so consumers can issue other commands from
    * inside the `for await` loop body without deadlocking against the iterator

--- a/packages/client/lib/sentinel/multi-commands.ts
+++ b/packages/client/lib/sentinel/multi-commands.ts
@@ -93,7 +93,7 @@ export default class RedisSentinelMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(command, resp);
 
     return function (this: RedisSentinelMultiCommand, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this.#sentinel._keyPrefix);
       command.parseCommand(parser, ...args);
 
       const redisArgs: CommandArguments = parser.redisArgs;
@@ -111,7 +111,7 @@ export default class RedisSentinelMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(command, resp);
 
     return function (this: { _self: RedisSentinelMultiCommand }, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self.#sentinel._keyPrefix);
       command.parseCommand(parser, ...args);
 
       const redisArgs: CommandArguments = parser.redisArgs;
@@ -130,7 +130,7 @@ export default class RedisSentinelMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(fn, resp);
 
     return function (this: { _self: RedisSentinelMultiCommand }, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this._self.#sentinel._keyPrefix);
       parser.push(...prefix);
       fn.parseCommand(parser, ...args);
 
@@ -149,7 +149,7 @@ export default class RedisSentinelMultiCommand<REPLIES = []> {
     const transformReply = getTransformReply(script, resp);
 
     return function (this: RedisSentinelMultiCommand, ...args: Array<unknown>) {
-      const parser = new BasicCommandParser();
+      const parser = new BasicCommandParser(this.#sentinel._keyPrefix);
       script.parseCommand(parser, ...args);
 
       const scriptArgs: CommandArguments = parser.redisArgs;

--- a/packages/client/lib/sentinel/types.ts
+++ b/packages/client/lib/sentinel/types.ts
@@ -1,6 +1,6 @@
 import { RedisClientOptions } from '../client';
 import { CommandOptions } from '../client/commands-queue';
-import { CommandSignature, CommanderConfig, RedisFunctions, RedisModules, RedisScripts, RespVersions, TypeMapping } from '../RESP/types';
+import { CommandSignature, CommanderConfig, RedisArgument, RedisFunctions, RedisModules, RedisScripts, RespVersions, TypeMapping } from '../RESP/types';
 import { NON_STICKY_COMMANDS } from '../commands';
 import RedisSentinel, { RedisSentinelClient } from '.';
 import { RedisTcpSocketOptions } from '../client/socket';
@@ -137,6 +137,17 @@ export interface SentinelCommander<
   // POLICIES extends CommandPolicies
 > extends CommanderConfig<M, F, S, RESP> {
   commandOptions?: CommandOptions<TYPE_MAPPING>;
+  /**
+   * Prefix prepended to every key sent to Redis (ioredis-compatible `keyPrefix`).
+   *
+   * Applied by the sentinel client itself. It is intentionally a sentinel-level option
+   * (not a per-node `nodeClientOptions` option) so it is applied exactly once.
+   *
+   * Matches ioredis semantics: only keys *sent* to Redis are prefixed. Keys *returned*
+   * by Redis are NOT un-prefixed, `MATCH` patterns are NOT auto-prefixed, and Pub/Sub
+   * channels are NOT prefixed.
+   */
+  keyPrefix?: RedisArgument;
 }
 
 export type RedisSentinelClientOptions = Omit<

--- a/packages/client/lib/sentinel/utils.ts
+++ b/packages/client/lib/sentinel/utils.ts
@@ -15,7 +15,7 @@ export function parseNode(node: Record<string, string>): RedisNode | undefined{
 }
 
 export function createNodeList(nodes: UnwrapReply<ArrayReply<Record<string, string>>>) {
-  var nodeList: Array<RedisNode> = [];
+  const nodeList: Array<RedisNode> = [];
 
   for (const nodeData of nodes) {
     const node = parseNode(nodeData)
@@ -41,7 +41,7 @@ export function createCommand<T extends ProxySentinel | ProxySentinelClient>(com
   const transformReply = getTransformReply(command, resp);
 
   return async function (this: T, ...args: Array<unknown>) {
-    const parser = new BasicCommandParser();
+    const parser = new BasicCommandParser(this._self._keyPrefix);
     command.parseCommand(parser, ...args);
 
     return this._self._execute(
@@ -56,7 +56,7 @@ export function createFunctionCommand<T extends NamespaceProxySentinel | Namespa
   const transformReply = getTransformReply(fn, resp);
 
   return async function (this: T, ...args: Array<unknown>) {
-    const parser = new BasicCommandParser();
+    const parser = new BasicCommandParser(this._self._keyPrefix);
     parser.push(...prefix);
     fn.parseCommand(parser, ...args);
 
@@ -71,7 +71,7 @@ export function createModuleCommand<T extends NamespaceProxySentinel | Namespace
   const transformReply = getTransformReply(command, resp);
 
   return async function (this: T, ...args: Array<unknown>) {
-    const parser = new BasicCommandParser();
+    const parser = new BasicCommandParser(this._self._keyPrefix);
     command.parseCommand(parser, ...args);
 
     return this._self._execute(
@@ -86,7 +86,7 @@ export function createScriptCommand<T extends ProxySentinel | ProxySentinelClien
   const transformReply = getTransformReply(script, resp);
 
   return async function (this: T, ...args: Array<unknown>) {
-    const parser = new BasicCommandParser();
+    const parser = new BasicCommandParser(this._self._keyPrefix);
     parser.push(...prefix);
     script.parseCommand(parser, ...args);
 


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

Restores key prefixing functionality.

The reasoning is described in #2982

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prefixing touches almost all command construction and cluster/sentinel routing and WATCH behavior; incorrect edge cases could cause silent wrong-key access or broken optimistic locking, though coverage is broad.
> 
> **Overview**
> Adds a **`keyPrefix`** client option that prepends a string or `Buffer` to every key on the wire, with ioredis-style semantics: outbound keys are prefixed, replies are not stripped, `SCAN`/`KEYS` `MATCH` patterns are not auto-prefixed, and Pub/Sub channels (including sharded `SPUBLISH`) stay unprefixed.
> 
> Prefixing is wired through **`BasicCommandParser`** (`prefixKey` / `prefixKeys`, optional `pushKey(..., applyPrefix=false)`), and every command path that builds parsers now passes the configured prefix—standalone client, **pool**, **cluster**, **sentinel**, **MULTI**/pipelines, and **`WATCH`** (which previously could watch the wrong key). The pool keeps prefixing at the pool layer and clears `keyPrefix` on pooled node clients to avoid double-prefixing; cluster **`multi(routingKey)`** prefixes the explicit routing key so slot selection matches prefixed command keys.
> 
> Several commands were adjusted to use **`pushKey`** where keys were previously pushed raw (**`APPEND`**, **`SORT` STORE**, **`MIGRATE`**, **`CLUSTER KEYSLOT`**). Docs cover configuration, semantics, and the **`scanIterator` + `mGet`** double-prefix pitfall; integration tests cover transactions, scripts, WATCH, pool/cluster/sentinel, and parser unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bef1784de2c2d74965535c55d2bee5b28c064d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->