### PR TITLE
fix(cluster): reject commands before cluster topology is ready

### DIFF
--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -169,10 +169,16 @@ export default class RedisClusterSlots<
     }
 
     this.#isOpen = true;
+    this.#isReady = false;
     try {
       await this.#discoverWithRootNodes();
-      this.#isReady = true;
-      this.#emit('connect');
+      // `destroy()` may have run while discovery was in flight; if so, this
+      // resolution is stale and must not resurrect readiness for a session
+      // that's already been torn down.
+      if (this.#isOpen) {
+        this.#isReady = true;
+        this.#emit('connect');
+      }
     } catch (err) {
       this.#isOpen = false;
       this.#isReady = false;

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -1,5 +1,5 @@
 import type { RedisClusterClientOptions, RedisClusterOptions } from '.';
-import { RootNodesUnavailableError } from '../errors';
+import { ClientClosedError, ClientOfflineError, RootNodesUnavailableError } from '../errors';
 import RedisClient, { RedisClientOptions, RedisClientType } from '../client';
 import { EventEmitter } from 'node:stream';
 import { ChannelListeners, PUBSUB_TYPE, PubSubListeners, PubSubTypeListeners } from '../client/pub-sub';
@@ -129,6 +129,12 @@ export default class RedisClusterSlots<
     return this.#isOpen;
   }
 
+  #isReady = false;
+
+  get isReady() {
+    return this.#isReady;
+  }
+
   #validateOptions(options?: RedisClusterOptions<M, F, S, RESP, TYPE_MAPPING>) {
     if (options?.clientSideCache && (options?.RESP ?? DEFAULT_RESP) !== 3) {
       throw new Error('Client Side Caching is only supported with RESP3');
@@ -165,9 +171,11 @@ export default class RedisClusterSlots<
     this.#isOpen = true;
     try {
       await this.#discoverWithRootNodes();
+      this.#isReady = true;
       this.#emit('connect');
     } catch (err) {
       this.#isOpen = false;
+      this.#isReady = false;
       throw err;
     }
   }
