### PR TITLE
chore: add agent skills and tooling configs

### DIFF
--- a/.agents/skills/docs-sync/SKILL.md
+++ b/.agents/skills/docs-sync/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: docs-sync
+description: Analyze master branch implementation and configuration to find missing, incorrect, or outdated documentation in docs/, README.md, and per-package READMEs. Use when asked to audit doc coverage, sync docs with code, or propose doc updates/structure changes. Provide a report and ask for approval before editing docs.
+---
+
+# Docs Sync
+
+## Overview
+
+Identify doc coverage gaps and inaccuracies by comparing master branch features and configuration options against the current docs, then propose targeted improvements.
+
+## Workflow
+
+1. Confirm scope and base branch
+   - Identify the current branch and default branch (`master`).
+   - Prefer analyzing the current branch to keep work aligned with in-flight changes.
+   - If the current branch is not `master`, analyze only the diff vs `master` to scope doc updates.
+   - Avoid switching branches if it would disrupt local changes; use `git show master:<path>` or `git worktree add` when needed.
+
+2. Build a feature inventory from the selected scope
+   - If on `master`: inventory the full surface area and review docs comprehensively.
+   - If not on `master`: inventory only changes vs `master` (feature additions/changes/removals).
+   - Focus on user-facing behavior: public exports, client/cluster/sentinel/pool config options, new or changed commands, connection-string options, default values, and documented runtime behaviors.
+   - Capture evidence for each item (file path + symbol/setting).
+   - Use targeted search to find option types and feature flags (for example: `rg "Options"`, `rg "interface .*Options"`, `rg "export"` under `packages/*/lib`).
+   - For Redis command behavior or server-side semantics, treat the source code (`parseCommand`/`transformReply` in `packages/*/lib/commands`) as the source of truth; consult [redis.io/commands](https://redis.io/commands) only to confirm server semantics when discrepancies appear.
+
+3. Doc-first pass: review existing pages
+   - Walk each relevant page under `docs/`, the top-level `README.md`, and each `packages/*/README.md`.
+   - Identify missing mentions of important, supported options (opt-in flags, config), customization points, or new features from `packages/`.
+   - Propose additions where users would reasonably expect to find them on that page.
+
+4. Code-first pass: map features to docs
+   - Review the current docs layout under `docs/` (e.g. `client-configuration.md`, `clustering.md`, `sentinel.md`, `pool.md`, `RESP.md`, `transactions.md`, `programmability.md`, `pub-sub.md`, `scan-iterators.md`, `command-options.md`).
+   - Determine the best page/section for each feature based on existing patterns and package boundaries.
+   - Identify features that lack any doc page or have a page but no corresponding content.
+   - Note when a structural adjustment would improve discoverability.
+
+5. Detect gaps and inaccuracies
+   - **Missing**: features/configs present in master but absent in docs.
+   - **Incorrect/outdated**: names, defaults, or behaviors that diverge from master.
+   - **Structural issues** (optional): pages overloaded, missing overviews, or mis-grouped topics.
+
+6. Produce a Docs Sync Report and ask for approval
+   - Provide a clear report with evidence, suggested doc locations, and proposed edits.
+   - Ask the user whether to proceed with doc updates.
+
+7. If approved, apply changes
+   - Edit docs under `docs/`, `README.md`, and the relevant `packages/*/README.md`.
+   - Keep changes aligned with the existing docs style and navigation.
+   - Place any runnable code snippets under `examples/` or `doctests/`, mirroring existing patterns.
+   - Verify any snippet you add still compiles with `npm run build` and fix issues before handoff.
+
+## Output format
+
+Use this template when reporting findings:
+
+Docs Sync Report
+
+- Doc-first findings
+  - Page + missing content → evidence + suggested insertion point
+- Code-first gaps
+  - Feature + evidence → suggested doc page/section (or missing page)
+- Incorrect or outdated docs
+  - Doc file + issue + correct info + evidence
+- Structural suggestions (optional)
+  - Proposed change + rationale
+- Proposed edits
+  - Doc file → concise change summary
+- Questions for the user
+
+## References
+
+- `references/doc-coverage-checklist.md`

--- a/.agents/skills/docs-sync/agents/openai.yaml
+++ b/.agents/skills/docs-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Docs Sync"
+  short_description: "Audit docs coverage and propose targeted updates"
+  default_prompt: "Use $docs-sync to audit the current branch against docs/ and propose targeted documentation updates."

--- a/.agents/skills/docs-sync/references/doc-coverage-checklist.md
+++ b/.agents/skills/docs-sync/references/doc-coverage-checklist.md
@@ -1,0 +1,55 @@
+# Doc Coverage Checklist
+
+Use this checklist to scan the selected scope (master = comprehensive, or current-branch diff) and validate documentation coverage.
+
+## Feature inventory targets
+
+- Public exports: clients (`RedisClient`, `RedisCluster`, `RedisSentinel`), pool, factory functions, types, and module entry points.
+- Configuration options: `*Options` types, default config objects (`defaults.ts`), and connection-string options.
+- New or changed commands under `packages/*/lib/commands` (names, args, reply shape, RESP2/RESP3 differences).
+- User-facing behaviors: reconnection, timeouts, pub/sub, pipelining/transactions, scan iterators, errors, caching, telemetry, and data handling.
+- Deprecations, removals, or renamed settings (track against migration guides `docs/v*-to-v*.md`).
+
+## Doc-first pass (page-by-page)
+
+- Review each relevant page under `docs/`, the top-level `README.md`, and each `packages/*/README.md`.
+- Look for missing opt-in flags or customization options that the page implies.
+- Add new features that belong on that page based on user intent and navigation.
+
+## Code-first pass (feature inventory)
+
+- Map features to the closest existing page based on package or feature area.
+- Prefer updating existing pages over creating new ones unless the topic is clearly new.
+- Use conceptual pages for cross-cutting concerns (auth, errors, RESP, clustering, pub/sub).
+- Keep quick-start flows minimal; move advanced details into deeper pages.
+
+## Evidence capture
+
+- Record the master-branch file path and symbol/setting name.
+- Note defaults or behavior-critical details for accuracy checks.
+- Avoid large code dumps; a short identifier is enough.
+
+## Red flags for outdated or incorrect docs
+
+- Option names/types no longer exist or differ from code.
+- Default values or allowed ranges do not match implementation.
+- Features removed in code but still documented.
+- New behaviors introduced without corresponding docs updates.
+
+## When to propose structural changes
+
+- A page mixes unrelated audiences (quick-start + deep reference) without clear separation.
+- Multiple pages duplicate the same concept without cross-links.
+- New feature areas have no obvious home in the docs structure.
+
+## Diff mode guidance (current branch vs master)
+
+- Focus only on changed behavior: new exports/options, modified defaults, removed features, or renamed settings.
+- Use `git diff master...HEAD` (or equivalent) to constrain analysis.
+- Document removals explicitly so docs can be pruned if needed.
+
+## Patch guidance
+
+- Keep edits scoped and aligned to existing tone and format.
+- Update cross-links when moving or renaming sections.
+- Place any runnable snippets under `examples/` or `doctests/`.

--- a/.agents/skills/implement-command/SKILL.md
+++ b/.agents/skills/implement-command/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: implement-command
+description: Add a new Redis command (or command variant) to node-redis end-to-end — the `<NAME>.ts` Command file, its registration with JSDoc in the package `commands/index.ts`, and a co-located `<NAME>.spec.ts` with arg + behavior tests. Use when asked to implement, add, or wire up a Redis command in the client or a module package (json/search/bloom/time-series).
+---
+
+# Implement a node-redis Command
+
+## Overview
+
+A command in node-redis is a single `Command` object exported from
+`packages/<pkg>/lib/commands/<NAME>.ts`. It declares how to serialize arguments
+onto the wire (`parseCommand`) and how to map the RESP reply to a JS value
+(`transformReply`). It becomes callable on clients only after it is registered
+in the package's `commands/index.ts`. Both the raw name and a camelCase alias
+are exposed (`HSET` and `hSet`).
+
+This skill is for `@redis/client` core commands and for module packages
+(`@redis/json`, `@redis/search`, `@redis/bloom`, `@redis/time-series`). It does
+not cover RESP codec changes or new client transports.
+
+Before writing, **read 2-3 existing commands with a similar shape** (simple
+key read, key + options, variadic, RESP2/3-divergent reply) and mirror them.
+Consult [redis.io/commands](https://redis.io/commands) for argument order and
+reply type, but treat existing `parseCommand`/`transformReply` files as the
+source of truth for repo conventions.
+
+## File layout
+
+| Package | Command dir | Import paths | Wire name prefix |
+| --- | --- | --- | --- |
+| `client` | `packages/client/lib/commands/` | `../client/parser`, `../RESP/types`, `./generic-transformers` | none (`GET`) |
+| `json` | `packages/json/lib/commands/` | `@redis/client/dist/lib/...` | `JSON.` (`JSON.ARRAPPEND`) |
+| `search` | `packages/search/lib/commands/` | `@redis/client/dist/lib/...` | `FT.` |
+| `bloom` | `packages/bloom/lib/commands/<family>/` | `@redis/client/dist/lib/...` | e.g. `BF.`, `CF.`, `TOPK.` |
+| `time-series` | `packages/time-series/lib/commands/` | `@redis/client/dist/lib/...` | `TS.` |
+
+**Naming**: file name = raw wire name with subcommand `_` separators
+(`ACL_CAT`, `CONFIG_GET`, `CLUSTER_FORGET`). A distinct reply variant gets its
+own file (`HRANDFIELD_COUNT_WITHVALUES`). Module commands drop the dotted
+prefix from the file name (`ARRAPPEND.ts` → wire `JSON.ARRAPPEND`).
+
+## Step 1 — Write `<NAME>.ts`
+
+Minimal pass-through command (`packages/client/lib/commands/GET.ts`):
+
+```typescript
+import { CommandParser } from '../client/parser';
+import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/types';
+
+export default {
+  CACHEABLE: true,
+  IS_READ_ONLY: true,
+  parseCommand(parser: CommandParser, key: RedisArgument) {
+    parser.push('GET');
+    parser.pushKey(key);
+  },
+  transformReply: undefined as unknown as () => BlobStringReply | NullReply
+} as const satisfies Command;
+```
+
+`as const satisfies Command` is mandatory — it preserves the literal arg types
+for the public API while type-checking the shape.
+
+### Command flags (all optional)
+
+- `IS_READ_ONLY: true` — read command; routable to replicas. Set for reads, omit/`false` for writes.
+- `CACHEABLE: true` — eligible for client-side caching. Only for pure reads with no side effects.
+- `NOT_KEYED_COMMAND: true` — command takes no key (server/connection level, e.g. `PING`, `CONFIG_GET`).
+- `IS_FORWARD_COMMAND` — internal; do not set on new commands.
+
+### `parseCommand` — serialize args via `CommandParser`
+
+First arg is always `parser`. Push the wire name first, then args in order.
+Use the parser helpers — **do not** hand-build arrays:
+
+- `push(...args)` — raw args (the command token, flags, stringified numbers).
+- `pushKey(key)` — a key. Registers it for cluster slot routing. Use for **every** key, never `push` a key.
+- `pushKeys(keys)` / `pushKeysLength(keys)` — multiple keys; the `Length` variant prefixes the count.
+- `pushVariadic(vals)` — a `RedisVariadicArgument` (one value or array) as flat args.
+- `pushVariadicWithLength(vals)` — same, prefixed with the count (e.g. `FIELDS <n> ...`).
+- `pushVariadicNumber(vals)` — number or array of numbers, stringified.
+
+Numbers are not auto-stringified by `push` — call `.toString()`. Optional
+trailing args go in an `options` object; export its `interface` (see
+`SET.ts`'s `SetOptions`). Encode keyword flags conditionally:
+
+```typescript
+parseCommand(parser: CommandParser, key: RedisArgument, value: RedisArgument, options?: SetOptions) {
+  parser.push('SET');
+  parser.pushKey(key);
+  parser.push(value);
+  if (options?.condition) parser.push(options.condition); // 'NX' | 'XX'
+}
+```
+
+### `transformReply` — map RESP reply to JS
+
+- **Pass-through** (reply already the right shape): `transformReply: undefined as unknown as () => <ReplyType>`.
+- **Function**: `(reply: <RawType>) => <JsType>`. Use `UnwrapReply<...>` to read the raw RESP container.
+- **RESP-version keyed**: `{ 2: (reply) => ..., 3: (reply) => ... }` when RESP2 and RESP3 shapes differ (e.g. flat array vs map/tuple). See `HRANDFIELD_COUNT_WITHVALUES.ts`.
+
+Reply types live in `RESP/types`: `BlobStringReply`, `SimpleStringReply<'OK'>`,
+`NumberReply`, `DoubleReply`, `NullReply`, `BooleanReply`, `ArrayReply<T>`,
+`TuplesReply<[...]>`, `MapReply`, `UnwrapReply`.
+
+**RESP3 is the default.** No separate RESP3 test is needed for a new command;
+the default test setup already exercises RESP3.
+
+### Type-mapping precision caveats
+
+- A `BLOB_STRING` reply cannot be remapped to `Number` via type mapping; only RESP3 `DOUBLE`/`BIG_NUMBER` are precision-risky.
+- If a `NumberReply` can exceed `Number.MAX_SAFE_INTEGER` (2^53-1), add a `@remarks` line to the JSDoc (Step 2) telling users to do `client.withTypeMapping({ [RESP_TYPES.NUMBER]: String })`. See the `ARGREP` entries in the client index for the exact wording.
+
+### Module package commands
+
+Import from the published client subpath, prefix the wire name, and reuse
+shared transformers (`packages/json/lib/commands/ARRAPPEND.ts`):
+
+```typescript
+import { CommandParser } from '@redis/client/dist/lib/client/parser';
+import { RedisArgument, NumberReply, Command } from '@redis/client/dist/lib/RESP/types';
+
+export default {
+  IS_READ_ONLY: false,
+  parseCommand(parser, key, path, value) {
+    parser.push('JSON.ARRAPPEND');
+    parser.pushKey(key);
+    parser.push(path, /* transform */ value);
+  },
+  transformReply: undefined as unknown as () => NumberReply
+} as const satisfies Command;
+```
+
+## Step 2 — Register in `commands/index.ts`
+
+`import` the command, then add it to the default-export map **twice**: the raw
+name (shorthand) and a camelCase alias. **Every entry MUST have a JSDoc block
+directly above it** — `npm run check:command-jsdoc` fails on any registry entry
+without an attached JSDoc comment (no blank-line gap allowed).
+
+```typescript
+import GET from './GET';
+// ...
+export default {
+  /**
+   * Returns the value of a key, or null if the key does not exist
+   * @param key - Key to read
+   */
+  GET,
+  /**
+   * Returns the value of a key, or null if the key does not exist
+   * @param key - Key to read
+   */
+  get: GET,
+} satisfies RedisCommands;
+```
+
+Keep both JSDoc blocks (raw + alias) in sync. Document every `parseCommand`
+param after `parser` with `@param`. Add `@remarks` for the precision caveat
+above when relevant. For module packages the registry files are
+`packages/<pkg>/lib/commands/index.ts` (bloom: per-family `.../<family>/index.ts`).
+
+## Step 3 — Write `<NAME>.spec.ts` (co-located)
+
+Two layers: arg serialization (no server) + behavior (real server, server +
+cluster topologies). Mirror `GET.spec.ts`:
+
+```typescript
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { parseArgs } from './generic-transformers';
+import GET from './GET';
+
+describe('GET', () => {
+  it('transformArguments', () => {
+    assert.deepEqual(parseArgs(GET, 'key'), ['GET', 'key']);
+  });
+
+  testUtils.testAll('get', async client => {
+    assert.equal(await client.get('key'), null);
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+});
+```
+
+- `parseArgs(COMMAND, ...args)` asserts the exact wire array — cover each option/flag branch and variadic shapes.
+- `testUtils.testAll(name, fn, { client, cluster })` runs the same body against a standalone server and a cluster. Use it so cluster key routing (`pushKey`) is exercised. Drop `cluster` only when the command is genuinely cluster-incompatible.
+- Pick the right `GLOBAL.SERVERS.*` / `GLOBAL.CLUSTERS.*` setup (see `test-utils.ts`); `OPEN` is the default.
+- **Docker is required** — test-utils starts real Redis containers.
+
+## Step 4 — Build, verify, lint
+
+```bash
+npm run build                                   # tsc --build (project references)
+npm run check:command-jsdoc                     # registry JSDoc gate
+npm run test-single -- packages/<pkg>/lib/commands/<NAME>.spec.ts
+npm run lint                                     # changed files
+```
+
+If the build fails on stale `dist/` from project references:
+
+```bash
+find packages -type d -name "dist" -exec rm -rf {} + && npm run build
+```
+
+For module packages, build the client first (or whole repo) — they import from
+`@redis/client/dist`.
+
+## Completion checklist
+
+- [ ] `<NAME>.ts` created with `parseCommand` + `transformReply`, `as const satisfies Command`.
+- [ ] Flags set correctly (`IS_READ_ONLY` for reads, `CACHEABLE` only for side-effect-free reads, `NOT_KEYED_COMMAND` if no key).
+- [ ] Every key uses `pushKey`/`pushKeys`; numbers stringified; options behind an exported `interface`.
+- [ ] RESP2/3 divergence handled via keyed `transformReply` if shapes differ.
+- [ ] Registered in `commands/index.ts`: import + raw entry + camelCase alias, **each with JSDoc** (`@param` per arg; `@remarks` for >2^53 precision).
+- [ ] `<NAME>.spec.ts`: `parseArgs` covers all branches; `testUtils.testAll` covers server + cluster.
+- [ ] `npm run build`, `npm run check:command-jsdoc`, the spec, and `npm run lint` all pass.
+- [ ] Commit message uses Conventional Commits; no company-internal refs.
+```

--- a/.agents/skills/implement-command/SKILL.md
+++ b/.agents/skills/implement-command/SKILL.md
@@ -39,6 +39,71 @@ source of truth for repo conventions.
 own file (`HRANDFIELD_COUNT_WITHVALUES`). Module commands drop the dotted
 prefix from the file name (`ARRAPPEND.ts` → wire `JSON.ARRAPPEND`).
 
+## Step 0 — Gather inputs (ask the user first)
+
+New commands are often implemented **before they are publicly released**, so
+redis.io may not document them yet and a default `redis:latest` may not have
+them. Before writing any code, ask the user for two things:
+
+1. **The command spec.** Ask for the redis/redis JSON spec file — one per
+   command under
+   [`src/commands/<name>.json`](https://github.com/redis/redis/tree/unstable/src/commands)
+   (subcommands use `-`, e.g. `client-info.json`, `acl-cat.json`). If the
+   command is unreleased, ask the user to paste the spec from their branch.
+   As a fallback on a live server: `redis-cli --json COMMAND DOCS <name>` and
+   `COMMAND INFO <name>`.
+2. **A running Redis instance that has the command.** Ask for connection
+   details (host/port, TLS, auth, module loaded). Use it to explore real
+   behavior and confirm the implementation matches the spec — do not rely on
+   the spec alone. A quick `redis-cli` session or a throwaway probe script
+   (`packages/client` is already wired for `tsx`) is enough; never commit the
+   probe.
+
+If the user cannot provide a spec, derive arguments/reply from
+[redis.io/commands](https://redis.io/commands) but flag that it is unverified.
+If they cannot provide a live instance, implement from the spec but state that
+runtime behavior was not confirmed.
+
+### Reading the spec JSON → mapping to a Command
+
+The redis/redis spec drives every part of the `Command` object. Example
+(`getex.json`, trimmed):
+
+```json
+{
+  "GETEX": {
+    "since": "6.2.0", "arity": -2,
+    "command_flags": ["WRITE", "FAST"],
+    "key_specs": [{ "begin_search": { "index": { "pos": 1 } }, "flags": ["RW", "UPDATE"] }],
+    "arguments": [
+      { "name": "key", "type": "key", "key_spec_index": 0 },
+      { "name": "expiration", "type": "oneof", "optional": true, "arguments": [
+        { "name": "seconds", "type": "integer", "token": "EX" },
+        { "name": "persist", "type": "pure-token", "token": "PERSIST" }
+      ]}
+    ],
+    "reply_schema": { "oneOf": [ { "type": "string" }, { "type": "null" } ] }
+  }
+}
+```
+
+| Spec field | Drives |
+| --- | --- |
+| `command_flags` contains `READONLY` (and **not** `WRITE`) | `IS_READ_ONLY: true`. `WRITE` → omit it. Pure read with no side effects → also `CACHEABLE: true`. |
+| `key_specs` empty / no `key`-type args | `NOT_KEYED_COMMAND: true`. |
+| `arguments[].type: "key"` | `parser.pushKey(...)` (one per key, in spec order). |
+| `type: "pure-token"` + `token` | a literal flag pushed only when its option is set (`parser.push('PERSIST')`). |
+| `token` + value type (`integer`/`string`/...) | push the token then the stringified value (`parser.push('EX', seconds.toString())`). |
+| `type: "oneof"` | mutually exclusive branch → `if/else if` in `parseCommand`; model as a union/`options` field. |
+| `optional: true` | goes in the `options` object (exported `interface`); guard with `if (options?.x)`. |
+| `multiple: true` | variadic → `parser.pushVariadic*`. |
+| `arity` | sanity-check arg count in `parseArgs` tests. |
+| `reply_schema` (JSON Schema) | the `transformReply` return type. `oneOf [string, null]` → `BlobStringReply \| NullReply`; `integer` → `NumberReply`; `array` → `ArrayReply<...>`; a map differing by RESP version → keyed `transformReply: { 2, 3 }`. |
+| `since` | mention the version in JSDoc / `@remarks` when relevant. |
+
+After implementing, run the command against the live instance and diff the real
+reply against `reply_schema` and your `transformReply` output.
+
 ## Step 1 — Write `<NAME>.ts`
 
 Minimal pass-through command (`packages/client/lib/commands/GET.ts`):

--- a/.agents/skills/implement-command/agents/openai.yaml
+++ b/.agents/skills/implement-command/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Implement Command"
+  short_description: "Add a new Redis command to node-redis end-to-end"
+  default_prompt: "Use $implement-command to add a new Redis command to node-redis: write the <NAME>.ts Command file (parseCommand + transformReply), register it with JSDoc in the package commands/index.ts (raw name + camelCase alias), and add a co-located <NAME>.spec.ts with parseArgs and testUtils.testAll tests, then build, run check:command-jsdoc, the spec, and lint."

--- a/.agents/skills/maintainer-review/SKILL.md
+++ b/.agents/skills/maintainer-review/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: maintainer-review
+description: Review a GitHub issue or pull request URL as a node-redis maintainer, with a staged assessment of whether the claim is real, practically important, already solvable with supported functionality, correctly scoped, better served by another design, and worth maintainer and contributor effort. Use when assessing issue validity or severity, deciding whether an issue should be prioritized or closed, determining whether a requested feature represents an unmet need rather than a discoverability or usage gap, judging whether a PR is worth bringing to mergeable quality, comparing open PRs or alternative designs, separating code quality from repository readiness, or drafting a concise maintainer assessment. When closure, additional evidence, or code changes should be requested, also produce a polite, concise, complete, copy-paste-ready maintainer comment.
+---
+
+# Maintainer Review
+
+## Objective
+
+Make a maintainer decision, not a generic diff summary. Separate these questions:
+
+1. Is the claimed behavior real?
+2. What user outcome or constraint exists independently of the reporter's proposed API or fix?
+3. Can supported functionality already achieve that outcome with reasonable composition or configuration?
+4. If a gap remains, is the proposed solution the best design and implementation layer?
+5. Can supported users plausibly reach the gap, and what happens when they do?
+6. Is it important enough to act on now?
+7. If this PR did not already exist, would maintainers choose to open and implement the same work?
+8. For a PR, is this solution worth merging and maintaining?
+9. Can overlapping or stale operations corrupt shared state or clean up resources owned by surviving work?
+10. If competing PRs exist, which single implementation path should maintainers pursue?
+11. What concise maintainer message should communicate closure, an evidence request, or required changes?
+
+Treat an issue's requested field, callback, flag, class, or implementation strategy as a proposed mechanism, not as the accepted requirement. Do not begin by asking how to implement it. First establish either a concrete unmet user outcome or a violated supported contract, then prove that the proposed mechanism is better than the available alternatives.
+
+Lead with the current review state. Use `Preliminary assessment` while runtime approval or evidence is pending, and `Maintainer decision` only when the review can be concluded. Use the diff, issue narrative, and contributor effort as evidence, not as proxies for impact.
+
+## Workflow
+
+### 1. Establish the exact remote target
+
+- Accept a GitHub issue or PR URL as the primary input. Resolve owner, repository, item type, and number before reviewing it.
+- For an issue, read the full report, comments, reproduction, environment, linked material, and maintainer responses.
+- For a PR, inspect the current remote base and head, full patch, commit history when relevant, tests, linked issue, and review discussion. Do not substitute the current local checkout for the remote change.
+- State the claim in one falsifiable sentence. Separate the observed symptom from the proposed cause or fix.
+- Identify the latest released boundary when compatibility or regression claims matter.
+- Verify whether linked evidence matches the PR's exact runtime variant, provider or tool type, triggering condition, and user outcome. A generic issue title, conceptual similarity, or wording such as `Related to` does not transfer evidence of need to an adjacent extension. If the reported scenario has already been fixed, treat additional variants as new needs requiring their own evidence.
+
+Use read-only GitHub access. On this laptop, do not run `gh` unless the user explicitly asks in the same turn. A review never authorizes comments, labels, branch changes, pushes, merges, or other remote writes.
+
+### 2. Establish the unmet need and challenge the proposed solution
+
+Complete this pass before deeply evaluating a proposed implementation and before any positive issue or PR assessment.
+
+First assign one `Need evidence` status:
+
+- **Demonstrated**: The exact scope has a concrete supported scenario, a real-path reproduction, a released compatibility requirement, a violated supported contract, repeated demand, or a broad invariant with a meaningful consequence.
+- **Plausible but unproven**: The path can exist, but realistic provider behavior, user reach, frequency, consequence, or demand is not established.
+- **Already covered**: A reasonable supported workflow already satisfies the outcome.
+- **Unsupported**: The outcome belongs outside the client's public contract or at a Redis-server, adapter, or caller-owned layer.
+
+Only `Demonstrated` need may receive `Merge-worthy as-is` or `Merge-worthy after focused changes`. For `Plausible but unproven`, prefer `Needs evidence` or `Not worth completing`; for `Already covered` or `Unsupported`, prefer closure or the relevant simpler alternative.
+
+1. Restate the desired user outcome without naming the requested API, class, file, option, or implementation. Separate the actual constraint from the reporter's preferred mechanism.
+2. Trace the closest supported ways to achieve that outcome in the current release and current target. Inspect the owning code path, public API, tests, and relevant docs rather than assuming that an unfamiliar capability is missing. Consider configuration, composition, cloning, callbacks, extension points, provider adapters, and caller-owned code.
+3. Determine whether the report shows a capability gap, an ergonomics or discoverability gap, an unsupported use case, or no demonstrated gap. A more convenient spelling is not automatically a missing capability.
+4. Compare the proposed solution against the strongest existing approach and at least one better-design candidate: no code change, clearer documentation or validation, a narrower fix, reuse of an existing abstraction, or enforcement at a more coherent shared boundary.
+5. For each viable approach, compare whether it satisfies the concrete scenario, what new public or internal contract it creates, cross-path consistency, compatibility, and permanent maintenance cost.
+
+Do not treat a test proving that new code can work as evidence that the feature is needed. A `sinon` spy or stub, a fake socket, a synthetic fixture built with `@redis/test-utils`, or a new regression test can establish code-path reachability and implementation correctness; it does not by itself establish realistic server behavior, user reach, frequency, practical consequence, or demand.
+
+API symmetry, naming consistency, and parity with an adjacent command, reply type, or output type are design arguments, not evidence of need. Parity may justify work when it removes existing complexity or enforces a broad demonstrated invariant, but adding branches, tests, documentation, or public behavior requires independent practical justification.
+
+If the need is not `Demonstrated`, inspect the patch only far enough to understand its contract, risk, and maintenance cost. Do not turn implementation defects, missing tests, or documentation gaps into a request-changes recommendation, because those questions become merge-blocking only after the need gate passes. If the report provides no concrete scenario, the existing functionality appears sufficient, or the requested mechanism solves only a hypothetical convenience problem, prefer `Needs evidence`, `Close`, `Supersede with a simpler alternative`, or `Not worth completing` over designing the requested feature on the reporter's behalf.
+
+An existing workaround may change priority or solution shape, but it does not by itself erase a demonstrated correctness, security, compatibility, or lifecycle defect in supported behavior. Evaluate both the unmet outcome and the violated contract.
+
+### 3. Discover competing open PRs proportionally
+
+Do this before deeply evaluating a specified PR. A PR URL selects the starting point, not necessarily the entire comparison set.
+
+- Determine the primary issue from explicit closing keywords, linked issues, timeline/development links, PR body/comments, and the reproduced symptom. State when association is inferred.
+- When an issue is explicitly linked, enumerate all open PRs that address it through cross-references, closing keywords, and development links. Include drafts but label them.
+- When no issue is linked, run a bounded duplicate search using the strongest signals from the title, reproduction, violated invariant, and runtime path.
+- Exclude closed/merged PRs from the active comparison set while using them as history when relevant.
+- Require a shared issue, symptom, violated invariant, or materially overlapping path. A shared package label is not enough.
+- If repository access cannot establish completeness, say so instead of claiming every candidate was found.
+
+Compare candidates on need coverage, runtime correctness, placement, tests, compatibility, complexity, readiness, remaining maintainer work, and reusable pieces. Prefer the best maintainable solution, not the first or smallest diff by default.
+
+### 4. Use a two-stage evidence flow
+
+Always begin with a desk review. Inspect the real runtime path before judging a change as trivial or meaningful. Check callers, public exports, equivalent streaming/non-streaming or provider/runtime paths, persistence, cleanup, and focused tests. Inspecting test code is part of the desk review; executing tests, imports, examples, reproductions, benchmarks, or service calls is a runtime probe.
+
+Consult `AGENTS.md` and the `docs/` guides (for example client-configuration, clustering, sentinel, pool, RESP, and transactions) for architecture and background, and treat the source under `packages/*/lib` as the source of truth. Verify every current claim against the remote change, current source, tests, docs, release boundary, and runtime evidence. Do not infer issue status or PR correctness from a guide.
+
+Use this evidence order across the two stages:
+
+1. Trace the closest existing supported capabilities and determine whether they already satisfy the underlying user outcome.
+2. Inspect existing tests and complete the code-path trace, including the mandatory interleaving and ownership pass when triggered, without executing code.
+3. With explicit user approval, run a focused local reproduction of the exact claim when the desk-review rules below require it.
+4. A comparison with the latest release, base branch, or another known-good control.
+5. A broader runtime matrix only when the maintainer decision remains uncertain and the user approves it.
+
+#### Stage 1: desk review
+
+Produce an initial result from static evidence before running code:
+
+##### Mandatory unmet-need and design pass
+
+Before a positive assessment, complete the pass in step 2 and be able to state all of the following from concrete evidence:
+
+1. The user outcome that current supported behavior cannot achieve, or the supported contract that the reported defect violates.
+2. The closest existing API or composition path and the exact reason it is insufficient.
+3. Why the proposed behavior belongs at the chosen abstraction layer instead of a caller, provider, adapter, validation, documentation, or existing extension point.
+4. Why the proposed permanent contract is better than no code change and the strongest narrower alternative.
+5. What real scenario, compatibility requirement, violated invariant, or repeated demand justifies the maintenance surface.
+6. Whether maintainers would choose to pursue the same work if no contributor had already supplied a patch.
+
+If any answer is missing and could change whether code should exist at all, do not call the issue actionable or the PR merge-worthy. Request only the evidence needed to distinguish a genuine capability gap or contract violation from a usage, discoverability, or solution-design problem. This is a product and architecture evidence gap, not a runtime-probe trigger by itself.
+
+##### Mandatory interleaving and ownership pass
+
+Run this pass before any positive PR assessment when a patch adds, removes, or reorders cleanup, retry, reconnect, cancellation, listeners, shared promises or tasks, sockets or streams, state flags, or mutable state across an `await`, callback, event, or deferred completion.
+
+1. Name each shared resource or state value and the operation that owns it. Include listeners, promises, tasks, connections, streams, locks, caches, state flags, persistence, and telemetry.
+2. Trace at least two overlapping operations, `A` and `B`, across every suspension or re-entry point. Check `A pending -> B starts -> A fails -> B succeeds`, `A pending -> B starts -> B fails -> A succeeds`, close or cancellation between setup and completion, and a stale completion arriving after newer work.
+3. For every cleanup or rollback, identify the exact attempt and resource generation it is allowed to dispose. Treat unconditional cleanup after a suspension point as a regression candidate until the code proves it cannot tear down newer or surviving work.
+4. Compare base and head for the survivor invariant. Replacing duplicated work with missing handlers, a closed shared resource, reverted state, or a rejected surviving promise is a regression, not a successful cleanup.
+5. Inspect tests for controlled interleavings using deferred promises, callbacks, or events. Require assertions about the surviving operation's observable behavior and final resource state, not only listener counts or individual rejection results.
+
+Do not mark a concurrency-sensitive patch `Merge-worthy as-is` merely because sequential reconnect, retry, failure, and close tests pass. If the code trace proves an unsafe interleaving, conclude from static evidence and request a focused fix and regression test. If ownership remains ambiguous, keep the result preliminary and request approval for the smallest decisive runtime probe.
+
+- If the claim or PR is decisively negative from a complete reachable code-path trace, conclude the review without a runtime probe. Examples include an impossible or unsupported path, duplicated existing handling, a demonstrated no-op, a direct compatibility break, or a clearly wrong abstraction. Do not call an ambiguous result negative merely to avoid a probe.
+- If the initial result is positive and there is no unresolved runtime concern, and any triggered interleaving and ownership pass is complete, the desk review may be sufficient for a final maintainer decision. Do not run a probe only to restate evidence that cannot plausibly change the decision.
+- If the initial result is positive but there is any unresolved runtime concern that could plausibly change claim validity, severity, merge-worthiness, required changes, or the preferred competing PR, stop before executing code. Report a `Preliminary assessment`, name the concern, propose the smallest decisive probe and control, and ask the user for approval to run it.
+- A purely stylistic, documentation, CI-status, or repository-readiness concern does not trigger a runtime probe unless it masks a runtime question.
+
+Do not issue a definitive positive maintainer decision while a decision-relevant runtime concern remains unresolved. If the user declines the probe, keep the result preliminary and state the exact confidence limitation.
+
+#### Stage 2: approved runtime probe
+
+After explicit approval, run only the smallest probe needed to resolve the stated concern. Exercise the real public or internal path and include a base, release, or known-good control when relevant. Do not stop at a happy-path smoke check when failure behavior determines the decision. Return to the user for separate approval before expanding materially beyond the approved probe.
+
+For latency, timeout, buffering, backpressure, or cleanup, measure an observable elapsed-time or state transition where feasible. Do not assume that a mocked unit test exercises real scheduling or provider behavior. Prefer a local probe first; use an approval-gated live-service probe only when local evidence cannot settle the decision.
+
+Use `$runtime-behavior-probe` only when the user explicitly invokes it or approves using it for the proposed runtime work. Preserve its environment-variable, live-service, cost, cleanup, and reporting gates. Ordinary maintainer review must not depend on that skill.
+
+For validation, cleanup, retries, interruption, background work, or concurrency:
+
+- Identify the earliest correct decision point after dynamic inputs are available.
+- List resources acquired before and after it: listeners, promises/tasks, streams, connections, files, locks, caches, state mutations, and telemetry.
+- Exercise failure during construction, connection, validation, execution, and cleanup where applicable.
+- Verify explicit cleanup when failure occurs before normal teardown.
+- Require a negative-path test when a listener, promise, stream, connection, process, or state can remain.
+
+Stop when additional evidence is unlikely to change validity, severity, or maintainer action.
+
+### 5. Calibrate validity and impact
+
+Read [the evaluation framework](references/evaluation-framework.md) when validity, severity, or merge value is not immediately clear.
+
+Assess claim validity, realistic reach, consequence, breadth, frequency, recoverability, compatibility, and severity. Keep observed facts separate from inference and name missing evidence that could change the result.
+
+Report the `Need evidence` status before classifying the need as a capability gap, ergonomics or discoverability gap, unsupported use case, no demonstrated gap, or a defect in supported behavior. Do not assign practical impact to the absence of the requested mechanism when an existing supported workflow already produces the requested outcome. Do not infer practical importance merely from reachability, API asymmetry, or a technically successful patch.
+
+For a PR, make `Severity` describe the underlying issue or user need. Report patch-induced regression, compatibility, lifecycle, or maintenance risk separately as `Patch risk`.
+
+Do not speculate about AI authorship or contributor intent. Identify weak reports through objective evidence: no reproduction, unsupported input, impossible path, duplicated handling, a test that does not exercise the claim, or a fix that is a runtime no-op.
+
+### 6. Apply the maintainer-effort test
+
+Use one code recommendation:
+
+- **Merge-worthy as-is**: real need, sound placement, proportionate scope, and adequate tests.
+- **Merge-worthy after focused changes**: real need and viable direction with bounded corrections.
+- **Supersede with a simpler alternative**: real need, but a smaller or more coherent fix is preferable.
+- **Not worth completing**: negligible/unsupported impact, no-op behavior, wrong abstraction, or excessive completion cost.
+
+`Merge-worthy as-is` and `Merge-worthy after focused changes` are invalid unless `Need evidence` is `Demonstrated`. A bounded set of implementation fixes cannot promote a `Plausible but unproven` need into a merge-worthy recommendation.
+
+For merge-worthy recommendations, use one repository-readiness status when useful:
+
+- **Ready**
+- **CI or review pending**
+- **Rebase or conflict resolution required**
+- **Blocked**
+
+Omit readiness for supersede/not-worth-completing recommendations; CI does not change those code decisions. Do not downgrade sound code only because CI is pending, and do not call a PR ready when semantic changes remain.
+
+For competing PRs, make one portfolio recommendation: choose one, choose one after focused changes, combine exact pieces into one destination, replace all with a simpler approach, or merge none. State what should happen to every active candidate.
+
+Always compare the proposed patch with the strongest existing supported approach and at least one alternative: no code change, validation or documentation, a narrower fix, reuse of an existing helper, or a different layer that enforces the invariant consistently. A review is incomplete if it establishes only that the patch works without establishing why the current product cannot meet the underlying need or violates a supported contract, and why this design is preferable.
+
+### 7. Report the decision and action
+
+Choose the assessment language from the current user request and governing repository instructions. Maintainer comment drafts remain English.
+
+Use the matching compact report in the evaluation framework. While runtime approval is pending, use its preliminary-assessment variant and end with the approval request instead of presenting a final recommendation. Keep the report decision-oriented, put unexpected/negative evidence first, and use no more than five evidence bullets by default.
+
+For PRs, put `Need evidence` before the code recommendation. When the need is not `Demonstrated`, lead with that result, omit repository readiness, and avoid presenting patch fixes as the primary maintainer action.
+
+When existing functionality or a better alternative materially affects the decision, state it explicitly in the evidence and recommendation. Name the exact supported path, what it does and does not cover, and why it is preferable. Do not bury a `Not worth completing` or `Supersede with a simpler alternative` conclusion beneath praise for implementation quality.
+
+When recommending closure, more evidence, focused changes, or superseding a PR, append a polite, complete, copy-paste-ready English maintainer comment. Include only merge-blocking work in its required-action paragraph. Do not produce a line-by-line review unless requested, equate passing tests with merge-worthiness, or equate a logically correct patch with practical value.
+
+## Resource
+
+- `references/evaluation-framework.md` contains the severity rubric, evidence checks, lifecycle review, issue dispositions, PR value checks, documentation threshold, competing-PR framework, maintainer-comment guidance, and compact report variants.

--- a/.agents/skills/maintainer-review/agents/openai.yaml
+++ b/.agents/skills/maintainer-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Maintainer Review"
+  short_description: "Gate PR value on demonstrated user need"
+  default_prompt: "Use $maintainer-review with this GitHub issue or PR URL. Before evaluating implementation quality, verify that linked evidence matches the exact runtime variant and assign Need evidence as Demonstrated, Plausible but unproven, Already covered, or Unsupported. Only a Demonstrated need may receive a merge-worthy recommendation; synthetic tests, API parity, and contributor effort do not establish need. Then compare existing and alternative approaches, complete the desk review and required lifecycle ownership checks, request approval before any decision-relevant runtime probe, compare credible competing PRs, recommend the best maintainer action, and include an English comment draft when closure or changes are needed."

--- a/.agents/skills/maintainer-review/references/evaluation-framework.md
+++ b/.agents/skills/maintainer-review/references/evaluation-framework.md
@@ -1,0 +1,382 @@
+# Maintainer Evaluation Framework
+
+Use this reference when a claim is ambiguous, severity is disputed, or a technically correct PR may not justify permanent maintenance.
+
+## Contents
+
+- [Decision model](#decision-model)
+- [Severity](#severity)
+- [Evidence strength](#evidence-strength)
+- [Unmet need and alternative design gate](#unmet-need-and-alternative-design-gate)
+- [Issue disposition](#issue-disposition)
+- [PR quality and value](#pr-quality-and-value)
+- [Documentation threshold](#documentation-threshold)
+- [Lifecycle and failure paths](#lifecycle-and-failure-paths)
+- [Concurrency and cleanup ownership](#concurrency-and-cleanup-ownership)
+- [Better-alternative prompts](#better-alternative-prompts)
+- [Competing pull requests](#competing-pull-requests)
+- [Maintainer comments](#maintainer-comments)
+- [Compact report variants](#compact-report-variants)
+
+## Decision Model
+
+Treat validity, severity, and merge-worthiness as separate outputs. Also distinguish a `Preliminary assessment`, which may still require approved runtime evidence, from a final `Maintainer decision`. Do not label a provisional positive result as a verdict or final decision.
+
+| Dimension | Question | Strong evidence |
+| --- | --- | --- |
+| Claim validity | Does the exact behavior occur, and is the proposed cause correct? | Reproduction, failing focused test, or complete reachable path |
+| Reachability | Can supported realistic inputs reach it? | Public API trace, real configuration, user report, or release comparison |
+| Consequence | What fails, and is it silent or recoverable? | Observed output/error/state and downstream effect |
+| Breadth | Which packages, runtimes, providers, and versions are affected? | Explicit path and compatibility matrix |
+| Frequency | Is it normal, intermittent, or pathological? | Repeats, deterministic preconditions, reports, or telemetry |
+| Need evidence | Is the exact scope demonstrated, merely plausible, already covered, or unsupported? | Same-scope user scenario, real-path reproduction, released compatibility requirement, violated supported contract, repeated demand, or broad consequential invariant |
+| Unmet need | What user outcome cannot be achieved through supported behavior today, or what supported contract is violated? | Concrete scenario plus a trace showing why the closest existing path is insufficient or defective |
+| Existing capability | Can configuration, composition, cloning, callbacks, extension points, or a caller-owned layer already satisfy the outcome? | Current release code, tests, docs, and an exact supported workflow |
+| Compatibility | Is released API, package resolution, protocol, or durable state changed? | Latest release comparison and contract inspection |
+| Solution fit | Is the requested mechanism the best design and implementation layer? | Proposed solution compared with the strongest existing path and at least one narrower or more coherent alternative |
+| Resource ownership | Can stale, failed, cancelled, or overlapping work mutate or clean up resources owned by surviving work? | Interleaving trace, attempt or generation ownership, and survivor assertions |
+| Maintenance cost | What permanent complexity and review burden is added? | New branches/configuration, changed surface, tests, and remaining work |
+
+## Severity
+
+- **Negligible**: no runtime difference, unreachable/unsupported input, cosmetic inconsistency, or harmless edge case. Usually close, document, or decline code complexity.
+- **Low**: real but narrow and recoverable behavior with a simple workaround and no data, security, or compatibility risk. Merge only when the fix is small and strengthens an invariant.
+- **Moderate**: supported use fails or produces incorrect behavior for a meaningful subset. Prioritize a bounded fix and regression test.
+- **High**: common or important use is broken, released compatibility is seriously affected, sensitive data can leak, or persistent corruption is possible. Require urgent strong validation.
+- **Critical**: broadly exploitable security impact, severe data loss, or systemic failure requiring coordinated action. Use only with concrete evidence.
+
+Severity is consequence multiplied by realistic reach and frequency, reduced by recoverability. Do not raise it because prose is alarming or lower it because a diff is small.
+
+## Evidence Strength
+
+Before calling a claim confirmed, answer:
+
+- Does the reproduction exercise the same public/internal path?
+- Does failure occur on the relevant base, latest release, or target?
+- Does the regression test fail without the patch and pass with it?
+- Are stale `dist`, wrong worktree/imports, dependency drift, proxies, caches, runtime conditions, unavailable Docker/sandbox, authentication, quota, and service failures excluded?
+- Does an equivalent RESP2/RESP3, single-node/cluster, sentinel, pub/sub, or package-export path differ?
+- Is behavior prohibited by a real contract or merely surprising?
+- For latency, timeout, buffering, backpressure, or cleanup, was observable time or state measured rather than inferred only from mocks?
+- For shared asynchronous state, do tests control completion order and prove that a stale failure or cleanup cannot affect the surviving operation?
+
+Use `partially confirmed` when the symptom is real but cause/reach/scope is wrong. Use `unproven` when decisive evidence is missing. Use `contradicted` only when evidence directly disproves the claim.
+
+## Unmet Need and Alternative Design Gate
+
+Issue reports often combine a desired outcome with a proposed API or implementation. Treat the proposed mechanism as a hypothesis. Confirm the unmet outcome or violated supported contract before evaluating how well the patch implements that mechanism.
+
+### Linked-evidence scope
+
+Evidence from a linked issue applies only when the issue and PR share the same runtime variant, provider or tool type, trigger, supported configuration, and user outcome. A broad title, ordinary reference, `Related to` statement, or conceptual similarity is not enough. If an earlier change already resolved the concrete reported scenario, an adjacent extension starts with no inherited evidence of need.
+
+### Need evidence status
+
+Assign one status before deep implementation review:
+
+- **Demonstrated**: The exact scope has a concrete supported scenario, real-path reproduction, released compatibility requirement, violated supported contract, repeated demand, or broad invariant with meaningful consequence.
+- **Plausible but unproven**: The code path is possible, but realistic reach, frequency, consequence, provider behavior, or demand is missing.
+- **Already covered**: A reasonable supported workflow already satisfies the outcome.
+- **Unsupported**: The outcome is outside the client's public contract or belongs at a Redis-server, adapter, or caller-owned layer.
+
+Only `Demonstrated` need can support a merge-worthy code recommendation. `Plausible but unproven` maps to `Needs evidence` or `Not worth completing`, even when the patch is technically correct and its remaining fixes are bounded. `Already covered` and `Unsupported` normally map to closure or a simpler non-core alternative.
+
+Before accepting an issue or recommending a PR, record:
+
+| Question | Required evidence |
+| --- | --- |
+| What outcome is needed? | A concrete supported scenario stated without the proposed API or fix |
+| What exists today? | The closest current-release API, configuration, composition, extension point, or caller-owned solution |
+| Why is it insufficient? | An exact behavioral, compatibility, lifecycle, or operational constraint, not preference alone |
+| What are the alternatives? | The proposed patch, the strongest existing path, and at least one no-code, narrower, or better-layer design |
+| Why add a contract? | Practical benefit sufficient to justify public surface, runtime branches, cross-path tests, documentation, and long-term maintenance |
+
+Classify the result:
+
+- **Capability gap**: a supported, realistic outcome cannot be achieved with current functionality. Code may be warranted.
+- **Ergonomics or discoverability gap**: the outcome is already possible, but the supported route is confusing or unnecessarily difficult. Prefer documentation, validation, or a narrowly justified convenience improvement.
+- **Unsupported use case**: the desired outcome lies outside the client's public contract or belongs at the Redis server, an adapter, application, or other caller-owned layer. Do not expand the core API merely to make it possible.
+- **No demonstrated gap**: no concrete scenario proves that existing functionality is insufficient. Request evidence or close rather than designing from the proposed mechanism.
+- **Defect in supported behavior**: the existing path violates a documented or established correctness, security, compatibility, or lifecycle contract. A workaround may affect priority or solution shape, but does not erase the defect.
+
+Passing tests for a new implementation establish feasibility and correctness, not need. A `sinon` spy or stub, a fake socket, a `@redis/test-utils` fixture, a mock, or any synthetic fixture does not establish realistic server behavior, user reach, frequency, consequence, or demand. API symmetry and parity with an adjacent runtime are design arguments, not need evidence. A technically coherent patch can still be `Not worth completing` when the motivating scenario is hypothetical, already supported, or better solved elsewhere.
+
+Use the counterfactual maintainer test: if the PR did not already exist, would maintainers choose to file and implement the same work from the available evidence? Contributor effort lowers implementation cost but does not create product need or remove permanent maintenance cost.
+
+When the need is not `Demonstrated`, inspect implementation only far enough to estimate contract, risk, and maintenance cost. Do not convert patch defects, missing tests, or documentation gaps into a request-changes disposition; those become merge blockers only after the need gate passes.
+
+## Issue Disposition
+
+Choose one:
+
+- **Prioritize**: confirmed moderate-or-higher impact or important invariant with no safe workaround.
+- **Accept, low priority**: confirmed low impact, existing supported functionality is insufficient or defective for the demonstrated scenario, and a proportionate fix is plausible.
+- **Narrow scope**: valid core, overstated paths or expected behavior.
+- **Needs evidence**: plausible but missing a supported reproduction, contract basis, or concrete scenario showing why existing functionality is insufficient.
+- **Close**: duplicate, unsupported, unreachable, contradicted, no-op, already addressed by a reasonable supported path, or not worth permanent complexity.
+
+Ask only for evidence that could change the disposition.
+
+## PR Quality and Value
+
+Assess independently:
+
+1. **Need**: same-scope evidence demonstrates a concrete unmet user outcome or defect in supported behavior, and the closest supported capability cannot reasonably satisfy the scenario as-is. Do not inherit evidence from an adjacent variant or already-fixed scenario.
+2. **Correctness**: the fix covers the claim and meaningful boundaries.
+3. **Placement**: the invariant is enforced once at the owning layer instead of duplicating existing functionality, patching locally, or moving caller- or server-owned policy into the core client.
+4. **Consistency**: equivalent streaming/non-streaming, provider, runtime, serialization, resume, package, and adapter paths stay aligned.
+5. **Tests**: a regression test fails on base, passes on head, and asserts the non-happy-path value/state. When shared state crosses an asynchronous boundary, tests control relevant completion orders and assert the surviving operation's behavior and final resource state.
+6. **Compatibility**: released exports, package conditions, types, protocols, schemas, and error behavior are preserved or intentionally migrated.
+7. **Proportionality**: public surface and complexity match impact.
+8. **Completion cost**: remaining code, tests, docs, design, and conflict work is bounded enough to justify attention.
+
+A PR can be correct but not merge-worthy because the need is negligible, the outcome is already supported through a reasonable existing mechanism, the real path is unchanged, equivalent paths remain inconsistent, the abstraction costs more than the benefit, or a simpler design exists at another layer.
+
+Do not use implementation correctness, bounded remaining work, CI status, or contributor effort to upgrade a need that is only `Plausible but unproven`. Merge-worthiness is gated by demonstrated need, not by how close the patch is to completion.
+
+Keep issue severity separate from `Patch risk`. A patch-induced regression, compatibility break, listener/resource leak, or maintenance hazard does not make the underlying issue more severe.
+
+## Documentation Threshold
+
+Make docs merge-blocking only when:
+
+- Existing docs become materially false, unsafe, or misleading.
+- Safe/correct use depends on a non-obvious constraint, migration, compatibility boundary, or operational warning.
+- Repository policy, accepted scope, or an explicit maintainer decision requires docs in the same PR.
+- The feature is practically unusable or undiscoverable without a user-facing entrypoint and generated/API discovery is insufficient.
+
+Keep optional discoverability/completeness non-blocking. Do not downgrade a code recommendation solely for optional docs or include optional docs in a required-action paragraph.
+
+## Lifecycle and Failure Paths
+
+Apply this section when a change adds validation, fail-fast behavior, cleanup, retry, interruption, background work, streaming, or concurrency.
+
+- Identify the earliest point where all dynamic inputs required for a correct decision exist.
+- List side effects before and after that point: listeners, promises/tasks, streams, sockets, peer connections, processes, files, locks, caches, state, persistence, and telemetry.
+- Exercise failure during construction, connection, validation, execution, persistence, and teardown where those phases exist.
+- Confirm normal teardown is actually entered. If construction/connect fails, verify explicit cleanup.
+- Prefer validation after dynamic configuration is resolved but before avoidable side effects begin.
+- Require a regression test for any listener, promise, stream lock, connection, process, file, or state that can remain after failure.
+
+## Concurrency and Cleanup Ownership
+
+Apply this section before a positive assessment whenever lifecycle work crosses an `await`, callback, event, deferred completion, retry, reconnect, cancellation, or shared resource boundary. Sequential correctness is insufficient because the patch can improve isolated cleanup while introducing cross-attempt teardown.
+
+Use a two-operation interleaving matrix during desk review:
+
+| Ordering | Required question |
+| --- | --- |
+| `A pending -> B starts -> A fails -> B succeeds` | Can A's cleanup remove or revert anything B needs? |
+| `A pending -> B starts -> B fails -> A succeeds` | Can B's cleanup leave A successful but non-functional? |
+| `A succeeds -> B starts -> stale A completion` | Can stale A overwrite B's newer state or generation? |
+| setup -> close/cancel -> late completion | Can late work resurrect listeners, state, tasks, or connections after teardown? |
+
+For each ordering:
+
+- Identify the resource owner before and after every suspension point.
+- Distinguish per-attempt resources from shared transport, session, cache, or listener state.
+- Require cleanup to carry an ownership token, generation, identity check, serialization guarantee, or another invariant that prevents cross-attempt disposal.
+- Compare base and head on the survivor invariant. Fewer duplicates do not justify losing the only active handler, connection, task, or state update.
+- Require a controlled interleaving test when the ordering is reachable. The test must assert both the failing operation and the surviving operation's observable behavior after all completions settle.
+
+An unscoped `finally`, `catch`, close handler, cancellation callback, or rollback that mutates shared state after a suspension point is merge-blocking when another operation can still own or use that state.
+
+## Better-Alternative Prompts
+
+Start with the strongest existing supported path, then test at least one additional alternative against the proposed patch. Do not complete a positive review without this comparison.
+
+- Can the requested outcome already be achieved through configuration, composition, cloning, callbacks, extension points, a custom provider or adapter, or caller-owned code?
+- If the existing route is awkward, is the problem discoverability or ergonomics rather than missing capability?
+- What happens with no code change?
+- Can input validation or an existing helper enforce the invariant earlier?
+- Can the fix be limited to the supported failing path?
+- Would clearer error or documentation prevent misuse without runtime complexity?
+- Can a failing test reveal a smaller correct change?
+- Is a new public option compensating for an internal ownership problem?
+- Can the same result be achieved in the converter, adapter, or state owner instead of every caller?
+- Is the proposed core behavior actually provider- or application-specific policy that belongs at another layer?
+
+## Competing Pull Requests
+
+Require an explicit issue link, same reproduction, same violated invariant, or materially overlapping runtime path before grouping candidates.
+
+| Criterion | Question |
+| --- | --- |
+| Need | Does a concrete user outcome remain unmet, or supported behavior remain defective, after tracing existing functionality? |
+| Existing capability | Could every candidate be avoided by configuration, composition, an extension point, or a better caller- or provider-owned solution? |
+| Coverage | Whole confirmed issue, useful subset, or adjacent problem? |
+| Correctness | Real path and meaningful boundaries? |
+| Placement | Owning shared layer? |
+| Tests | Base failure reproduced and approaches distinguished? |
+| Compatibility | Released APIs, packages, state, protocols, providers, runtimes? |
+| Complexity | Permanent branches, abstractions, configuration, coupling? |
+| Readiness | Mergeable now or bounded focused work? |
+| Reuse | Exact tests or ideas worth transferring? |
+
+Choose one portfolio action:
+
+- **Prefer one PR**
+- **Prefer one after focused changes**
+- **Combine selectively** into a named destination PR
+- **Replace all** with a simpler/coherent implementation
+- **Merge none**
+
+Do not issue independent approvals for overlapping candidates. State the action for every active PR.
+
+## Maintainer Comments
+
+Write drafts in English. Produce one when recommending closure, more evidence, focused changes, superseding, or choosing among competing PRs.
+
+Keep it polite, direct, complete, and usually 60-160 words in one to three short paragraphs:
+
+1. Acknowledge the contribution/report.
+2. State the decision with decisive technical evidence.
+3. Give the exact next action or reconsideration condition.
+
+Do not include internal severity labels, speculate about authorship/intent, repeat the full review, or soften the requested action until it is unclear.
+
+### Close
+
+```text
+Thanks for taking the time to investigate this. I traced the reported case through <path or behavior>, and <decisive finding>. In the supported path, <practical result>, so the added complexity is not justified by the demonstrated impact.
+
+I am going to close this <issue/PR>. If you can provide <specific reproduction or evidence that would change the decision>, we can revisit the underlying problem with that narrower scope.
+```
+
+### Request Changes
+
+```text
+Thanks for the contribution. The underlying issue is valid, and this approach is directionally reasonable. Before we can merge it, please address the following points: <bounded required changes>.
+
+These changes are needed because <contract, lifecycle, compatibility, or test reason>. Once they are covered with a regression test that fails on the base and passes on the updated branch, the PR should be ready for another review.
+```
+
+Adapt these templates to evidence. Do not use them as filler.
+
+### Existing Capability or Better Alternative
+
+```text
+Thanks for the contribution. I traced the underlying use case through <existing API or workflow>, which already supports <desired outcome and relevant limits>. The proposed change adds <new contract or complexity>, but the issue does not demonstrate a concrete supported case that the existing approach cannot handle.
+
+I am going to close this <issue/PR> for now. If you can provide <specific scenario showing the existing approach is insufficient>, we can revisit the unmet need and choose the narrowest appropriate design from that evidence.
+```
+
+## Compact Report Variants
+
+Use `Maintainer decision` for a concluded review. Use `Preliminary assessment` when a desk review is tentatively positive but a decision-relevant runtime concern remains. `Verdict` is intentionally avoided in the report headings because it does not communicate whether the result is provisional or final.
+
+### Runtime Approval Gate
+
+```markdown
+## Preliminary assessment
+
+<Tentative issue or PR assessment based on desk review only.>
+
+## Static evidence
+
+- <decisive code-path or test-inspection evidence>
+- <what remains uncertain at runtime>
+
+## Proposed runtime probe
+
+- Concern: <the uncertainty that could change the decision>
+- Probe: <smallest exact execution path>
+- Control: <base, release, or known-good comparison when relevant>
+- Scope: <local-only or any live-service, cost, mutation, or cleanup implications>
+
+## Approval request
+
+<Ask whether to run this exact probe. Do not present a final positive recommendation yet.>
+```
+
+### Issue
+
+```markdown
+## Maintainer decision
+
+<Real/partial/unproven/contradicted, severity, and disposition.>
+
+## Evidence
+
+- <decisive evidence>
+- <scope or uncertainty>
+
+## Existing capability and alternatives
+
+<Closest supported path, why it is or is not sufficient, and the preferred design alternative.>
+
+## Recommendation
+
+<Prioritize, accept low priority, narrow, request evidence, or close.>
+
+## Maintainer comment draft
+
+<Include for closure or an evidence request.>
+```
+
+### Pull Request
+
+```markdown
+## Maintainer decision
+
+<Need, practical impact, and merge-worthiness.>
+
+- Need evidence: <Demonstrated / Plausible but unproven / Already covered / Unsupported>
+- Code recommendation: <code disposition>
+- Repository readiness: <one allowed status; only when useful for a merge-worthy recommendation>
+
+## Evidence
+
+- <runtime/code-path result>
+- <test/compatibility result>
+
+## Existing capability and alternatives
+
+<Closest supported path, why the demonstrated scenario cannot use it or remains defective, and why this patch is preferable to no code change or a narrower design.>
+
+## Issue impact
+
+- Validity: <claim validity>
+- Severity: <underlying issue severity>
+- Reach: <realistic reach>
+
+## Patch risk
+
+<Only meaningful patch-induced risk.>
+
+## PR quality
+
+- Solution fit: <assessment>
+- Tests: <assessment>
+- Remaining effort: <bounded/unbounded and why>
+
+## Recommendation
+
+<Merge, focused changes, simpler replacement, or close.>
+
+## Maintainer comment draft
+
+<Only when closure, evidence, or changes should be requested.>
+```
+
+### Competing Pull Requests
+
+```markdown
+## Maintainer decision
+
+<Issue validity, severity, and preferred implementation path.>
+
+## Open PR comparison
+
+| PR   | Approach | Correctness | Tests | Compatibility/complexity | Readiness |
+| ---- | -------- | ----------- | ----- | ------------------------ | --------- |
+| #... | ...      | ...         | ...   | ...                      | ...       |
+
+## Recommendation
+
+<Select one, request focused changes, combine exact pieces, replace all, or merge none.> <State the action for every other active candidate.>
+
+## Maintainer comment drafts
+
+<One draft for each PR that should be closed, changed, or superseded.>
+```

--- a/.agents/skills/pr-draft-summary/SKILL.md
+++ b/.agents/skills/pr-draft-summary/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: pr-draft-summary
+description: Create the required PR-ready summary block, branch suggestion, title, and draft description for node-redis. Must be used before the final response whenever the actual task diff includes runtime code, tests, examples, build/test configuration, or docs with behavior impact, regardless of perceived change size. Skip only when no eligible files changed, every change is repo-meta or docs-only without behavior impact, the task is conversation-only, or the user explicitly opts out.
+---
+
+# PR Draft Summary
+
+## Purpose
+
+Produce a PR-ready summary after eligible work is complete: a concise change summary plus a PR-ready title and draft description for node-redis.
+
+## Close-out Gate
+
+1. Inspect the actual task diff before sending the final response.
+2. Run this skill when the diff includes runtime code, tests, examples, build/test configuration, or docs with behavior impact. Do not use perceived change size to skip an eligible change.
+3. Run it after any required verification and before sending the "work complete" response.
+4. Skip only when no eligible files changed, every change is repo-meta or docs-only without behavior impact, the task is conversation-only, or the user explicitly opts out.
+
+## Inputs to Collect Automatically (do not ask the user)
+
+- Current branch: `git rev-parse --abbrev-ref HEAD`.
+- Working tree: `git status -sb`.
+- Untracked files: `git ls-files --others --exclude-standard` (use with `git status -sb`; `--stat` omits them).
+- Changed files: `git diff --name-only` (unstaged) and `git diff --name-only --cached` (staged); sizes via `git diff --stat` and `git diff --stat --cached`.
+- Pull request base reference (use `origin/master`; never use a feature branch's upstream as the PR base):
+  - `BASE_REF=origin/master`; if it does not exist locally, use `master`.
+  - `BASE_COMMIT=$(git merge-base "$BASE_REF" HEAD)`.
+- Committed branch diff: `git diff --name-only "${BASE_COMMIT}..HEAD"` and `git diff --stat "${BASE_COMMIT}..HEAD"`.
+- Commits ahead of the base fork point: `git log --oneline --no-merges ${BASE_COMMIT}..HEAD`.
+- Category signals for this repo: runtime (`packages/*/lib`, `examples/`, `doctests/`, `benchmark/`, `scripts/`), tests (co-located `packages/**/*.spec.ts`), docs (`docs/`, `README.md`, `packages/*/README.md`, `AGENTS.md`, `.github/`), build/test config (`package.json`, `package-lock.json`, `tsconfig*.json`, `eslint.config.mjs`, `.mocharc*`, `mocha-multi-reporter-config.json`, `.nycrc*`).
+
+## Workflow
+
+1. Run the commands above without asking the user; compute `BASE_REF`/`BASE_COMMIT` first so later commands reuse them. Compare against `origin/master` or `master`, not the current branch's upstream.
+2. Combine the committed branch diff with staged, unstaged, and untracked changes. If the combined diff is empty, reply briefly that no code changes were detected and skip emitting the PR block.
+3. Infer change type from the touched paths listed under "Category signals"; classify as feature, fix, refactor, or docs-with-impact, and flag backward-compatibility risk only when the diff changes released public APIs, client/command behavior, connection config, or the RESP wire handling. Judge that risk against the latest release tag, not unreleased branch-only churn.
+4. Summarize changes in 1–3 short sentences using the top five paths and stats from the committed, staged, and unstaged diffs. Explicitly call out untracked files because `--stat` does not include them. Use commit messages as supporting context, not as a substitute for inspecting the committed diff.
+5. Choose the lead verb for the description: feature → `adds`, bug fix → `fixes`, refactor/perf → `improves` or `updates`, docs-only → `updates`.
+6. Suggest a branch name. If already off `master`, keep it; otherwise propose `feat/<slug>`, `fix/<slug>`, or `docs/<slug>` based on the primary area (for example `docs/pr-draft-summary-guidance`).
+7. If the current branch matches `issue-<number>` (digits only), keep that branch suggestion. When an issue number is present, reference `https://github.com/redis/node-redis/issues/<number>` and include an auto-closing line such as `This pull request resolves #<number>.` Do not block if the issue cannot be fetched.
+8. Draft the PR title and description using the template below. Use Conventional Commits prefixes for the title (`feat:`, `fix:`, `docs:`, `chore:`, etc.).
+9. Output only the block in "Output Format". Keep any surrounding status note minimal and in English. Do not include company-internal references (e.g. Jira/Confluence IDs) in the branch name, title, or description.
+
+## Output Format
+
+When closing out a task, add this concise Markdown block (English only) after any brief status note unless the task falls under the documented skip cases or the user says they do not want it.
+
+```
+# Pull Request Draft
+
+## Branch name suggestion
+
+git checkout -b <kebab-case suggestion, e.g., feat/pr-draft-summary-skill>
+
+## Title
+
+<single-line imperative title, which can be a commit message; a Conventional Commits prefix such as feat:, fix:, or docs: is preferred>
+
+## Description
+
+<include what you changed plus a draft pull request title and description for your local changes; start the description with prose such as "This pull request resolves/updates/adds ..." using a verb that matches the change (you can use bullets later), explain the change background (for bugs, clearly describe the bug, symptoms, or repro; for features, what is needed and why), any behavior changes or considerations to be aware of, and you do not need to mention any tests you ran.>
+```
+
+Keep it tight—no redundant prose around the block, and avoid repeating details between `Changes` and the description. Tests do not need to be listed unless specifically requested.

--- a/.agents/skills/pr-draft-summary/agents/openai.yaml
+++ b/.agents/skills/pr-draft-summary/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Draft Summary"
+  short_description: "Draft the repo-ready PR title and description"
+  default_prompt: "Use $pr-draft-summary to generate the PR-ready summary block, title, and draft description for the current changes."

--- a/.agents/skills/runtime-behavior-probe/SKILL.md
+++ b/.agents/skills/runtime-behavior-probe/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: runtime-behavior-probe
+description: Plan and execute runtime-behavior investigations with temporary TypeScript probe scripts, validation matrices, state controls, and findings-first reports. Use only when the user explicitly invokes this skill to verify actual runtime behavior beyond normal code-level checks, especially to uncover edge cases, undocumented behavior, or common failure modes in local or live integrations. A baseline smoke check is fine as an entry point, but do not stop at happy-path confirmation.
+---
+
+# Runtime Behavior Probe
+
+## Overview
+
+Use this skill to investigate real runtime behavior, not to restate code or documentation. Start by planning the investigation, then execute a case matrix, record observed behavior, and report both the findings and the method used to obtain them.
+
+## Core Rules
+
+- Treat this skill as manual-only. Do not rely on implicit invocation.
+- For `node-redis`, treat this skill as a disposable-probe workflow, not a repository implementation workflow.
+- Unless the user explicitly asks for a reusable repository artifact, the allowed write scope is limited to:
+  - a temporary directory used for probe scripts or artifacts
+  - `.agents/skills/runtime-behavior-probe/**` when the user is editing this skill itself
+- For disposable probes in `node-redis`, do not modify `examples/**`, `packages/**`, any `package.json`, `README.md`, workspace config, or build config.
+- If your draft plan would touch a disallowed path, stop and rewrite the plan before editing anything.
+- A baseline success or smoke case is often the right entry point, but do not stop there when the real question involves edge cases, drift, or failure behavior.
+- Plan before running anything. Write the case matrix first, then fill it in with observed results. The matrix can live in a scratch note, a temporary file, or the probe script header.
+- Default to local or read-only probes. Consider a live service only when it is clearly relevant, then apply the lightweight gates below before you run it.
+- Size the probe to the decision. Start with the smallest matrix that can disqualify or validate the current hypothesis, then expand only when uncertainty remains.
+- Before a live probe, apply three lightweight gates:
+  - Destination gate. Use only a live destination that is clearly allowed for the task.
+  - Intent gate. Run the live probe only when the user explicitly wants runtime verification on that integration, or explicitly approves it after you propose the probe.
+  - Data gate. If the probe will read environment variables, mutate remote state, incur material cost, or exercise non-public or user data, name the exact variable names or data class and get explicit approval first.
+- Classify each case as read-only, mutating, or costly before execution. For mutating or costly cases, or for any live case that will read environment variables, define cleanup or rollback before running the probe.
+- Use temporary files or a temporary directory for one-off probe scripts.
+- In `node-redis`, use disposable probe files outside git-tracked paths by default. Do not add one-off probes, harnesses, benchmarks, or examples under `examples/`, `packages/`, or other repository directories unless the user explicitly asks for a checked-in artifact.
+- Keep temporary artifacts until the final response is drafted. Then delete them by default unless the user asked to keep them or they are needed for follow-up. Even when artifacts are deleted, keep a short run summary of the command shape, runtime context, and artifact status in the report.
+- Before executing a live probe that will read environment variables, tell the user the exact variable names you plan to use and why, then wait for explicit approval. Examples include `REDIS_URL`, `REDIS_PASSWORD`, and other expected default names for the system under test.
+- Never print secrets, even when they come from standard environment variables that this skill may use.
+- For Redis command or server semantics, treat the repository source as the truth and use [redis.io/commands](https://redis.io/commands) to confirm contract-sensitive details such as argument order, reply types, and version availability. Use runtime probing to validate or challenge the documented behavior, not to skip the documentation pass entirely. If you rely on the website rather than source, say so in the report.
+- For benchmark or comparison probes, make parity explicit before execution. Record what is held constant, what variable is under test, which reply-shape constraints keep the comparison fair, and any counters or timings that matter for interpreting latency or cost.
+- In `node-redis`, default to a light local loop for probe authoring: temporary `probe.ts` plus temporary `tsconfig.json`, `npx tsc --noEmit -p <tmp-tsconfig>`, then `npx tsx <tmp-probe>`. Escalate to `npm run build` only when the runtime question is specifically about `dist/`, emitted exports, or packaged output.
+- In `node-redis`, do not treat a request for runtime verification, benchmarking, or comparison as permission to add a reusable example, benchmark harness, package script, or checked-in sample. Those repository changes require explicit user intent.
+- For probes that need a running Redis, remove setup ambiguity before attributing a negative result to client behavior:
+  - Confirm the server is reachable and note its mode (standalone, cluster, or sentinel) and RESP version before interpreting reply shapes.
+  - Treat RESP2 and RESP3 as separate cases, not interchangeable setup details, when the question is about reply type mapping or push messages.
+  - Clear unsupported server-version or command options first so they do not invalidate the probe. The repo test harness `@redis/test-utils` can start Redis in Docker for local probes.
+
+## Workflow
+
+1. Restate the investigation target in operational terms. Name the runtime surface, the key uncertainty, and the highest-risk behaviors to test.
+2. For `node-redis`, declare the allowed write scope before you do any implementation work. For a normal disposable probe, that means a temporary directory only.
+3. Do a short preflight. Check the relevant code or docs first, decide whether the question needs local or live validation, and note any repo, baseline, or release boundary that matters.
+4. Create a validation matrix before executing probes. Cover both baseline behavior and the most relevant failure or drift cases. The matrix can live in a scratch note, a temporary file, or a structured header inside the probe script.
+5. For each case, choose an execution mode up front:
+   - `single-shot` for deterministic one-run checks.
+   - `repeat-N` for cache, retry, streaming, interruption, rate-limit, concurrency, or other run-to-run-sensitive behavior.
+   - `warm-up + repeat-N` when first-run cold-start effects could distort the result. Use these defaults unless the task clearly needs something else:
+   - Quick screen of a repeat-sensitive question: `repeat-3`.
+   - Decision-grade latency or release recommendation: `warm-up + repeat-10`.
+   - Costly live cases: start at `repeat-3`, then expand only if the answer remains unclear. If it is genuinely unclear whether extra runs are worth the time or cost, ask the user before expanding the probe.
+6. When the question is benchmark-like or comparative, run in phases. Start with a high-signal pilot matrix against a control, then expand only the surviving candidates or unresolved cases.
+7. If the question is about a suspected regression or behavior change, add at least one known-good control case such as `origin/master`, the latest release, or the same request without the suspected option.
+8. For comparative probes, define parity before execution. Record prompt or input shape, tool-choice setup, model-settings parity, state reuse rules, and any response-shape constraint that keeps the comparison fair. If materially different output length could bias the result, record usage or token notes too.
+9. If the question asks whether one option has the same intelligence or quality as another, decide whether the matrix supports only example-pattern parity or a broader quality claim. For broader claims, add at least one harder or more open-ended case. Otherwise say explicitly that the result is limited to the covered patterns.
+10. Plan state controls before execution when hidden state could affect the result. Record whether each case uses fresh or reused state, how cache reuse or cache busting is handled, what unique IDs isolate repeated runs, and how cleanup is verified.
+11. If any live case will read environment variables, list the exact variable names and purpose for each case, then ask the user for approval before execution. Keep the approval ask short and include destination, read-only versus mutating or costly risk, exact variable names, and cleanup or rollback if relevant.
+12. Build task-specific probe scripts in a temporary location. Keep the script small, observable, and easy to discard.
+13. If you are about to propose a checked-in script, example, benchmark, or workspace script for `node-redis`, stop and verify that the user explicitly asked for a reusable repository artifact. If not, keep the probe temporary.
+14. In `node-redis`, make the runtime context explicit:
+
+- Run TypeScript probes from the repository root with `npx tsx` when practical.
+- For probe authoring, create both `probe.ts` and a sibling temporary `tsconfig.json` under `mktemp -d`, then run `npx tsc --noEmit -p <tmp-tsconfig>` before the first live execution.
+- Record the current commit, working directory, Node executable, Node version, and the package or source path you imported.
+- Avoid accidental imports from a different checkout or from `/tmp/node_modules`. If the probe needs repository code, import it from a repository-relative `file://` URL rooted at `process.cwd()`.
+- Prefer current-branch `lib/` imports when the question is "what does this branch do now?" and prefer `dist/` imports only when the question is specifically about packaged output after a build.
+- Do not run a repository-wide build just to typecheck a disposable probe. Reserve `npm run build` for `dist/` probes or when emitted output is itself part of the question.
+
+15. Execute the matrix and capture evidence. Record request shape, setup, observation summary, unexpected or negative result, error details, timing, runtime context, approved environment-variable names, repeat counts, warm-up handling, variance when relevant, cleanup behavior, and for comparisons note what was held constant plus any response-shape or usage notes that affect interpretation.
+16. Update the matrix with actual outcomes, not guesses.
+17. Keep temporary artifacts until the final response is drafted. Then delete them unless the user asked to keep them or they are needed for follow-up. Benchmark and repeat-heavy probes often need follow-up, so keeping artifacts is normal when the result may be revisited. If deleted, retain and report a short run summary.
+18. Report findings first, with unexpected or negative findings first. Then summarize how the validation was performed and which cases were covered.
+19. If the probe isolates one clear defect, you may include a short implementation hypothesis or minimal repro direction. Do not expand into a larger next-step plan unless the user asked for it.
+
+## Validation Matrix
+
+Use a matrix that makes the news easy to scan. Start from the runtime question and the observation summary, not just from `expected` and `pass` or `fail`.
+
+Use a matrix with at least these columns:
+
+- `case_id`
+- `scenario`
+- `mode`
+- `question`
+- `setup`
+- `observation_summary`
+- `result_flag`
+- `evidence`
+
+Add these columns when they materially improve the investigation:
+
+- `comparison_basis`
+- `variable_under_test`
+- `held_constant`
+- `output_constraint`
+- `status`
+- `confidence`
+- `state_setup`
+- `repeats`
+- `warm_up`
+- `variance`
+- `usage_note`
+- `risk_profile`
+- `env_vars`
+- `approval`
+- `control`
+
+Treat `result_flag` as a fast scan field such as `unexpected`, `negative`, `expected`, or `blocked`. Use `status` only when there is a credible comparison basis, baseline, or documented contract to compare against.
+
+Always consider whether the matrix should include these categories:
+
+- Baseline success.
+- Control or baseline comparison when a regression is suspected.
+- Boundary input or parameter variation.
+- Invalid or unsupported input.
+- Missing or incorrect configuration.
+- Transient external failure such as timeout, network interruption, or rate limiting.
+- Retry, idempotence, or cleanup behavior.
+- Concurrency or overlapping operations when shared state or ordering may matter.
+- Open-ended quality or intelligence samples when the question is broader than pattern parity.
+
+Open [validation-matrix.md](./references/validation-matrix.md) when you need a stronger prioritization model or a reusable case template.
+
+## Temporary Probe Scripts
+
+Write one-off scripts in a temporary file or temporary directory such as one created by `mktemp -d`. Keep the script outside the repository by default, even when it imports code from the repository.
+
+For `node-redis`, a disposable runtime probe should stay disposable. Do not add a package script, modify workspace config, or create a checked-in benchmark or example unless the user explicitly asks for a reusable repository artifact.
+
+For `node-redis`, the default authoring loop should be:
+
+1. `tmpdir=$(mktemp -d)`
+2. Write `probe.ts` and `tsconfig.json` into `$tmpdir`
+3. From the repository root, run `npx tsc --noEmit -p "$tmpdir/tsconfig.json"`
+4. If the quick typecheck passes, run `npx tsx "$tmpdir/probe.ts"`
+5. Only run `npm run build` if the probe intentionally imports `dist/` or validates packaged output
+
+Use a temporary `tsconfig.json` that extends the repository base settings but includes only the disposable probe, for example:
+
+```json
+{
+  "extends": "/absolute/path/to/node-redis/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./probe.ts"]
+}
+```
+
+If the probe needs repository code:
+
+- Run it with the repository root as the working directory.
+- Use `npx tsx /tmp/probe.ts` from the repository root when practical.
+- Use `npx tsc --noEmit -p /tmp/probe-tsconfig.json` as the default quick typecheck step before executing the probe.
+- Import repository modules with a `file://` URL built from `process.cwd()` and a repo-relative path. Do not assume bare workspace imports such as `@redis/client` will resolve from `/tmp`.
+- Use `lib/` imports for current-branch behavior probes and `dist/` imports for packaged-output probes.
+
+Design the probe to maximize observability:
+
+- Print or log the exact scenario being exercised.
+- Capture runtime context such as git SHA, working directory, Node executable and version, relevant package versions, model or deployment name, endpoint or base URL alias, and any retry or tool options that materially affect behavior.
+- For live probes, record only the names of environment variables that were approved for use. Never print their values.
+- Capture structured outputs when possible.
+- Preserve raw error type, message, and status code.
+- For repeat-sensitive cases, capture the attempt index, warm-up status, and any stable identifiers that help compare runs.
+- For repeated or benchmark-style probes, write both raw results and a compact summary artifact when practical.
+- Keep branching minimal so each script answers a narrow question.
+
+Before deleting the temporary script or directory, keep a short run summary of the script path, command used, runtime context, and whether the evidence was kept or deleted.
+
+Open [typescript_probe.ts](./templates/typescript_probe.ts) when you want a lightweight disposable TypeScript probe scaffold. Open [repo-import-patterns.md](./references/repo-import-patterns.md) when you need to load current-branch workspace code from a temporary script.
+
+## Reporting
+
+Report in this order:
+
+1. Findings. Put unexpected or negative findings first. If there was no real news, say that explicitly.
+2. Validation approach. Summarize the code used, the runtime surface exercised, the execution modes, and the case matrix coverage.
+3. Case results. Include the matrix or a condensed version of it when the case count is large.
+4. Artifact status and brief run summary. State whether temporary artifacts were deleted or kept, and provide kept paths or the retained summary.
+5. Optional implementation note. Include this only when one clear defect was isolated and a short implementation direction would help.
+
+For comparative probes, the report should also say what was held constant, what variable was under test, and whether the result supports only pattern parity or a broader quality claim.
+
+Open [reporting-format.md](./references/reporting-format.md) for the recommended response template.
+
+## Resources
+
+- Open [validation-matrix.md](./references/validation-matrix.md) to design and prioritize the case matrix.
+- Open [error-cases.md](./references/error-cases.md) to expand common failure scenarios.
+- Open [redis-runtime-patterns.md](./references/redis-runtime-patterns.md) for recurring node-redis runtime probe patterns.
+- Open [repo-import-patterns.md](./references/repo-import-patterns.md) for repository-relative TypeScript import guidance.
+- Open [reporting-format.md](./references/reporting-format.md) for the final report structure.
+- Open [typescript_probe.ts](./templates/typescript_probe.ts) for a minimal disposable TypeScript probe scaffold.

--- a/.agents/skills/runtime-behavior-probe/agents/openai.yaml
+++ b/.agents/skills/runtime-behavior-probe/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Runtime Behavior Probe"
+  short_description: "Plan and run runtime behavior probes"
+  default_prompt: "Use $runtime-behavior-probe to investigate actual runtime behavior with a validation matrix, disposable TypeScript probes outside git-tracked paths, and a findings-first report. For node-redis, the default write scope is a temporary directory only. Do not modify examples/, packages/, package.json files, README.md, workspace config, or build config, and do not add checked-in examples, benchmarks, or package scripts unless the user explicitly asks for a reusable repository artifact."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/runtime-behavior-probe/references/error-cases.md
+++ b/.agents/skills/runtime-behavior-probe/references/error-cases.md
@@ -1,0 +1,80 @@
+# Common Error Cases
+
+Use this reference to expand beyond the happy path. Favor error cases that a real user or operator is likely to hit.
+
+## Configuration Errors
+
+Check whether the runtime behaves differently for:
+
+- Missing required environment variables.
+- Present but malformed secrets or identifiers.
+- Wrong endpoint or base URL.
+- Wrong model or deployment name.
+- Incompatible local dependency versions.
+
+Look for:
+
+- Error type and status code.
+- Whether the failure is immediate or delayed.
+- Whether the message is actionable.
+- Whether retrying without fixing configuration changes anything.
+
+## Input Errors
+
+Probe common bad-input patterns such as:
+
+- Missing required fields.
+- Wrong data type.
+- Unsupported enum or option value.
+- Empty but syntactically valid input.
+- Oversized input or too many items.
+- Mutually incompatible options.
+
+Prefer realistic invalid inputs over artificial nonsense. The point is to learn how the runtime fails in practice.
+
+## Transport and Availability Errors
+
+When networked services are involved, consider:
+
+- Connection failure.
+- Read timeout.
+- Server timeout or upstream gateway error.
+- Rate limit response.
+- Partial stream interruption.
+- Reusing a connection after a failure.
+
+Capture whether the client library retries automatically, whether it surfaces retry metadata, and whether the final exception preserves the original cause.
+
+## State and Repetition Errors
+
+Many surprising bugs appear only when an operation is repeated or interrupted:
+
+- Re-submit the same request.
+- Repeat after a timeout.
+- Retry after a partial tool call or partial stream.
+- Resume after local cleanup or process restart.
+- Repeat with slightly changed inputs while reusing shared state.
+
+Observe whether the operation is idempotent, duplicated, silently ignored, or left in a partial state.
+
+## Concurrency Errors
+
+When shared state, ordering, or isolation may matter, consider:
+
+- Two overlapping requests with the same logical input.
+- Parallel runs that reuse the same cache key, session, container, or temporary resource.
+- Concurrent retries, cancellation, or cleanup racing with active work.
+- Output or event streams from one run leaking into another.
+
+Capture whether the runtime serializes, rejects, duplicates, corrupts, or cross-contaminates the work.
+
+## Investigation Heuristics
+
+Use these heuristics to pick error cases quickly:
+
+- Ask which failure a real engineer would debug first in production.
+- Ask which failure is most expensive if it is misunderstood.
+- Ask which failure would be invisible from code review alone.
+- Ask which failure path is likely to differ across environments.
+
+If the error behavior is already perfectly obvious from a local validator or type system, it is usually low priority for this skill.

--- a/.agents/skills/runtime-behavior-probe/references/redis-runtime-patterns.md
+++ b/.agents/skills/runtime-behavior-probe/references/redis-runtime-patterns.md
@@ -1,0 +1,135 @@
+# Redis Runtime Patterns
+
+Use this reference for recurring node-redis investigations so you do not have to rediscover the probe strategy each time. Treat the repository source as the truth for client behavior, and use [redis.io/commands](https://redis.io/commands) to confirm contract-sensitive details such as argument order, reply types, and version availability. If you rely on the website rather than source, say so in the report.
+
+## General Rules
+
+- Prefer small, focused probes over large harnesses. Keep one script focused on one uncertainty.
+- For comparative or benchmark-like questions, start with a pilot and expand only when the answer is still unclear.
+- Capture both the request shape (command and arguments as sent) and the raw reply, before any client-side type mapping.
+- Preserve raw error type, message, and any Redis error prefix such as `WRONGTYPE`, `MOVED`, `ASK`, `CROSSSLOT`, `NOSCRIPT`, or `LOADING`.
+- Record whether behavior differs between the first call and a repeated call, and across a reconnect.
+- When the question is about regression or contract drift, add a known-good control run before attributing the result to the change under investigation.
+- Keep comparison parity explicit. Record what was held constant, what variable changed, and whether reply-shape or encoding differences could bias the conclusion.
+- Record the runtime context that actually changes Redis client behavior: server mode (standalone, cluster, sentinel), RESP version (2 vs 3), server version, and whether a feature such as client-side caching or sharded pub/sub is in use.
+
+## Connection Environment Variables
+
+Do not read these variables automatically. Before a live probe uses any of them, tell the user the exact variable names you plan to read and why each one is needed, then wait for explicit approval. Never print their values:
+
+- `REDIS_URL`
+- `REDIS_PASSWORD`
+- `REDIS_TLS_CA`, `REDIS_TLS_CERT`, `REDIS_TLS_KEY` (and any other `REDIS_TLS_*` the probe needs)
+
+For most local probes you do not need any of these. The repository test harness `@redis/test-utils` can start Redis in Docker, so a disposable probe can target a local containerized server (for example `redis://localhost:6379`) without reading credentials. Prefer that over a live remote service unless the question is specifically about the remote deployment.
+
+If the task targets another integration, use that integration's expected default variable names under the same rule.
+
+## Environment False Signals
+
+Before attributing a failure to the patch or client code under review, exclude source-selection and environment problems with a controlled comparison.
+
+- Confirm the commit, worktree, working directory, Node executable/version, and imported module path. A probe of stale `dist`, another checkout, `/tmp/node_modules`, or an installed `redis` package does not prove current `lib` behavior.
+- Rebuild when emitted declarations, package exports, generated metadata, or `dist` is the subject. Otherwise prefer current-source `lib/` imports so stale build output cannot create a false result.
+- Confirm a Redis server is actually running and reachable. A connection refused or timeout against a missing Docker/Redis container is an environment condition, not a client defect, until a controlled rerun against a known-good server ties it to the code.
+- Confirm the RESP version the client negotiated. A reply-shape surprise is often just RESP2 vs RESP3, not a bug.
+- Confirm server mode matches the probe assumptions. Running a cluster-only expectation against a standalone server, or the reverse, produces misleading routing and slot errors.
+- Run base and head controls with the same Node version, dependency graph, server mode, RESP version, environment-variable names, and command shape. Record intentional differences.
+- Treat sandbox denials, unavailable Docker infrastructure, expired remote sessions, authentication, quota, rate limits, service outages, and stale caches as environment conditions until a controlled rerun ties them to the patch.
+- Never print credentials, connection URLs with embedded passwords, or TLS key material. Change only the minimum in-scope environment or disposable state needed for the control and record variable names rather than values.
+
+In the final report, distinguish code failures, unsupported configurations, environment blockers, and inconclusive probes. Do not collapse them into one failed-test count.
+
+## Node-Redis Probe Patterns
+
+Start from the uncertainty instead of from the full client surface. The patterns below cover the runtime questions that recur most often in node-redis.
+
+### RESP2 vs RESP3 reply shapes and type mapping
+
+Use when the uncertainty is what a command returns at runtime and how the client maps it.
+
+- Run the same command under RESP2 and RESP3 as separate cases. Maps, sets, doubles, big numbers, verbatim strings, and booleans differ between the two protocols.
+- Capture the raw reply and the post-mapping JavaScript value. Note whether the client returns plain objects, `Map`, arrays, `null`, or typed numbers.
+- Watch precision-sensitive types. RESP3 `DOUBLE` and `BIG_NUMBER` can lose precision when mapped to `Number`; record the exact value.
+- If the probe configures a custom `typeMapping`, treat each mapping choice as part of `held_constant`.
+
+### Single-node vs cluster vs sentinel
+
+Use when key routing, slot ownership, or topology matters.
+
+- For cluster, capture which node served the command and whether a `MOVED` or `ASK` redirect occurred. Probe multi-key commands across keys in different slots to observe `CROSSSLOT` behavior and any client-side slot checks.
+- Use hash tags (`{tag}`) to force keys into the same slot when the probe needs a multi-key command to succeed.
+- For sentinel, capture master discovery and what happens on a simulated failover.
+- Keep mode constant within a case. A standalone control alongside a cluster case is a useful comparison, not a substitute.
+
+### Pub/sub and sharded pub/sub
+
+Use when delivery semantics or resubscription matter.
+
+- Capture subscribe confirmation, message delivery order, and whether messages are delivered to pattern (`PSUBSCRIBE`) and channel subscribers as expected.
+- For sharded pub/sub (`SSUBSCRIBE` and `SPUBLISH`) in cluster, capture which shard delivered the message.
+- Force a reconnect and observe whether the client resubscribes to channels and patterns automatically. This is a common drift point.
+
+### Reconnection, retry, and the offline command queue
+
+Use when the question is about resilience.
+
+- Simulate a dropped connection (stop or restart the container, or close the socket) and capture: whether commands issued while offline are queued, the order they flush in on reconnect, and whether the reconnect strategy backoff behaves as configured.
+- Distinguish commands rejected immediately from commands queued and later resolved or rejected.
+- Capture whether in-flight commands at disconnect are retried, rejected, or hang.
+
+### Pipelining and MULTI/EXEC transactions
+
+Use when batching or atomicity is under test.
+
+- For pipelining, confirm replies map back to the right commands in order, including when one command in the batch errors.
+- For `MULTI`/`EXEC`, capture queueing errors versus execution errors, behavior on `DISCARD`, and `WATCH` optimistic-locking aborts (`EXEC` returning `null`).
+
+### Client-side caching (RESP3 push invalidation)
+
+Use when caching correctness matters.
+
+- Requires RESP3. Capture whether invalidation push messages arrive after a tracked key is modified by another client, and whether the local cache entry is dropped.
+- Probe the broadcast and default tracking modes separately.
+
+### Blocking commands and connection isolation
+
+Use for `BLPOP`, `BRPOP`, `XREAD BLOCK`, `WAIT`, and similar.
+
+- Capture whether the blocking command monopolizes a connection and whether the client isolates it (for example via a dedicated connection) so other commands are not stalled.
+- Probe timeout behavior and what resolves when the block is satisfied by another client versus when it times out.
+
+### Pool behavior
+
+Use when a pooled client is involved.
+
+- Capture how commands are distributed across pool connections, behavior under saturation, and what happens when a pooled connection drops.
+- For commands that require connection affinity (transactions, blocking, subscriptions), confirm the pool keeps them on a single connection.
+
+### SCAN iterators
+
+Use for `SCAN`, `HSCAN`, `SSCAN`, and `ZSCAN`.
+
+- Capture cursor progression, whether the async iterator terminates, and whether `COUNT` and `MATCH` behave as expected. Note that SCAN gives no count or completeness guarantees mid-iteration.
+
+### Large payloads and timeouts
+
+Use when size or latency is the concern.
+
+- Capture behavior with large values and large reply sets, and whether command-level or socket timeouts fire as configured.
+- For repeat-sensitive latency, use warm-up plus repeat-N and record medians, not a single sample.
+
+## What to Capture
+
+For node-redis probes, try to record:
+
+- The command and arguments as sent, plus the raw reply before type mapping.
+- The mapped JavaScript value and its type, especially for RESP3 maps, sets, doubles, and big numbers.
+- Server mode (standalone, cluster, or sentinel), negotiated RESP version, and server version.
+- Whether fields are absent, `null`, empty, or transformed by the client.
+- Raw error type, message, and any Redis error prefix for failures.
+- Reconnect and retry behavior, offline-queue flush order, and resubscription on reconnect when relevant.
+- For cluster, which node served the command and any redirect.
+- Which environment-variable names were approved for the probe when a live or credentialed server was required.
+
+Do not spend time rediscovering static documentation unless the runtime result seems to contradict what you expected. The value of this skill is in the observed behavior.

--- a/.agents/skills/runtime-behavior-probe/references/repo-import-patterns.md
+++ b/.agents/skills/runtime-behavior-probe/references/repo-import-patterns.md
@@ -1,0 +1,97 @@
+# Repository Import Patterns
+
+Use this reference when a temporary probe script outside the repository needs to load code from the current branch.
+
+## Why This Exists
+
+When you run `npx tsx /tmp/probe.ts` from the repository root, `tsx` itself comes from this repository, but the probe file still lives under `/tmp`. Bare workspace imports such as `@redis/client` or `@redis/json` therefore resolve as if the script were its own package. That is often not what you want for "what does the current branch do right now?" investigations.
+
+The safe default is to build a `file://` import URL from `process.cwd()`, which should be the repository root, and a repository-relative path.
+
+## Default Rule
+
+- Use `lib/` imports when the question is about current-branch behavior.
+- Use `dist/` imports when the question is about packaged output after a build.
+- Avoid bare workspace imports from `/tmp` unless the probe is explicitly testing published package resolution rather than branch-local source behavior.
+
+## Quick Typecheck Loop
+
+For disposable probes in `node-redis`, the default loop should stay outside the repository and avoid a full workspace build:
+
+1. Create a temporary directory with `mktemp -d`.
+2. Write `probe.ts` there.
+3. Write a sibling `tsconfig.json` that extends the repository's `tsconfig.base.json`.
+4. From the repository root, run `npx tsc --noEmit -p /tmp/.../tsconfig.json`.
+5. If that passes, run `npx tsx /tmp/.../probe.ts`.
+
+Example temporary `tsconfig.json`:
+
+```json
+{
+  "extends": "/absolute/path/to/node-redis/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./probe.ts"]
+}
+```
+
+This keeps TypeScript module resolution and strictness close to the repository defaults while limiting the check surface to the disposable probe file.
+
+Do not convert this default loop into a checked-in benchmark, example, or package script unless the user explicitly asks for a reusable repository artifact.
+
+## Recommended Helper
+
+The disposable TypeScript scaffold exposes:
+
+    const module = await importRepoModule("packages/client/lib/index.ts");
+
+Internally, the helper should be equivalent to:
+
+    import { join } from "node:path";
+    import { pathToFileURL } from "node:url";
+
+    async function importRepoModule(repoRelativePath: string) {
+      const absolutePath = join(process.cwd(), repoRelativePath);
+      return import(pathToFileURL(absolutePath).href);
+    }
+
+This keeps the import anchored to the current checkout instead of the temporary script location.
+
+## Choosing `lib/` Versus `dist/`
+
+Use `lib/` when:
+
+- You are validating a bug fix or regression on the current branch.
+- You want to know how the repository behaves before packaging.
+- The question is about implementation details or internal helper behavior.
+
+Use `dist/` when:
+
+- The question is specifically about what consumers load after `npm run build`.
+- You need to validate export maps or emitted `.js` and `.d.ts` output.
+- The bug only reproduces in generated output.
+
+If the probe uses `dist/`, record whether you ran a fresh build first. A stale `dist/` directory can create false positives or false negatives.
+
+Do not run `npm run build` only to typecheck or execute a `lib/`-based disposable probe. The fast path is temp `tsconfig` plus `npx tsc --noEmit`, then `npx tsx`.
+
+## Simple Smoke Targets
+
+When you only need to prove the helper works, start with a simple target that has minimal side effects, for example:
+
+- `packages/client/lib/index.ts`
+- `packages/client/lib/client/index.ts`
+- `packages/json/lib/index.ts`
+- another file with obvious exported symbols and no environment requirement
+
+If a chosen file pulls in more of the repo than expected, switch to a simpler target rather than weakening the import guidance.
+
+## What To Record
+
+When a probe imports repo code, report:
+
+- The repo-relative path you imported.
+- Whether it came from `lib/` or `dist/`.
+- The repository root used by `process.cwd()`.
+- Any prerequisite step such as `npm run build`.

--- a/.agents/skills/runtime-behavior-probe/references/reporting-format.md
+++ b/.agents/skills/runtime-behavior-probe/references/reporting-format.md
@@ -1,0 +1,118 @@
+# Reporting Format
+
+Lead with findings, not process. The user asked for investigation results, so the answer should start with the most important observed behaviors. Put the real news first.
+
+## Recommended Order
+
+1. Findings.
+2. Validation approach.
+3. Case matrix or condensed case summary.
+4. Artifact status and brief run summary.
+5. Optional implementation note.
+
+## Findings Section
+
+Make each finding answer one user-relevant question. Good findings usually include:
+
+- What was observed.
+- Why it matters.
+- The condition under which it happens.
+- What was held constant when the finding comes from a comparison probe.
+- `scope`: The boundary of the finding, such as commit, model, Node version, live versus local, or repeat mode.
+- `confidence`: `high`, `medium`, or `low`.
+
+Avoid burying the main result under setup details.
+
+Put `unexpected` or `negative` findings first. If there were no unexpected or negative findings in the executed cases, say that explicitly before the rest of the findings section.
+
+If the probe was comparative, say whether the result supports:
+
+- Pattern parity only.
+- A broader quality claim.
+
+Do not imply a broader quality equivalence than the executed cases justify.
+
+## Validation Approach Section
+
+Summarize:
+
+- The runtime surface you exercised.
+- The shape of the probe code, in overview only.
+- Which categories of cases you covered.
+- Which execution modes you used, including repeat counts or warm-up handling when relevant.
+- Whether live credentials or external services were used.
+- Any important state controls such as fresh state, cache reuse, cache busting, unique IDs, or cleanup verification.
+- For comparison probes, what was held constant, what was varied, and whether output-shape or usage differences could still influence the conclusion.
+- Whether the usual docs path or an official-docs fallback was used for contract-sensitive checks.
+
+Keep this concise. The user needs enough detail to trust the result, not a line-by-line replay of the script.
+
+## Case Summary
+
+Include either the full matrix or a condensed summary. At minimum, show:
+
+- Which scenarios were executed.
+- Whether the run was a quick pilot, an expanded matrix, or both.
+- Which ones produced `unexpected` or `negative` results.
+- Which ones passed or failed when a real comparison basis existed.
+- Which cases were blocked.
+- Where the supporting evidence lived, or that it was deleted.
+
+If the matrix is large, show the highest-value cases in the main response and keep the rest as a compact appendix or note.
+
+## Artifact Status And Brief Run Summary
+
+State one of these explicitly:
+
+- Temporary artifacts were kept until the final response was drafted, then deleted after validation.
+- Temporary artifacts were kept at `<path>` because the user asked to keep them.
+- Temporary artifacts were kept at `<path>` because they are needed for follow-up analysis.
+
+Even if artifacts were deleted, retain a short run summary such as:
+
+- Probe command or runner shape.
+- Runtime context summary such as commit, Node executable, Node version, or model.
+- Artifact path and final status.
+
+For benchmark or repeat-heavy probes, keeping artifacts for follow-up is often the right default even when the immediate report is done.
+
+## Optional Implementation Note
+
+Include this only when one clear defect was isolated and a short implementation hypothesis or minimal repro direction would help. Keep it brief. Do not turn the report into a broader next-step plan unless the user asked for that.
+
+## Compact Template
+
+Use this outline when you need a fast structure:
+
+    Findings:
+    - <finding 1>
+      held constant: <prompt/tool/state settings kept the same, if comparative>
+      scope: <commit/model/node/live-local/repeat-mode>
+      confidence: <high|medium|low>
+    - <finding 2>
+      held constant: <prompt/tool/state settings kept the same, if comparative>
+      scope: <commit/model/node/live-local/repeat-mode>
+      confidence: <high|medium|low>
+
+    Validation approach:
+    - Surface: <what was exercised>
+    - Probe code: <brief overview>
+    - Coverage: <success, edge, error, repeat-sensitive, and quality categories>
+    - Execution modes: <single-shot|repeat-N|warm-up + repeat-N>
+    - Comparison parity: <what was held constant and what varied, if comparative>
+    - Docs source: <MCP or official-docs fallback, if relevant>
+
+    Case summary:
+    | case_id | scenario | result_flag | status | note |
+    | --- | --- | --- | --- | --- |
+    | S1 | ... | expected | pass | ... |
+    | E1 | ... | negative | fail | ... |
+
+    Artifact status and brief run summary:
+    - Temporary artifacts were kept until the final response was drafted, then deleted.
+    - Summary: <command/runtime-context/artifact-status summary>
+
+    Optional implementation note:
+    - <brief hypothesis or minimal repro direction>
+
+Adjust the format to the task, but preserve the ordering.

--- a/.agents/skills/runtime-behavior-probe/references/validation-matrix.md
+++ b/.agents/skills/runtime-behavior-probe/references/validation-matrix.md
@@ -1,0 +1,137 @@
+# Validation Matrix
+
+Use the matrix to decide what to probe before writing scripts. The goal is not exhaustive combinatorics; the goal is high-value coverage that is visible, explainable, and likely to reveal runtime surprises. The matrix should make the real news easy to scan.
+
+## Minimum Columns
+
+Use these columns unless the task clearly needs more:
+
+- `case_id`: Stable identifier such as `S1`, `E3`, or `R2`.
+- `scenario`: Short description of the behavior under test.
+- `mode`: `single-shot`, `repeat-N`, or `warm-up + repeat-N`.
+- `question`: The concrete runtime uncertainty this case is answering.
+- `setup`: Inputs, environment, or preconditions required for the case.
+- `observation_summary`: A compact summary of what actually happened.
+- `result_flag`: `unexpected`, `negative`, `expected`, or `blocked`.
+- `evidence`: Path, log reference, or `deleted`.
+
+Add these columns when they materially improve the investigation:
+
+- `comparison_basis`: The baseline, docs, or prior behavior you are comparing against.
+- `variable_under_test`: The single factor that is intentionally changing in a comparison case.
+- `held_constant`: Prompt shape, tool setup, model settings, or state rules that were intentionally kept the same.
+- `output_constraint`: Any schema, length, or response-shape constraint used to keep the comparison fair.
+- `status`: Use `pass`, `fail`, `unexpected-pass`, `unexpected-fail`, or `blocked` only when there is a credible comparison basis or control.
+- `confidence`: `high`, `medium`, or `low`.
+- `state_setup`: Fresh or reused state, cache strategy, unique IDs, and cleanup checks.
+- `repeats`: Number of measured runs.
+- `warm_up`: Whether a warm-up run was used and why.
+- `variance`: Any useful spread or instability note across repeated runs.
+- `usage_note`: Token, usage, or output-length note when it materially affects interpretation.
+- `control`: Known-good comparison point for regression or behavior-change questions.
+- `risk_profile`: `read-only`, `mutating`, or `costly` for live probes.
+- `env_vars`: Exact environment-variable names the case plans to read.
+- `approval`: `not-needed`, `pending`, or `approved` for cases that need user permission before execution.
+
+Use `result_flag` as the fast scan field. It is what makes unexpected or negative findings jump out before the reader studies the full report.
+
+Use `status` only when you have a real comparison basis. If the case is exploratory and there is no trustworthy baseline, prefer a strong `observation_summary` plus `result_flag` and `confidence` instead of pretending the result is a clean pass or fail.
+
+## Choosing Execution Mode
+
+Pick an execution mode before you run the case:
+
+- Use `single-shot` for deterministic, one-run checks.
+- Use `repeat-N` automatically when the question involves cache behavior, retries, streaming, interruptions, rate limiting, concurrency, or other run-to-run-sensitive behavior.
+- Use `warm-up + repeat-N` when the first run is likely to include cold-start effects such as container provisioning, import caches, or prompt-cache population.
+
+Use these defaults unless the task clearly needs something else:
+
+- `repeat-3` for a quick screen of a repeat-sensitive question.
+- `warm-up + repeat-10` for decision-grade latency comparisons or release-facing recommendations.
+- For costly live probes, start at `repeat-3`, then expand only if the answer is still unclear.
+
+If it is genuinely unclear whether extra runs are worth the time or cost, ask the user before expanding the probe.
+
+## Phase The Matrix
+
+When the question is comparative or benchmark-like, do not jump straight to the largest matrix.
+
+Start with a pilot:
+
+- One control.
+- One or two highest-signal success cases.
+- The smallest repeat count that can disqualify a weak candidate quickly.
+
+Expand only when:
+
+- The candidate survives the pilot.
+- The results are close enough that more samples matter.
+- A major runtime surface is still uncovered.
+- The user explicitly wants decision-grade evidence.
+
+## Coverage Categories
+
+Try to cover at least one case from each relevant category:
+
+- `success`: Normal behavior that should work.
+- `control`: Known-good comparison such as `origin/master`, the latest release, or the same request without the suspected option.
+- `boundary`: Size, count, or parameter limits near a plausible edge.
+- `invalid`: Bad inputs or unsupported combinations.
+- `misconfig`: Missing key, wrong endpoint, bad permissions, or incompatible local setup.
+- `transient`: Timeout, temporary server issue, network breakage, or rate limiting.
+- `recovery`: Retry behavior, partial completion, duplicate submission, or cleanup.
+- `concurrency`: Overlapping operations when shared state, ordering, or isolation may matter.
+- `quality`: A harder or more open-ended sample when the user is asking about model intelligence, not just workflow parity.
+
+If time is limited, prioritize categories in this order:
+
+1. Known-good control when the question implies regression or drift.
+2. Highest-risk success case.
+3. Most plausible user-facing failure.
+4. Most likely edge case with ambiguous behavior.
+5. Cleanup or retry semantics.
+6. Lower-probability extremes.
+
+## Matrix Template
+
+Use this compact template:
+
+    | case_id | scenario | mode | question | setup | state_setup | variable_under_test | held_constant | comparison_basis | observation_summary | result_flag | status | evidence |
+    | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+    | K1 | Known-good control | single-shot | Does the baseline still show the expected behavior? | Same probe against baseline target | Fresh state | none | current probe shape | `origin/master` or latest release | pending | pending | pending | pending |
+    | S1 | Baseline success | single-shot | What does the normal success path look like at runtime? | Valid config and representative input | Fresh state | none | representative input and setup | current docs or local expectation | pending | pending | pending | pending |
+    | R1 | Cache or retry behavior | warm-up + repeat-N | Does behavior change after the first run or across retries? | Same request repeated under controlled settings | Cache key or retry setup recorded | reuse versus fresh state | prompt shape and tool setup | same request without reuse, or docs if available | pending | pending | pending | pending |
+    | C1 | Model comparison pilot | warm-up + repeat-N | Does candidate B preserve the covered behavior while improving latency? | Same scenario across two models | Fresh state and stable IDs | model name | prompt shape, tool choice, and model settings parity | control model in the same probe | pending | pending | pending | pending |
+    | E1 | Invalid input | single-shot | How does the runtime reject a realistic bad input? | Missing required field | Fresh state | invalid field value | same request with valid field | same request with valid field | pending | pending | pending | pending |
+    | X1 | Concurrent overlap | repeat-N | Do overlapping runs interfere with each other? | Two or more overlapping operations | Unique IDs plus cleanup verification | overlap timing | same logical input | same request serialized, if available | pending | pending | pending | pending |
+
+## Recording Results
+
+Keep `question` unchanged after execution. Put the actual behavior in `observation_summary`, then mark the scan-friendly `result_flag`.
+
+Use these `result_flag` values consistently:
+
+- `unexpected`: The result diverged from the best current understanding in a surprising way.
+- `negative`: The result exposed a user-relevant failure, risk, or sharp edge.
+- `expected`: The result matched the current understanding and did not reveal new risk.
+- `blocked`: The case did not produce a trustworthy observation.
+
+Only fill `status` when there is a credible comparison basis. Otherwise use `observation_summary`, `result_flag`, and `confidence` to communicate what was learned without over-claiming certainty.
+
+For comparison cases, use `observation_summary` and the final report to say whether the evidence supports pattern parity only or a broader quality claim.
+
+If a case reveals a new branch of behavior, add a follow-up case instead of overloading the original one.
+
+## Evidence Discipline
+
+Treat a case as incomplete when:
+
+- The observed output omits the key result you were testing.
+- The script mixed multiple questions and the result is ambiguous.
+- Hidden state, cache behavior, or previous runs may have influenced the result and were not controlled or documented.
+- The question is whether behavior changed, but the case has no credible control or baseline to compare against.
+- The case plans to read environment variables, but the exact variable names were not approved by the user before execution.
+- The case was repeat-sensitive, but it ran only once without a clear rationale.
+
+When this happens, narrow the probe and rerun. A smaller script with a cleaner result is better than a more complicated script that is hard to trust.

--- a/.agents/skills/runtime-behavior-probe/templates/typescript_probe.ts
+++ b/.agents/skills/runtime-behavior-probe/templates/typescript_probe.ts
@@ -1,0 +1,326 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Disposable probe workflow for node-redis:
+ * 1. Put this file in a temporary directory created with `mktemp -d`.
+ * 2. Add a sibling `tsconfig.json` that extends `${process.cwd()}/tsconfig.base.json`
+ *    and includes only `./probe.ts`.
+ * 3. From the repository root, run `npx tsc --noEmit -p /tmp/.../tsconfig.json`.
+ * 4. If that passes, run `npx tsx /tmp/.../probe.ts`.
+ * 5. Only switch to `dist/` imports and `npm run build` when packaged output is the thing under test.
+ */
+
+type ProbeMode = 'single-shot' | 'repeat-N' | 'warm-up + repeat-N';
+type ResultFlag = 'unexpected' | 'negative' | 'expected' | 'blocked';
+
+type CaseResult = {
+  case_id: string;
+  mode: ProbeMode;
+  is_warmup: boolean;
+  observation_summary: string;
+  result_flag: ResultFlag;
+  metrics: Record<string, unknown>;
+  error: string | null;
+  total_latency_s?: number;
+  first_token_latency_s?: number;
+};
+
+const SCENARIO = 'replace-me';
+const RUN_LABEL = 'replace-me';
+const MODE: ProbeMode = 'single-shot';
+const APPROVED_ENV_VARS: string[] = [];
+const OUTPUT_DIR_ENV = 'PROBE_OUTPUT_DIR';
+
+const RESULTS: CaseResult[] = [];
+const repoRequire = createRequire(join(process.cwd(), 'package.json'));
+
+function gitValue(...args: string[]): string {
+  const result = spawnSync('git', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    return 'unknown';
+  }
+  const value = result.stdout.trim();
+  return value || 'unknown';
+}
+
+function outputDir(): string | null {
+  const value = process.env[OUTPUT_DIR_ENV];
+  return value ? resolve(value) : null;
+}
+
+function writeJson(path: string, payload: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function emit(kind: string, payload: Record<string, unknown> = {}): void {
+  console.log(
+    JSON.stringify({
+      ts: Number((Date.now() / 1000).toFixed(3)),
+      kind,
+      ...payload,
+    }),
+  );
+}
+
+function findNearestPackageJson(startPath: string): string | null {
+  let current = resolve(startPath);
+  while (true) {
+    const candidate = join(current, 'package.json');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = resolve(current, '..');
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function resolvePackageVersion(packageName: string): string | null {
+  try {
+    const packageJsonPath = repoRequire.resolve(`${packageName}/package.json`);
+    return JSON.parse(readFileSync(packageJsonPath, 'utf8')).version ?? null;
+  } catch {
+    try {
+      const entryPath = repoRequire.resolve(packageName);
+      const packageJsonPath = findNearestPackageJson(resolve(entryPath, '..'));
+      if (!packageJsonPath) {
+        return null;
+      }
+      return JSON.parse(readFileSync(packageJsonPath, 'utf8')).version ?? null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export async function importRepoModule(
+  repoRelativePath: string,
+): Promise<Record<string, unknown>> {
+  const absolutePath = resolve(process.cwd(), repoRelativePath);
+  return import(pathToFileURL(absolutePath).href);
+}
+
+function runtimeContext(): Record<string, unknown> {
+  const approvedEnvVars = Object.fromEntries(
+    APPROVED_ENV_VARS.map((name) => [
+      name,
+      process.env[name] ? 'set' : 'unset',
+    ]),
+  );
+
+  const packageVersions = Object.fromEntries(
+    ['redis', '@redis/client']
+      .map((name) => [name, resolvePackageVersion(name)])
+      .filter((entry): entry is [string, string] => Boolean(entry[1])),
+  );
+
+  return {
+    scenario: SCENARIO,
+    run_label: RUN_LABEL,
+    mode: MODE,
+    cwd: process.cwd(),
+    script_path: resolve(process.argv[1] ?? ''),
+    node_executable: process.execPath,
+    node_version: process.version,
+    platform: process.platform,
+    git_commit: gitValue('rev-parse', 'HEAD'),
+    git_branch: gitValue('rev-parse', '--abbrev-ref', 'HEAD'),
+    npm_execpath: process.env.npm_execpath ?? null,
+    package_versions: packageVersions,
+    approved_env_vars: approvedEnvVars,
+    output_dir: outputDir(),
+  };
+}
+
+function startCase(
+  caseId: string,
+  options: { mode?: ProbeMode; note?: string } = {},
+): void {
+  emit('case_start', {
+    case_id: caseId,
+    mode: options.mode ?? MODE,
+    note: options.note ?? null,
+  });
+}
+
+function recordCaseResult(
+  caseId: string,
+  observationSummary: string,
+  resultFlag: ResultFlag,
+  options: {
+    mode?: ProbeMode;
+    isWarmup?: boolean;
+    totalLatencyS?: number;
+    firstTokenLatencyS?: number;
+    metrics?: Record<string, unknown>;
+    error?: string | null;
+  } = {},
+): void {
+  const payload: CaseResult = {
+    case_id: caseId,
+    mode: options.mode ?? MODE,
+    is_warmup: options.isWarmup ?? false,
+    observation_summary: observationSummary,
+    result_flag: resultFlag,
+    metrics: options.metrics ?? {},
+    error: options.error ?? null,
+  };
+
+  if (options.totalLatencyS !== undefined) {
+    payload.total_latency_s = options.totalLatencyS;
+  }
+  if (options.firstTokenLatencyS !== undefined) {
+    payload.first_token_latency_s = options.firstTokenLatencyS;
+  }
+
+  RESULTS.push(payload);
+  emit('case_result', payload as Record<string, unknown>);
+}
+
+function summarizeResults(): Record<string, unknown> {
+  const cases = new Map<string, CaseResult[]>();
+  for (const result of RESULTS) {
+    const existing = cases.get(result.case_id) ?? [];
+    existing.push(result);
+    cases.set(result.case_id, existing);
+  }
+
+  const summarizedCases = Object.fromEntries(
+    [...cases.entries()].map(([caseId, items]) => {
+      const measured = items.filter((item) => !item.is_warmup);
+      const effectiveItems = measured.length > 0 ? measured : items;
+      const totalLatencies = effectiveItems
+        .map((item) => item.total_latency_s)
+        .filter((value): value is number => typeof value === 'number');
+      const firstTokenLatencies = effectiveItems
+        .map((item) => item.first_token_latency_s)
+        .filter((value): value is number => typeof value === 'number');
+      const resultFlags = Object.fromEntries(
+        [...new Set(effectiveItems.map((item) => item.result_flag))].map(
+          (flag) => [
+            flag,
+            effectiveItems.filter((item) => item.result_flag === flag).length,
+          ],
+        ),
+      );
+      const median = (values: number[]): number | null => {
+        if (values.length === 0) {
+          return null;
+        }
+        const sorted = [...values].sort((a, b) => a - b);
+        const middle = Math.floor(sorted.length / 2);
+        if (sorted.length % 2 === 1) {
+          return sorted[middle];
+        }
+        return (sorted[middle - 1] + sorted[middle]) / 2;
+      };
+
+      return [
+        caseId,
+        {
+          mode: items.at(-1)?.mode ?? MODE,
+          runs: effectiveItems.length,
+          warmups: items.length - effectiveItems.length,
+          result_flags: resultFlags,
+          median_total_latency_s: median(totalLatencies),
+          median_first_token_latency_s: median(firstTokenLatencies),
+          observations: effectiveItems
+            .slice(0, 3)
+            .map((item) => item.observation_summary),
+        },
+      ];
+    }),
+  );
+
+  const overallResultFlags = Object.fromEntries(
+    [...new Set(RESULTS.map((item) => item.result_flag))].map((flag) => [
+      flag,
+      RESULTS.filter((item) => item.result_flag === flag).length,
+    ]),
+  );
+
+  return {
+    scenario: SCENARIO,
+    run_label: RUN_LABEL,
+    mode: MODE,
+    result_count: RESULTS.length,
+    cases: summarizedCases,
+    result_flags: overallResultFlags,
+  };
+}
+
+function finalize(exitCode: number): void {
+  const metadataPayload = {
+    exit_code: exitCode,
+    runtime_context: runtimeContext(),
+  };
+  const summaryPayload = summarizeResults();
+  emit('summary', {
+    metadata: metadataPayload,
+    summary: summaryPayload,
+  });
+
+  const directory = outputDir();
+  if (!directory) {
+    return;
+  }
+
+  mkdirSync(directory, { recursive: true });
+  const metadataPath = join(directory, 'metadata.json');
+  const resultsPath = join(directory, 'results.json');
+  const summaryPath = join(directory, 'summary.json');
+  writeJson(metadataPath, metadataPayload);
+  writeJson(resultsPath, RESULTS);
+  writeJson(summaryPath, summaryPayload);
+  emit('artifact_paths', {
+    metadata_path: metadataPath,
+    results_path: resultsPath,
+    summary_path: summaryPath,
+  });
+}
+
+async function main(): Promise<number> {
+  const caseId = process.env.PROBE_CASE_ID ?? 'case-0001';
+  emit('banner', { context: runtimeContext() });
+  startCase(caseId);
+
+  // Replace this block with the narrow runtime question you want to test.
+  // Example:
+  // const client = await importRepoModule('packages/client/lib/index.ts');
+  // const hasCreateClient =
+  //   typeof (client as { createClient?: unknown }).createClient === 'function';
+  // recordCaseResult(
+  //   caseId,
+  //   hasCreateClient
+  //     ? 'Loaded @redis/client source from the repository root.'
+  //     : '@redis/client source loaded but expected exports were missing.',
+  //   hasCreateClient ? 'expected' : 'negative',
+  //   { metrics: { import_path: 'packages/client/lib/index.ts' } },
+  // );
+  recordCaseResult(
+    caseId,
+    'Template executed. Replace the placeholder block with the runtime behavior you want to observe.',
+    'expected',
+  );
+
+  finalize(0);
+  return 0;
+}
+
+void main().catch((error: unknown) => {
+  const message =
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  emit('fatal', { error: message });
+  finalize(1);
+  process.exitCode = 1;
+});

--- a/.agents/skills/test-coverage-improver/SKILL.md
+++ b/.agents/skills/test-coverage-improver/SKILL.md
@@ -1,0 +1,46 @@
+--
+name: test-coverage-improver
+description: 'Improve test coverage in the node-redis monorepo: run a package test suite under nyc, inspect coverage artifacts, identify low-coverage files and branches, propose high-impact tests, and confirm with the user before writing tests.'
+---
+
+# Test Coverage Improver
+
+## Overview
+
+Use this skill whenever coverage needs assessment or improvement (coverage regressions, failing thresholds, or user requests for stronger tests). It runs the coverage suite, analyzes results, highlights the biggest gaps, and prepares test additions while confirming with the user before changing code.
+
+Coverage is collected per package via `nyc` (each package's `test` script runs `nyc -r text-summary -r lcov mocha ...`). **Docker must be running** — the test harness starts real Redis containers via `@redis/test-utils`.
+
+## Quick Start
+
+1. Pick the target package (e.g. `@redis/client`) and run its tests under coverage from the repo root: `npm test -w @redis/client`. This regenerates that package's `coverage/`.
+2. Collect artifacts: the `text-summary` printed to stdout for totals, plus `packages/<pkg>/coverage/lcov.info` and `packages/<pkg>/coverage/lcov-report/index.html` for line/branch drill-downs. For machine-readable file totals, rerun with an added summary reporter: `npm test -w @redis/client -- ... ` is awkward, so prefer `npx nyc -r json-summary -r text-summary mocha ...` from inside the package when you need `coverage/coverage-summary.json`.
+3. Summarize coverage: total percentages, lowest files, branches under 80%, and uncovered lines/paths.
+4. Draft test ideas per file: scenario, behavior under test, expected outcome, and likely coverage gain.
+5. Ask the user for approval to implement the proposed tests; pause until they agree.
+6. After approval, write the tests next to the source in the relevant package, rerun coverage, then run `npm run build` and `npm run lint` before marking work complete.
+
+## Workflow Details
+
+- **Run coverage**: Execute the target package's test script (`npm test -w <pkg>`) from the repo root. Avoid watch flags. Keep prior coverage artifacts only if comparing trends. Confirm Docker is available first.
+- **Parse summaries efficiently**:
+  - Use the printed `text-summary` for quick totals.
+  - Use `coverage/lcov.info` or `coverage/lcov-report/index.html` to spot branch- and line-level holes.
+  - Add the `json-summary` nyc reporter when you need `coverage/coverage-summary.json` for file-level totals.
+- **Prioritize targets**:
+  - Core client/cluster/sentinel/pool/RESP code in `packages/*/lib` before examples or docs.
+  - Files with statements/branches below 80% or newly added code at 0%.
+  - Recent bug fixes or risky code paths (error handling, reconnection, timeouts, pub/sub, concurrency).
+- **Design impactful tests**:
+  - Hit uncovered branches: error cases, boundary inputs, optional flags, and cancellation/timeouts.
+  - Cover combinational logic rather than trivial happy paths.
+  - Co-locate specs next to source as `packages/<pkg>/lib/**/<NAME>.spec.ts` (mocha + `tsx`, `node:assert`). For command/topology tests use `testUtils.testAll(name, fn, { client, cluster })`. Avoid flaky async timing.
+- **Coordinate with the user**: Present a numbered, concise list of proposed test additions and expected coverage gains. Ask explicitly before editing code or fixtures.
+- **After implementation**: Rerun coverage, report the updated summary, and note any remaining low-coverage areas.
+
+## Notes
+
+- Keep any added comments or code in English.
+- Do not create `scripts/`, `references/`, or `assets/` unless needed later.
+- If coverage artifacts are missing or stale, rerun the package test suite instead of guessing.
+- `nyc` excludes `dist`, `**/*.spec.ts`, `lib/test-utils.ts`, and `examples/*` (see each package's `.nycrc`); do not target those for coverage.

--- a/.agents/skills/test-coverage-improver/agents/openai.yaml
+++ b/.agents/skills/test-coverage-improver/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Test Coverage Improver"
+  short_description: "Analyze coverage gaps and propose high-impact tests"
+  default_prompt: "Use $test-coverage-improver to analyze coverage gaps, propose high-impact tests, and update coverage after approval."

--- a/.claude/agents
+++ b/.claude/agents
@@ -1,0 +1,1 @@
+../.agents/agents

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gemini/agents
+++ b/.gemini/agents
@@ -1,0 +1,1 @@
+../.agents/agents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+Guidance for agents working in this repo.
+
+## What this is
+
+`node-redis` — modern Redis client for Node.js. A **monorepo** (npm workspaces) of
+publishable packages. Requires Node `>= 20`. TypeScript throughout.
+
+## Packages (`packages/`)
+
+| Package | Purpose |
+| --- | --- |
+| `redis` | "All-in-one" meta-package re-exporting client + all modules |
+| `client` (`@redis/client`) | Core: `RedisClient`, `RedisCluster`, `RedisSentinel`, pool, RESP codec, command framework |
+| `bloom` (`@redis/bloom`) | Probabilistic commands (bloom, cuckoo, count-min, t-digest, top-k) |
+| `json` (`@redis/json`) | RedisJSON commands |
+| `search` (`@redis/search`) | RediSearch commands |
+| `time-series` (`@redis/time-series`) | Time-series commands |
+| `entraid` (`@redis/entraid`) | Microsoft Entra ID token auth |
+| `test-utils` (`@redis/test-utils`) | Shared test harness; spins up Redis via docker |
+
+Module packages depend on `@redis/client` and follow the same command structure.
+
+## Core layout — `packages/client/lib/`
+
+- `client/` — connection internals: `index.ts` (RedisClient), `socket.ts`, `commands-queue.ts`, `parser.ts`, `pool.ts`, `pub-sub.ts`, `cache.ts`
+- `cluster/`, `sentinel/` — cluster & sentinel clients
+- `commands/` — one file per Redis command (e.g. `GET.ts`) + `index.ts` registry
+- `RESP/` — RESP2/RESP3 protocol: `encoder.ts`, `decoder.ts`, `types.ts`
+- `authx/` — auth/credential providers
+
+## Command pattern
+
+Each command is `<NAME>.ts` exporting a `Command` object:
+
+```typescript
+export default {
+  CACHEABLE: true,
+  IS_READ_ONLY: true,
+  parseCommand(parser: CommandParser, key: RedisArgument) {
+    parser.push('GET');
+    parser.pushKey(key);
+  },
+  transformReply: undefined as unknown as () => BlobStringReply | NullReply
+} as const satisfies Command;
+```
+
+- `parseCommand` builds wire args via `CommandParser` (`push`, `pushKey`, ...).
+- `transformReply` maps reply to JS type; `undefined` = pass-through. Can be keyed by RESP version `{ 2: ..., 3: ... }`.
+- Register new command in the package's `commands/index.ts` (import + map entry). RESP3 is default — no extra RESP3 test needed for new commands.
+- JSDoc on commands is checked: `npm run check:command-jsdoc`.
+
+## Tests
+
+- Co-located `<NAME>.spec.ts` next to source. Mocha + `tsx`, `node:assert`.
+- `testUtils.testAll(name, fn, { client, cluster })` runs same test across server + cluster topologies (see `test-utils.ts`, `GLOBAL`).
+- **Docker required** — test-utils starts real Redis containers.
+- Pure arg/reply tests use `parseArgs(COMMAND, ...args)`.
+
+Commands:
+- `npm test` — full suite, all workspaces (runs `cleanup` first).
+- `npm test -w @redis/client` — one package.
+- Single file from root: `npm run test-single -- <path-to-spec>`.
+- `npm run build` — `tsc --build` (project references; build before cross-package work).
+- Build can break on stale `dist/` from project references. Clean rebuild:
+  ```bash
+  find packages -type d -name "dist" -exec rm -rf {} + && npm run build
+  ```
+- `npm run lint` — lint changed files only; `npm run lint:all` for everything.
+
+## Conventions
+
+- TypeScript strict mode; `noUnusedLocals` on. Target ES2022 / NodeNext modules.
+- Raw command names (`HSET`) and camelCase aliases (`hSet`) both exposed.
+- Conventional Commits. Per-package releases via `release-it` (`npm run release`).
+- Keep company-internal refs (Jira/Confluence IDs, internal links) out of OSS commits, branches, PRs, code.
+
+## Docs
+
+Deep-dive guides in `docs/` (client-configuration, clustering, sentinel, pool, RESP, transactions, programmability, pub-sub, scan-iterators, migration guides). Runnable examples in `examples/`, `doctests/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
### Description

This pull request adds the repository's shared agent tooling so Claude Code, OpenAI/Codex, and Gemini runners all work from one source: a set of skills under `.agents/skills/`, the `AGENTS.md`/`CLAUDE.md`/`GEMINI.md` guidance files, and `.claude`/`.gemini` symlinks pointing into `.agents/`. Each skill ships a `SKILL.md`, an `agents/openai.yaml` interface descriptor for cross-runner parity, and any supporting `references/`/`templates/`.

Skills included:

- **implement-command** — add a Redis command to node-redis end-to-end: the `<NAME>.ts` Command file, JSDoc registration in `commands/index.ts`, and a co-located `<NAME>.spec.ts`, with the monorepo conventions baked in.
- **docs-sync** — audit `docs/`, `README.md`, and per-package READMEs against the master implementation and propose targeted updates.
- **maintainer-review** — review a GitHub issue or PR as a maintainer, with a staged need-evidence assessment and a copy-paste-ready maintainer comment.
- **pr-draft-summary** — generate the PR-ready summary block, branch suggestion, title, and draft description for a change.
- **runtime-behavior-probe** — investigate actual runtime behavior with a validation matrix and disposable TypeScript probes, producing a findings-first report.
- **test-coverage-improver** — analyze coverage gaps and propose high-impact tests.

No runtime code, tests, or build configuration changes — repository tooling only, with no behavior or backward-compatibility impact.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)? — N/A, no runtime/build changes
- [ ] Is the new or changed code fully tested? — N/A, docs/tooling only
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? — N/A, no API changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-config only; no published API, client behavior, or test/build pipeline changes.
> 
> **Overview**
> This pull request adds **shared agent tooling** so multiple AI runners can use the same workflows from one tree under `.agents/`.
> 
> It introduces **six skills** (`docs-sync`, `implement-command`, `maintainer-review`, `pr-draft-summary`, `runtime-behavior-probe`, `test-coverage-improver`), each with a `SKILL.md`, an `agents/openai.yaml` interface descriptor, and supporting reference/template files where needed. **`AGENTS.md`** documents monorepo layout, the command pattern, and test/build conventions; **`CLAUDE.md`** and **`GEMINI.md`** delegate to that file. **`.claude/`** and **`.gemini/`** symlinks point at `.agents/` for skills (and agents) so Claude and Gemini pick up the same definitions.
> 
> There are **no changes** under `packages/`, tests, or build config—repository metadata and contributor/agent guidance only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb4cbf9a7e011ced1fc249e1885bbce70aef41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->