### PR TITLE
chore(tests): bump default docker test image to 8.10 ( unstable M3 )

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,8 @@ jobs:
             version: "8.4"
           - tag: "8.8.0"
             version: "8.8"
+          - tag: "custom-28772936538-debian"
+            version: "8.10"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/packages/bloom/lib/test-utils.ts
+++ b/packages/bloom/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default  TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
+  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
 });
 
 export const GLOBAL = {

--- a/packages/client/lib/sentinel/test-util.ts
+++ b/packages/client/lib/sentinel/test-util.ts
@@ -175,7 +175,7 @@ export class SentinelFramework extends DockerBase {
       dockerImageName: 'redislabs/client-libs-test',
       dockerImageTagArgument: 'redis-tag',
       dockerImageVersionArgument: 'redis-version',
-      defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
+      defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
     });
     this.#nodeMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelNodes']>>>>();
     this.#sentinelMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelSentinels']>>>>();

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -10,7 +10,7 @@ const utils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
+  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
 });
 
 export default utils;

--- a/packages/entraid/lib/test-utils.ts
+++ b/packages/entraid/lib/test-utils.ts
@@ -7,7 +7,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
+  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
 });
 
 const DEBUG_MODE_ARGS = testUtils.isVersionGreaterThan([7]) ?

--- a/packages/json/lib/test-utils.ts
+++ b/packages/json/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
+  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
 });
 
 export const GLOBAL = {

--- a/packages/search/lib/test-utils.ts
+++ b/packages/search/lib/test-utils.ts
@@ -6,7 +6,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
+  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
 });
 
 export const GLOBAL = {

--- a/packages/test-utils/lib/test-utils.ts
+++ b/packages/test-utils/lib/test-utils.ts
@@ -4,7 +4,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
+  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
 });
 
 

--- a/packages/time-series/lib/test-utils.ts
+++ b/packages/time-series/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.8.0', version: '8.8' }
+  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
 });
 
 export const GLOBAL = {


### PR DESCRIPTION
Bump the default Redis test image to `custom-28772936538-debian` (8.10) across all package `test-utils`, and add an 8.10 entry to the CI test matrix.

## Changes
- `defaultDockerVersion` → `{ tag: 'custom-28772936538-debian', version: '8.10' }` in all 8 package test-utils (used for local runs).
- `.github/workflows/tests.yml`: added matrix entry `tag: custom-28772936538-debian / version: 8.10`, keeping existing 7.4 / 8.2 / 8.4 / 8.8 coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only configuration; no runtime or library behavior changes, only which Redis image local and CI tests use by default.
> 
> **Overview**
> Raises the default Redis Docker image used for **local** integration tests from `8.8.0` / `8.8` to `custom-28772936538-debian` / `8.10` by updating `defaultDockerVersion` in every package `test-utils` (bloom, client, sentinel, entraid, json, search, test-utils, time-series).
> 
> CI in **`.github/workflows/tests.yml`** gains a matching matrix row for Redis **8.10** alongside existing 7.4, 8.2, 8.4, and 8.8 runs; Node 20/22 matrix is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4af383e23ce7d74db12e256392569a6d750d36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->