### PR TITLE
fix(client): GETEX PXAT with Date must encode milliseconds

### DIFF
--- a/packages/client/lib/commands/GETEX.spec.ts
+++ b/packages/client/lib/commands/GETEX.spec.ts
@@ -55,6 +55,17 @@ describe('GETEX', () => {
           ['GETEX', 'key', 'EXAT', Math.floor(d.getTime() / 1000).toString()]
         );
       });
+
+      it('PXAT date', () => {
+        const d = new Date();
+        assert.deepEqual(
+          parseArgs(GETEX, 'key', {
+            type: 'PXAT',
+            value: d
+          }),
+          ['GETEX', 'key', 'PXAT', d.getTime().toString()]
+        );
+      });
     });
 
     describe('EXAT (backwards compatibility)', () => {

--- a/packages/client/lib/commands/GETEX.ts
+++ b/packages/client/lib/commands/GETEX.ts
@@ -51,8 +51,11 @@ export default {
           break;
         
         case 'EXAT':
-        case 'PXAT':
           parser.push(options.type, transformEXAT(options.value));
+          break;
+
+        case 'PXAT':
+          parser.push(options.type, transformPXAT(options.value));
           break;
 
         case 'PERSIST':


### PR DESCRIPTION
## Description

`GETEX` with the modern `{ type: 'PXAT', value: Date }` option encodes the expiry in seconds instead of milliseconds.

In `parseCommand`, `EXAT` and `PXAT` shared a single `switch` case that ran both through `transformEXAT`, which does `Math.floor(date.getTime() / 1000)`. `PXAT` is the millisecond absolute-timestamp variant, so a `Date` is sent about 1000x too small. Redis reads that number as a millisecond timestamp far in the past and deletes the key immediately instead of extending its TTL.

For a numeric `value` there is no visible difference (both transforms pass a number straight through), which is why the existing number-only test passed and the bug went unnoticed.

## Reproduction

```js
await client.set('session:123', 'token');
// read the value and refresh it to an absolute expiry
await client.getEx('session:123', { type: 'PXAT', value: new Date(Date.now() + 60_000) });
// key is gone: the PXAT timestamp was encoded as seconds
```

## Fix

Route `PXAT` through `transformPXAT` (milliseconds); `EXAT` keeps `transformEXAT` (seconds). `transformPXAT` was already imported. Numeric values are unchanged.

## Test

Added a `PXAT date` case to `GETEX.spec.ts` asserting the modern `type: 'PXAT'` + `Date` path encodes `getTime()` (milliseconds). It fails before the change (seconds value) and passes after (milliseconds value).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix in GETEX argument parsing with a regression test; no auth or broad API surface changes.
> 
> **Overview**
> Fixes **`GETEX`** when using `{ type: 'PXAT', value: Date }`: the command encoder no longer treats **PXAT** like **EXAT**. **PXAT** now goes through **`transformPXAT`** (millisecond absolute timestamps); **EXAT** still uses **`transformPXAT`**’s second-based sibling **`transformEXAT`**.
> 
> Previously both shared one branch that always applied second encoding, so a **Date** on the modern **PXAT** path was sent ~1000× too small and Redis could expire the key immediately. Numeric **PXAT** values were unaffected.
> 
> Adds a **`GETEX.spec.ts`** case asserting **`type: 'PXAT'`** + **Date** serializes **`getTime()`** as the argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69cc3854e516c4b43eba873951b06e1c91a557d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->