### PR TITLE
fix(client): RESTORE with IDLETIME/FREQ 0 must emit the argument

### DIFF
--- a/packages/client/lib/commands/RESTORE.spec.ts
+++ b/packages/client/lib/commands/RESTORE.spec.ts
@@ -49,6 +49,24 @@ describe('RESTORE', () => {
       );
     });
 
+    it('with IDLETIME 0', () => {
+      assert.deepEqual(
+        parseArgs(RESTORE, 'key', 0, 'value', {
+          IDLETIME: 0
+        }),
+        ['RESTORE', 'key', '0', 'value', 'IDLETIME', '0']
+      );
+    });
+
+    it('with FREQ 0', () => {
+      assert.deepEqual(
+        parseArgs(RESTORE, 'key', 0, 'value', {
+          FREQ: 0
+        }),
+        ['RESTORE', 'key', '0', 'value', 'FREQ', '0']
+      );
+    });
+
     it('with REPLACE, ABSTTL, IDLETIME and FREQ', () => {
       assert.deepEqual(
         parseArgs(RESTORE, 'key', 0, 'value', {

--- a/packages/client/lib/commands/RESTORE.ts
+++ b/packages/client/lib/commands/RESTORE.ts
@@ -37,11 +37,11 @@ export default {
       parser.push('ABSTTL');
     }
 
-    if (options?.IDLETIME) {
+    if (options?.IDLETIME !== undefined) {
       parser.push('IDLETIME', options.IDLETIME.toString());
     }
 
-    if (options?.FREQ) {
+    if (options?.FREQ !== undefined) {
       parser.push('FREQ', options.FREQ.toString());
     }
   },


### PR DESCRIPTION
`RESTORE ... IDLETIME <n>` and `RESTORE ... FREQ <n>` were guarded by truthy checks (`if (options?.IDLETIME)` / `if (options?.FREQ)`), so a value of `0` was silently dropped from the argument array.

`FREQ 0` is observable: RESTORE without FREQ initialises the LFU access counter to the server default (`LFU_INIT_VAL`, 5), whereas the caller asking for `FREQ 0` wants a counter of 0. Both options accept 0 per the Redis spec (FREQ range 0–255).

Guard on `!== undefined` so an explicit `0` is forwarded. Adds `with IDLETIME 0` / `with FREQ 0` argument tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client command-encoding fix with added unit tests; no security or persistence behavior beyond correct Redis argument emission.
> 
> **Overview**
> Fixes a bug where **`RESTORE`** omitted **`IDLETIME`** and **`FREQ`** when the caller passed **`0`**, because those options were only appended when truthy.
> 
> **`RESTORE.ts`** now treats both options as present when they are explicitly set (`!== undefined`), so **`0`** is serialized into the command (e.g. `IDLETIME 0`, `FREQ 0`). That matters for **`FREQ 0`**, which should set the LFU counter to 0 instead of leaving the server default.
> 
> Adds **`transformArguments`** tests for **`IDLETIME: 0`** and **`FREQ: 0`** in **`RESTORE.spec.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc54a925baaf1d0a0f3149111d5aeb5182e0995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->