### PR TITLE
feat(time-series): add TS.READ cursor read command

### DIFF
--- a/packages/time-series/lib/commands/READ.spec.ts
+++ b/packages/time-series/lib/commands/READ.spec.ts
@@ -19,6 +19,13 @@ describe('TS.READ', () => {
       );
     });
 
+    it('with string cursor (precision-safe timestamp)', () => {
+      assert.deepEqual(
+        parseArgs(READ, 'key', '9007199254740993'),
+        ['TS.READ', 'key', '9007199254740993']
+      );
+    });
+
     it('with MAX_COUNT', () => {
       assert.deepEqual(
         parseArgs(READ, 'key', TS_READ_TIMESTAMP.EARLIEST, {

--- a/packages/time-series/lib/commands/READ.spec.ts
+++ b/packages/time-series/lib/commands/READ.spec.ts
@@ -92,4 +92,50 @@ describe('TS.READ', () => {
     ...GLOBAL.SERVERS.OPEN,
     minimumDockerVersion: [8, 10]
   });
+
+  testUtils.testWithClient('client.ts.read with LATEST sentinel', async client => {
+    await client.ts.add('key', 100, 1);
+    await client.ts.add('key', 200, 2);
+    await client.ts.add('key', 300, 3);
+
+    assert.deepEqual(
+      await client.ts.read('key', TS_READ_TIMESTAMP.LATEST),
+      [{ timestamp: 300, value: 3 }]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.read with BLOCK returns synchronously when minCount is met', async client => {
+    await client.ts.add('key', 100, 1);
+    await client.ts.add('key', 200, 2);
+
+    assert.deepEqual(
+      await client.ts.read('key', 0, {
+        BLOCK: { milliseconds: 5000, minCount: 2 }
+      }),
+      [
+        { timestamp: 100, value: 1 },
+        { timestamp: 200, value: 2 }
+      ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.read with NEW sentinel and BLOCK flushes empty on timeout', async client => {
+    await client.ts.add('key', 100, 1);
+
+    assert.deepEqual(
+      await client.ts.read('key', TS_READ_TIMESTAMP.NEW, {
+        BLOCK: { milliseconds: 100 }
+      }),
+      []
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
 });

--- a/packages/time-series/lib/commands/READ.spec.ts
+++ b/packages/time-series/lib/commands/READ.spec.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import READ, { TS_READ_TIMESTAMP } from './READ';
+import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
+
+describe('TS.READ', () => {
+  describe('transformArguments', () => {
+    it('minimal', () => {
+      assert.deepEqual(
+        parseArgs(READ, 'key', 0),
+        ['TS.READ', 'key', '0']
+      );
+    });
+
+    it('with sentinel cursor', () => {
+      assert.deepEqual(
+        parseArgs(READ, 'key', TS_READ_TIMESTAMP.NEW),
+        ['TS.READ', 'key', '$']
+      );
+    });
+
+    it('with MAX_COUNT', () => {
+      assert.deepEqual(
+        parseArgs(READ, 'key', TS_READ_TIMESTAMP.EARLIEST, {
+          MAX_COUNT: 2
+        }),
+        ['TS.READ', 'key', '-', 'MAX_COUNT', '2']
+      );
+    });
+
+    it('with BLOCK (default minCount)', () => {
+      assert.deepEqual(
+        parseArgs(READ, 'key', 0, {
+          BLOCK: { milliseconds: 5000 }
+        }),
+        ['TS.READ', 'key', '0', 'BLOCK', '5000', '1']
+      );
+    });
+
+    it('with BLOCK and MAX_COUNT', () => {
+      assert.deepEqual(
+        parseArgs(READ, 'key', TS_READ_TIMESTAMP.NEW, {
+          BLOCK: { milliseconds: 0, minCount: 10 },
+          MAX_COUNT: 100
+        }),
+        ['TS.READ', 'key', '$', 'BLOCK', '0', '10', 'MAX_COUNT', '100']
+      );
+    });
+  });
+
+  testUtils.testWithClient('client.ts.read', async client => {
+    await client.ts.add('key', 100, 1);
+    await client.ts.add('key', 200, 2);
+    await client.ts.add('key', 300, 3);
+
+    assert.deepEqual(
+      await client.ts.read('key', 0),
+      [
+        { timestamp: 100, value: 1 },
+        { timestamp: 200, value: 2 },
+        { timestamp: 300, value: 3 }
+      ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.read with MAX_COUNT', async client => {
+    await client.ts.add('key', 100, 1);
+    await client.ts.add('key', 200, 2);
+    await client.ts.add('key', 300, 3);
+
+    assert.deepEqual(
+      await client.ts.read('key', TS_READ_TIMESTAMP.EARLIEST, { MAX_COUNT: 2 }),
+      [
+        { timestamp: 100, value: 1 },
+        { timestamp: 200, value: 2 }
+      ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.read empty on missing key', async client => {
+    assert.deepEqual(
+      await client.ts.read('missing', 0),
+      []
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+});

--- a/packages/time-series/lib/commands/READ.ts
+++ b/packages/time-series/lib/commands/READ.ts
@@ -1,6 +1,6 @@
 import { CommandParser } from '@redis/client/dist/lib/client/parser';
 import { RedisArgument, Command, Resp2Reply } from '@redis/client/dist/lib/RESP/types';
-import { Timestamp, transformTimestampArgument, SamplesRawReply, transformSamplesReply } from './helpers';
+import { transformTimestampArgument, SamplesRawReply, transformSamplesReply } from './helpers';
 
 /**
  * Sentinel cursor values for {@link READ}'s `timestamp` argument.
@@ -18,7 +18,7 @@ export const TS_READ_TIMESTAMP = {
   NEW: '$'
 } as const;
 
-export type TsReadTimestamp = Timestamp | typeof TS_READ_TIMESTAMP[keyof typeof TS_READ_TIMESTAMP];
+export type TsReadTimestamp = number | Date | typeof TS_READ_TIMESTAMP[keyof typeof TS_READ_TIMESTAMP];
 
 export interface TsReadOptions {
   /**

--- a/packages/time-series/lib/commands/READ.ts
+++ b/packages/time-series/lib/commands/READ.ts
@@ -1,0 +1,70 @@
+import { CommandParser } from '@redis/client/dist/lib/client/parser';
+import { RedisArgument, Command, Resp2Reply } from '@redis/client/dist/lib/RESP/types';
+import { Timestamp, transformTimestampArgument, SamplesRawReply, transformSamplesReply } from './helpers';
+
+/**
+ * Sentinel cursor values for {@link READ}'s `timestamp` argument.
+ *
+ * The wire values must remain `-`, `+`, and `$`; only the first call of an
+ * iteration should use a sentinel. Every subsequent call should pass
+ * `last returned timestamp + 1`.
+ */
+export const TS_READ_TIMESTAMP = {
+  /** `-` — no lower bound, reads from the earliest sample (equivalent to `0`). */
+  EARLIEST: '-',
+  /** `+` — the latest existing sample's timestamp, inclusive. */
+  LATEST: '+',
+  /** `$` — the latest sample's timestamp + 1: only samples added after the call qualify. Meaningful only with `BLOCK`. */
+  NEW: '$'
+} as const;
+
+export type TsReadTimestamp = Timestamp | typeof TS_READ_TIMESTAMP[keyof typeof TS_READ_TIMESTAMP];
+
+export interface TsReadOptions {
+  /**
+   * Opt into blocking. All-or-nothing: when present, both `milliseconds` and
+   * `minCount` are emitted on the wire.
+   */
+  BLOCK?: {
+    /** Maximum wait in milliseconds, non-negative. `0` means wait indefinitely. */
+    milliseconds: number;
+    /** Unblock threshold, positive integer. Defaults to `1`. */
+    minCount?: number;
+  };
+  /** Reply cap, positive integer. Omitted means unlimited. */
+  MAX_COUNT?: number;
+}
+
+export default {
+  IS_READ_ONLY: true,
+  parseCommand(
+    parser: CommandParser,
+    key: RedisArgument,
+    timestamp: TsReadTimestamp,
+    options?: TsReadOptions
+  ) {
+    parser.push('TS.READ');
+    parser.pushKey(key);
+    parser.push(transformTimestampArgument(timestamp));
+
+    if (options?.BLOCK !== undefined) {
+      parser.push(
+        'BLOCK',
+        options.BLOCK.milliseconds.toString(),
+        (options.BLOCK.minCount ?? 1).toString()
+      );
+    }
+
+    if (options?.MAX_COUNT !== undefined) {
+      parser.push('MAX_COUNT', options.MAX_COUNT.toString());
+    }
+  },
+  transformReply: {
+    2(reply: Resp2Reply<SamplesRawReply>) {
+      return transformSamplesReply[2](reply);
+    },
+    3(reply: SamplesRawReply) {
+      return transformSamplesReply[3](reply);
+    }
+  }
+} as const satisfies Command;

--- a/packages/time-series/lib/commands/READ.ts
+++ b/packages/time-series/lib/commands/READ.ts
@@ -1,6 +1,6 @@
 import { CommandParser } from '@redis/client/dist/lib/client/parser';
 import { RedisArgument, Command, Resp2Reply } from '@redis/client/dist/lib/RESP/types';
-import { transformTimestampArgument, SamplesRawReply, transformSamplesReply } from './helpers';
+import { transformTimestampArgument, SamplesRawReply, transformSamplesReply, Timestamp } from './helpers';
 
 /**
  * Sentinel cursor values for {@link READ}'s `timestamp` argument.
@@ -18,7 +18,12 @@ export const TS_READ_TIMESTAMP = {
   NEW: '$'
 } as const;
 
-export type TsReadTimestamp = number | Date | typeof TS_READ_TIMESTAMP[keyof typeof TS_READ_TIMESTAMP];
+/**
+ * Cursor for {@link READ}'s `timestamp` argument. A {@link Timestamp}
+ * (`number | Date | string`; strings keep precision for values beyond
+ * `Number.MAX_SAFE_INTEGER`) or a {@link TS_READ_TIMESTAMP} sentinel.
+ */
+export type TsReadTimestamp = Timestamp | typeof TS_READ_TIMESTAMP[keyof typeof TS_READ_TIMESTAMP];
 
 export interface TsReadOptions {
   /**

--- a/packages/time-series/lib/commands/index.ts
+++ b/packages/time-series/lib/commands/index.ts
@@ -32,6 +32,7 @@ import MREVRANGE_WITHLABELS_GROUPBY from './MREVRANGE_WITHLABELS_GROUPBY';
 import MREVRANGE_WITHLABELS from './MREVRANGE_WITHLABELS';
 import MREVRANGE from './MREVRANGE';
 import QUERYINDEX from './QUERYINDEX';
+import READ from './READ';
 import RANGE_MULTIAGGR from './RANGE_MULTIAGGR';
 import RANGE from './RANGE';
 import REVRANGE_MULTIAGGR from './REVRANGE_MULTIAGGR';
@@ -547,6 +548,22 @@ export default {
    * @param filter - Filter to match time series labels
    */
   queryIndex: QUERYINDEX,
+  /**
+   * Reads a batch of samples with timestamp at or after a cursor, in ascending timestamp order.
+   * With `BLOCK`, waits until at least `minCount` samples qualify or the timeout elapses.
+   * @param key - The key name of the time series
+   * @param timestamp - Inclusive cursor: a non-negative integer or one of the {@link TS_READ_TIMESTAMP} sentinels (`-`, `+`, `$`)
+   * @param options - Optional `BLOCK` and `MAX_COUNT` parameters
+   */
+  READ,
+  /**
+   * Reads a batch of samples with timestamp at or after a cursor, in ascending timestamp order.
+   * With `BLOCK`, waits until at least `minCount` samples qualify or the timeout elapses.
+   * @param key - The key name of the time series
+   * @param timestamp - Inclusive cursor: a non-negative integer or one of the {@link TS_READ_TIMESTAMP} sentinels (`-`, `+`, `$`)
+   * @param options - Optional `BLOCK` and `MAX_COUNT` parameters
+   */
+  read: READ,
   /**
    * Gets multi-aggregation samples from a time series within a time range
    * @param args - Arguments passed to the {@link transformRangeMultiArguments} function

--- a/packages/time-series/lib/index.ts
+++ b/packages/time-series/lib/index.ts
@@ -7,3 +7,4 @@ export { TIME_SERIES_AGGREGATION_TYPE, TimeSeriesAggregationType } from './comma
 export { TIME_SERIES_BUCKET_TIMESTAMP, TimeSeriesBucketTimestamp } from './commands/RANGE';
 export { TimeSeriesAggregationTypeList, TsRangeMultiAggrOptions } from './commands/RANGE_MULTIAGGR';
 export { TIME_SERIES_REDUCERS, TimeSeriesReducer } from './commands/MRANGE_GROUPBY';
+export { TS_READ_TIMESTAMP, TsReadTimestamp, TsReadOptions } from './commands/READ';


### PR DESCRIPTION
This pull request adds client support for the RedisTimeSeries `TS.READ` command (`since 8.10.0`), a read-only, single-key cursor reader that returns a batch of `(timestamp, value)` samples with timestamp at or after a cursor, in ascending order. With the optional `BLOCK` group it waits until at least `minCount` qualifying samples exist or a timeout elapses, enabling continuous batch consumption of historical and newly appended samples without polling `TS.RANGE`.

Wire shape: `TS.READ key timestamp [BLOCK milliseconds min_count] [MAX_COUNT max_count]`. The `timestamp` cursor accepts a non-negative integer or one of the sentinels `-`/`+`/`$` (exposed as `TS_READ_TIMESTAMP`). The `BLOCK` group is all-or-nothing; `minCount` may be omitted in the typed API (defaults to `1`) but is always emitted on the wire. Replies reuse the existing `TS.RANGE` sample parser (RESP2/RESP3).

Behavior considerations:
- Command is marked read-only and is not cacheable (server declares `dont_cache`); cluster clients route by the key's hash slot.
- Blocking connection handling is the caller's responsibility, consistent with existing blocking commands (e.g. `BLPOP`); the command object carries no blocking flag. Callers opting into `BLOCK` should run it on an isolated connection.
- An empty reply is a successful result (nothing qualifies, timeout, or key removal) — no automatic retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API with no changes to existing commands; blocking behavior matches other blocking Redis commands and is caller-managed.
> 
> **Overview**
> Adds **client support for RedisTimeSeries `TS.READ`** (Redis 8.10+): a read-only, single-key cursor read that returns ascending `(timestamp, value)` batches from an inclusive cursor, with optional **`BLOCK`** (wait for `minCount`, default 1) and **`MAX_COUNT`**.
> 
> The new `READ` command module exposes **`TS_READ_TIMESTAMP`** sentinels (`-`, `+`, `$`), typed **`TsReadTimestamp`** / **`TsReadOptions`**, and wires **`client.ts.read`** / **`READ`** into the time-series command map. Replies reuse the existing **`TS.RANGE`** sample transformers for RESP2/RESP3.
> 
> **Tests** cover argument encoding (cursors, precision-safe string timestamps, `BLOCK`/`MAX_COUNT`) and integration cases (full read, caps, missing key, `LATEST`, blocking when `minCount` is already met, empty flush on `NEW` + `BLOCK` timeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79ae841b5c9c4e0ddf89a0941934a7af148b8425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->