### PR TITLE
fix(client): correct DoublyLinkedList head removal

### DIFF
--- a/packages/client/lib/client/linked-list.spec.ts
+++ b/packages/client/lib/client/linked-list.spec.ts
@@ -128,6 +128,28 @@ describe("DoublyLinkedList", () => {
     equal(list.length, 3);
     deepEqual(Array.from(list), [1, 3, 5]);
   });
+
+  it("should clear the previous pointer of the new head when removing the head", () => {
+    list.reset();
+    const first = list.push(1);
+    list.push(2);
+    list.remove(first);
+    equal(list.head!.previous, undefined);
+  });
+
+  it("should stay consistent after removing the head and then the tail", () => {
+    list.reset();
+    const first = list.push(1);
+    const second = list.push(2);
+    list.remove(first);
+    list.remove(second);
+    equal(list.length, 0);
+    equal(list.head, undefined);
+    equal(list.tail, undefined);
+    list.push(3);
+    equal(list.length, 1);
+    deepEqual(Array.from(list), [3]);
+  });
 });
 
 describe("SinglyLinkedList", () => {

--- a/packages/client/lib/client/linked-list.ts
+++ b/packages/client/lib/client/linked-list.ts
@@ -86,19 +86,18 @@ export class DoublyLinkedList<T> {
     if (this.#length === 0) return;
     --this.#length;
 
-    if (this.#tail === node) {
-      this.#tail = node.previous;
-    } 
-    if (this.#head === node) {
-      this.#head = node.next;
+    if (node.previous) {
+      node.previous.next = node.next;
     } else {
-      if (node.previous) {
-          node.previous.next = node.next;
-      }
-      if (node.next) {
-        node.next.previous = node.previous;
-      }
+      this.#head = node.next;
     }
+
+    if (node.next) {
+      node.next.previous = node.previous;
+    } else {
+      this.#tail = node.previous;
+    }
+
     node.previous = undefined;
     node.next = undefined;
   }


### PR DESCRIPTION
### Description

`DoublyLinkedList.remove` skipped the neighbor pointer fixup whenever the removed node was the head, so the new head kept a stale `previous` pointer to the removed node. If that head was later removed, `tail` was set to the already removed node, leaving the list inconsistent and causing following `push` calls to silently drop values (length reported items that iteration never yielded). This list backs the connection pool, so the corruption could surface there.

The fix sets `head` and `tail` from the node's own `previous`/`next` links, so both neighbors are always relinked correctly. Added tests cover removing the head and the head-then-tail sequence. Relates to #3062.

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core list logic used by the connection pool and command write queue, but the change is a small, well-tested fix to pointer maintenance rather than new behavior.
> 
> **Overview**
> Fixes **`DoublyLinkedList.remove`** so removing the head always relinks neighbors instead of only advancing `head` and skipping pointer fixup on the old head’s successor.
> 
> The implementation now uses a single path: splice via `previous`/`next`, and set **`#head`** or **`#tail`** when the removed node is at an end. That clears stale **`previous`** on the new head and avoids **`tail`** pointing at a detached node after head-then-tail removal (which could make later **`push`** values disappear from iteration while length still increased).
> 
> Adds unit tests for the new-head **`previous`** invariant and for head-then-tail followed by **`push`**. The list backs the Redis client **connection pool** and **commands write queue**, so this corruption could surface as pool or outbound-command inconsistencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 882c26d76ba3d7c7b25264f447746b9943e73102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->