### PR TITLE
feat(cluster): add getNodeClientForKey for WATCH/MULTI/EXEC

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -152,3 +152,21 @@ Admin commands such as `MEMORY STATS`, `FLUSHALL`, etc. are not attached to the 
 
 Certain commands (e.g. `PUBLISH`) are forwarded to other cluster nodes by the Redis server. The client sends these commands to a random node in order to spread the load across the cluster.
 
+### Transactions with `WATCH`
+
+`WATCH` relies on connection-level state on a specific node, so it isn't exposed directly on the cluster client. Use `.getNodeClientForKey()` to get the node client responsible for a key's slot and run the optimistic-locking transaction on it:
+
+```javascript
+const key = 'key';
+const nodeClient = await cluster.getNodeClientForKey(key);
+
+await nodeClient.watch(key);
+const value = await nodeClient.get(key);
+const reply = await nodeClient
+  .multi()
+  .set(key, calculateNewValue(value)) // application logic
+  .exec(); // `null` if `key` changed since `WATCH`, retry in that case
+```
+
+All keys touched in the transaction must hash to the same slot. Pass `true` as the second argument (`getNodeClientForKey(key, true)`) to allow a replica for read-only use.
+

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -819,6 +819,18 @@ export default class RedisClusterSlots<
     };
   }
 
+  getClientForKey(
+    key: RedisArgument,
+    isReadonly: boolean | undefined
+  ): Promise<RedisClientType<M, F, S, RESP, TYPE_MAPPING>> {
+    const slotNumber = calculateSlot(key);
+    if (isReadonly) {
+      return this.nodeClient(this.getSlotRandomNode(slotNumber));
+    }
+
+    return this.nodeClient(this.slots[slotNumber].master);
+  }
+
   *#iterateAllNodes() {
     if(this.masters.length + this.replicas.length === 0) return
     let i = Math.floor(Math.random() * (this.masters.length + this.replicas.length));

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -7,6 +7,7 @@ import { RootNodesUnavailableError } from '../errors';
 import { spy } from 'sinon';
 import RedisClient from '../client';
 import { RESP_TYPES } from '../RESP/decoder';
+import calculateSlot from 'cluster-key-slot';
 
 describe('Cluster', () => {
   describe('default commandOptions', () => {
@@ -257,6 +258,25 @@ describe('Cluster', () => {
       minimizeConnections: undefined // reset to default
     }
   });
+
+  testUtils.testWithCluster('getNodeClientForKey returns the slot master and supports WATCH/MULTI/EXEC', async cluster => {
+    const key = 'key';
+    const nodeClient = await cluster.getNodeClientForKey(key);
+    assert.ok(nodeClient instanceof RedisClient);
+    assert.equal(nodeClient, cluster.slots[calculateSlot(key)].master.client);
+
+    await nodeClient.watch(key);
+    const reply = await nodeClient.multi()
+      .set(key, 'value')
+      .exec();
+    assert.deepEqual(reply, ['OK']);
+  }, GLOBAL.CLUSTERS.OPEN);
+
+  testUtils.testWithCluster('getNodeClientForKey with isReadonly returns a node from the slot', async cluster => {
+    const key = 'key';
+    const nodeClient = await cluster.getNodeClientForKey(key, true);
+    assert.ok(nodeClient instanceof RedisClient);
+  }, GLOBAL.CLUSTERS.WITH_REPLICAS);
 
   testUtils.testWithCluster('should throw CROSSSLOT error', async cluster => {
     await assert.rejects(cluster.mGet(['a', 'b']));

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -729,6 +729,27 @@ export default class RedisCluster<
   }
 
   /**
+   * Returns the connected node client responsible for the given key's slot.
+   * Useful for connection-level operations that the cluster client does not expose
+   * directly, such as `WATCH` followed by `MULTI`/`EXEC`:
+   *
+   * ```javascript
+   * const nodeClient = await cluster.getNodeClientForKey(key);
+   * await nodeClient.WATCH(key);
+   * const value = await nodeClient.GET(key);
+   * const reply = await nodeClient.MULTI()
+   *   .SET(key, calculateNewValue(value))
+   *   .EXEC(); // `null` if `key` changed, retry
+   * ```
+   *
+   * @param key - The key whose slot determines the node.
+   * @param isReadonly - If `true`, may return a replica client; otherwise returns the slot master.
+   */
+  getNodeClientForKey(key: RedisArgument, isReadonly?: boolean) {
+    return this._self._slots.getClientForKey(key, isReadonly);
+  }
+
+  /**
    * @deprecated use `.masters` instead
    * TODO
    */


### PR DESCRIPTION
Cluster client cannot expose WATCH because it needs connection-level state on a specific node. Previously users had to import cluster-key-slot, compute the slot, read cluster.slots, and call nodeClient manually.

Add getNodeClientForKey(key, isReadonly?) which resolves the key's slot and returns the connected node client (master, or a slot node when readonly), enabling optimistic-locking transactions in cluster mode.

Closes #3194

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and thin routing helper on existing slot logic; no changes to default command dispatch or auth.
> 
> **Overview**
> Adds **`getNodeClientForKey(key, isReadonly?)`** on the cluster client so callers can run **connection-scoped** work (especially **`WATCH` → `MULTI`/`EXEC`**) on the node that owns a key’s slot, without manually using `cluster-key-slot`, `cluster.slots`, and `nodeClient`.
> 
> Routing matches existing cluster behavior: **slot master** by default, or a **slot node (including replicas)** when `isReadonly` is `true`. **`docs/clustering.md`** documents the WATCH transaction pattern and the same-slot key constraint. **Integration tests** cover master resolution, WATCH/MULTI/EXEC, and readonly node selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b731f86753581c84e2d314afdeb74b137a10e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->