### PR TITLE
fix(client): XSETID with ENTRIESADDED 0 must emit the argument

### DIFF
--- a/packages/client/lib/commands/XSETID.spec.ts
+++ b/packages/client/lib/commands/XSETID.spec.ts
@@ -29,6 +29,15 @@ describe('XSETID', () => {
         ['XSETID', 'key', '0-0', 'MAXDELETEDID', '1-1']
       );
     });
+
+    it('with ENTRIESADDED 0', () => {
+      assert.deepEqual(
+        parseArgs(XSETID, 'key', '0-0', {
+          ENTRIESADDED: 0
+        }),
+        ['XSETID', 'key', '0-0', 'ENTRIESADDED', '0']
+      );
+    });
   });
 
   testUtils.testAll('xSetId', async client => {

--- a/packages/client/lib/commands/XSETID.ts
+++ b/packages/client/lib/commands/XSETID.ts
@@ -19,7 +19,7 @@ export default {
     parser.pushKey(key);
     parser.push(lastId);
 
-    if (options?.ENTRIESADDED) {
+    if (options?.ENTRIESADDED !== undefined) {
       parser.push('ENTRIESADDED', options.ENTRIESADDED.toString());
     }
 


### PR DESCRIPTION
`XSETID key last-id ENTRIESADDED <n>` was guarded by a truthy check (`if (options?.ENTRIESADDED)`), so a value of `0` was silently dropped from the argument array.

`ENTRIESADDED 0` is observable: omitting the clause leaves the stream's entries-added counter unchanged, while passing `0` resets it to `0` — the falsy guard turned an explicit reset into a no-op.

Guard on `!== undefined` so an explicit `0` is forwarded. Adds a `with ENTRIESADDED 0` argument test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client command-parser fix with a unit test; no auth, security, or broad API surface changes.
> 
> **Overview**
> Fixes **`XSETID`** argument building so **`ENTRIESADDED: 0`** is sent to Redis instead of being dropped.
> 
> The parser used a truthy check on **`ENTRIESADDED`**, so **`0`** was treated as absent. That changed semantics: omitting the clause leaves the stream’s entries-added counter unchanged, while **`ENTRIESADDED 0`** resets it. The guard is now **`!== undefined`**, and a **`with ENTRIESADDED 0`** transform test locks in the expected argv.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483edd70d30f941ebcc76e2fd20cbc1737fcecf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->