@@ -737,6 +745,7 @@ export default class RedisClusterSlots<
 
   destroy() {
     this.#isOpen = false;
+    this.#isReady = false;
 
     for (const client of this.#clients()) {
       client.destroy();
@@ -773,6 +782,7 @@ export default class RedisClusterSlots<
 
   async #destroy(fn: (client: RedisClientType<M, F, S, RESP>) => Promise<unknown>): Promise<void> {
     this.#isOpen = false;
+    this.#isReady = false;
 
     const promises = [];
     for (const client of this.#clients()) {
@@ -792,6 +802,16 @@ export default class RedisClusterSlots<
     this.#emit('disconnect');
   }
 
+  #assertReady() {
+    if (!this.#isOpen) {
+      throw new ClientClosedError();
+    }
+
+    if (!this.#isReady) {
+      throw new ClientOfflineError();
+    }
+  }
+
   async getClientAndSlotNumber(
     firstKey: RedisArgument | undefined,
     isReadonly: boolean | undefined
@@ -799,6 +819,8 @@ export default class RedisClusterSlots<
     client: RedisClientType<M, F, S, RESP, TYPE_MAPPING>,
     slotNumber?: number
   }> {
+    this.#assertReady();
+
     if (!firstKey) {
       return {
         client: await this.nodeClient(this.getRandomNode())
@@ -823,6 +845,8 @@ export default class RedisClusterSlots<
     key: RedisArgument,
     isReadonly: boolean | undefined
   ): Promise<RedisClientType<M, F, S, RESP, TYPE_MAPPING>> {
+    this.#assertReady();
+
     const slotNumber = calculateSlot(key);
     if (isReadonly) {
       return this.nodeClient(this.getSlotRandomNode(slotNumber));
@@ -902,6 +926,8 @@ export default class RedisClusterSlots<
   }
 
   getPubSubClient(): Promise<RedisClientType<M, F, S, RESP, TYPE_MAPPING>> {
+    this.#assertReady();
+
     if (!this.pubSubNode) return this.#initiatePubSubClient();
 
     return this.pubSubNode.connectPromise ?? Promise.resolve(this.pubSubNode.client);
@@ -952,6 +978,8 @@ export default class RedisClusterSlots<
   }
 
   getShardedPubSubClient(channel: string): Promise<RedisClientType<M, F, S, RESP, TYPE_MAPPING>> {
+    this.#assertReady();
+
     const { master } = this.slots[calculateSlot(channel)];
     if (!master.pubSub) return this.#initiateShardedPubSubClient(master);
     return master.pubSub.connectPromise ?? Promise.resolve(master.pubSub.client);

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -3,11 +3,47 @@ import { setTimeout } from 'node:timers/promises';
 import testUtils, { GLOBAL, waitTillBeenCalled } from '../test-utils';
 import RedisCluster from '.';
 import { SQUARE_SCRIPT } from '../client/index.spec';
-import { RootNodesUnavailableError } from '../errors';
+import { ClientClosedError, ClientOfflineError, RootNodesUnavailableError } from '../errors';
 import { spy } from 'sinon';
 import RedisClient from '../client';
 import { RESP_TYPES } from '../RESP/decoder';
 import calculateSlot from 'cluster-key-slot';
+
+describe('Cluster command lifecycle', () => {
+  it('rejects commands before connect', async () => {
+    const cluster = RedisCluster.create({ rootNodes: [] });
+    assert.equal(cluster.isOpen, false);
+    assert.equal(cluster.isReady, false);
+
+    await assert.rejects(
+      cluster.get('key'),
+      ClientClosedError
+    );
+  });
+
+  it('rejects commands while connect is in progress', async () => {
+    const cluster = RedisCluster.create({
+      rootNodes: [{
+        socket: {
+          host: '203.0.113.1',
+          port: 6379,
+          connectTimeout: 1
+        }
+      }]
+    });
+    const connectPromise = cluster.connect().catch(() => undefined);
+    assert.equal(cluster.isOpen, true);
+    assert.equal(cluster.isReady, false);
+
+    await assert.rejects(
+      cluster.get('key'),
+      ClientOfflineError
+    );
+
+    cluster.destroy();
+    await connectPromise;
+  });
+});
 
 describe('Cluster', () => {
   describe('default commandOptions', () => {

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -350,6 +350,10 @@ export default class RedisCluster<
     return this._self._slots.isOpen;
   }
 
+  get isReady() {
+    return this._self._slots.isReady;
+  }
+
   /**
    * @internal
    * Returns the cluster identity for tracking in metrics.


### PR DESCRIPTION
### Description

Fixes #2704.

If a command is issued on a `RedisCluster` client before `connect()` resolves (or without calling `connect()` at all), it throws an unclear `TypeError: Cannot read properties of undefined (reading 'replicas')` instead of a helpful error. This happens because the slot map (`this.slots`) is only populated once the initial topology discovery finishes, and command routing (`getClientAndSlotNumber`, `getClient`, `getPubSubClient`, `getShardedPubSubClient`) accessed it unconditionally.

This adds an `isReady` flag to `RedisClusterSlots` (exposed on `RedisCluster` alongside the existing `isOpen`), tracked independently of `isOpen`:
- `isOpen`: true once `connect()`/`.destroy()` toggles it (existing behavior)
- `isReady`: true only after the initial topology discovery succeeds; reset on error/destroy

A new `#assertReady()` guard runs before slot map access in the four command-routing entry points, throwing:
- `ClientClosedError` if the client was never opened
- `ClientOfflineError` if it's open but topology discovery hasn't completed yet

`isReady` is only touched by the initial `connect()`/`destroy()` paths — it is **not** affected by `rediscover()`/`#discover()`, so live topology refresh and resharding are unaffected (verified by tracing all call sites).

### Testing

- Reproduced the original crash directly against unmodified `main` (confirmed identical error message/stack to the issue) before writing the fix.
- Added two tests under a new `Cluster command lifecycle` describe block covering both reported scenarios (never connected, and `connect()` in flight but not awaited) — both fail with the original `TypeError` on `main` and pass with this change. These don't require a running Redis server.
- Ran the full `cluster/index.spec.ts` suite locally; the handful of unrelated failures (`FUNCTION LOAD`, generic `Client` sendCommand/multi tests) reproduce identically on unmodified `main`, confirmed via a side-by-side baseline run — pre-existing local flakiness, not introduced by this change.
- `npm run build` and `eslint` on the changed files are clean.

### Checklist

- [x] Does `npm test` pass with this change (including linting)? (see note above on pre-existing unrelated local flakiness)
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? — `isReady` is a small additive public getter; happy to add a docs mention if maintainers want one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lifecycle guard on cluster routing entry points; `isReady` is not tied to ongoing `rediscover()` so live topology refresh behavior stays unchanged.
> 
> **Overview**
> **Cluster clients now expose `isReady` and reject command routing until initial topology discovery finishes**, instead of crashing with a `TypeError` on an empty slot map.
> 
> `RedisClusterSlots` tracks **`isReady` separately from `isOpen`**: open as soon as `connect()` starts, ready only after the first successful discovery. **`#assertReady()`** runs before slot-based routing (`getClientAndSlotNumber`, `getClientForKey`, pub/sub client getters), throwing **`ClientClosedError`** when never opened and **`ClientOfflineError`** while discovery is still in flight. **`connect()`** only sets ready and emits **`connect`** if the cluster is still open after discovery (so a concurrent **`destroy()`** cannot resurrect readiness); **`destroy()`** / **`#destroy()`** clear ready.
> 
> **`RedisCluster`** forwards the **`isReady`** getter. New unit tests cover commands before connect and during an in-progress connect without a live Redis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f6fc90ad2e8ac89afdd4b33a3d6e727fffa5229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->