### PR TITLE
fix(test-utils): share one network namespace across cluster nodes

### DIFF
--- a/packages/test-utils/lib/dockers.ts
+++ b/packages/test-utils/lib/dockers.ts
@@ -4,7 +4,6 @@ import { createConnection } from 'node:net';
 import { once } from 'node:events';
 import { createClient } from '@redis/client/index';
 import { setTimeout } from 'node:timers/promises';
-// import { ClusterSlotsReply } from '@redis/client/dist/lib/commands/CLUSTER_SLOTS';
 import { execFile as execFileCallback } from 'node:child_process';
 import { promisify } from 'node:util';
 import * as fs from 'node:fs';
@@ -444,90 +443,76 @@ export type RedisClusterDockersConfig = RedisServerDockerOptions & {
   numberOfReplicas?: number;
 }
 
-async function spawnRedisClusterNodeDockers(
-  dockersConfig: RedisClusterDockersConfig,
-  serverArguments: Array<string>,
-  fromSlot: number,
-  toSlot: number,
-  clientConfig?: Partial<RedisClusterClientOptions>
-) {
-  const range: Array<number> = [];
-  for (let i = fromSlot; i < toSlot; i++) {
-    range.push(i);
+const CLUSTER_BUS_PORT_OFFSET = 10000;
+
+async function reservePorts(count: number): Promise<number[]> {
+  const ports: number[] = [];
+  for (let i = 0; i < count; i++) {
+    ports.push((await portIterator.next()).value);
   }
-
-  const master = await spawnRedisClusterNodeDocker(
-    dockersConfig,
-    serverArguments,
-    clientConfig
-  );
-
-  await master.client.clusterAddSlots(range);
-
-  if (!dockersConfig.numberOfReplicas) return [master];
-
-  const replicasPromises: Array<ReturnType<typeof spawnRedisClusterNodeDocker>> = [];
-  for (let i = 0; i < (dockersConfig.numberOfReplicas ?? 0); i++) {
-    replicasPromises.push(
-      spawnRedisClusterNodeDocker(dockersConfig, [
-        ...serverArguments,
-        '--cluster-enabled',
-        'yes',
-        '--cluster-node-timeout',
-        '5000'
-      ], clientConfig).then(async replica => {
-
-        const requirePassIndex = serverArguments.findIndex((x) => x === '--requirepass');
-        if (requirePassIndex !== -1) {
-          const password = serverArguments[requirePassIndex + 1];
-          await replica.client.configSet({ 'masterauth': password })
-        }
-        await replica.client.clusterMeet('127.0.0.1', master.docker.port);
-
-        while ((await replica.client.clusterSlots()).length === 0) {
-          await setTimeout(25);
-        }
-
-        await replica.client.clusterReplicate(
-          await master.client.clusterMyId()
-        );
-
-        return replica;
-      })
-    );
-  }
-
-  return [
-    master,
-    ...await Promise.all(replicasPromises)
-  ];
+  return ports;
 }
 
-async function spawnRedisClusterNodeDocker(
+// Spawns one redis-server node that's part of a cluster where *all* nodes
+// share a single Docker network namespace, instead of `--network host`.
+//
+// Why: on macOS/Windows, `--network host` only reaches the Docker Desktop VM,
+// not the real host, so the host test process can't connect to the nodes at
+// all (see #2358). Publishing ports (`-p`) the usual way fixes host access,
+// but Redis Cluster nodes can only *announce* one address for themselves --
+// an address that's valid for sibling containers (their bridge-network IP)
+// is *not* valid for the host, and vice-versa.
+//
+// Fix: put every node in the cluster in the *same* network namespace via
+// `--network container:<id>`. The first node spawned ("owner") gets a normal
+// network and publishes every port the whole cluster will ever use; every
+// other node joins the owner's namespace instead of getting its own. From
+// then on, `127.0.0.1:<port>` means the same thing to the host *and* to every
+// sibling node, so `--cluster-announce-ip 127.0.0.1` is simultaneously valid
+// for both audiences.
+async function spawnClusterNetworkNode(
   dockersConfig: RedisServerDockerOptions,
   serverArguments: Array<string>,
-  clientConfig?: Partial<RedisClusterClientOptions>
-) {
-  const docker = await spawnRedisServerDocker(dockersConfig, [
-      ...serverArguments,
-      '--cluster-enabled',
-      'yes',
-      '--cluster-node-timeout',
-      '5000'
-    ]),
-    client = createClient({
-      socket: {
-        port: docker.port
-      },
-      ...clientConfig
-    });
+  port: number,
+  ownerPorts: number[] | undefined,
+  networkOwnerId: string | undefined
+): Promise<RedisServerDocker> {
+  const portStr = port.toString();
+  const busPort = port + CLUSTER_BUS_PORT_OFFSET;
 
-  await client.connect();
+  const dockerArgs = ['run', '--init', '-e', `PORT=${portStr}`];
 
-  return {
-    docker,
-    client
-  };
+  if (networkOwnerId) {
+    dockerArgs.push('--network', `container:${networkOwnerId}`);
+  } else {
+    for (const p of ownerPorts!) {
+      dockerArgs.push(
+        '-p', `${p}:${p}`,
+        '-p', `${p + CLUSTER_BUS_PORT_OFFSET}:${p + CLUSTER_BUS_PORT_OFFSET}`
+      );
+    }
+  }
+
+  dockerArgs.push('-d', `${dockersConfig.image}:${dockersConfig.version}`);
+  dockerArgs.push(
+    ...serverArguments,
+    '--cluster-announce-ip', '127.0.0.1',
+    '--cluster-announce-port', portStr,
+    '--cluster-announce-bus-port', busPort.toString()
+  );
+
+  console.log(`[Docker] Spawning cluster node - Port: ${port}, network: ${networkOwnerId ? `container:${networkOwnerId}` : '(owner)'}`);
+
+  const { stdout, stderr } = await execAsync('docker', dockerArgs);
+  if (!stdout) {
+    throw new Error(`docker run error - ${stderr}`);
+  }
+
+  while (await isPortAvailable(port)) {
+    await setTimeout(50);
+  }
+
+  return { port, dockerId: stdout.trim() };
 }
 
 const SLOTS = 16384;
@@ -538,50 +523,99 @@ async function spawnRedisClusterDockers(
   clientConfig?: Partial<RedisClusterClientOptions>
 ): Promise<Array<RedisServerDocker>> {
   const numberOfMasters = dockersConfig.numberOfMasters ?? 2,
-    slotsPerNode = Math.floor(SLOTS / numberOfMasters),
-    spawnPromises: Array<ReturnType<typeof spawnRedisClusterNodeDockers>> = [];
-  for (let i = 0; i < numberOfMasters; i++) {
-    const fromSlot = i * slotsPerNode,
-      toSlot = i === numberOfMasters - 1 ? SLOTS : fromSlot + slotsPerNode;
-    spawnPromises.push(
-      spawnRedisClusterNodeDockers(
-        dockersConfig,
-        serverArguments,
-        fromSlot,
-        toSlot,
-        clientConfig
-      )
-    );
+    numberOfReplicas = dockersConfig.numberOfReplicas ?? 0,
+    totalNodeCount = numberOfMasters * (1 + numberOfReplicas),
+    slotsPerNode = Math.floor(SLOTS / numberOfMasters);
+
+  // All ports must be known up-front: the network "owner" node has to
+  // publish every port the cluster will use in its single `docker run`.
+  const ports = await reservePorts(totalNodeCount);
+  const nodeArguments = [...serverArguments, '--cluster-enabled', 'yes', '--cluster-node-timeout', '5000'];
+
+  const ownerDocker = await spawnClusterNetworkNode(dockersConfig, nodeArguments, ports[0], ports, undefined);
+  const restDockers = await Promise.all(
+    ports.slice(1).map(port =>
+      spawnClusterNetworkNode(dockersConfig, nodeArguments, port, undefined, ownerDocker.dockerId)
+    )
+  );
+  const dockers = [ownerDocker, ...restDockers];
+
+  const nodes = await Promise.all(
+    dockers.map(async docker => {
+      const client = createClient({ socket: { port: docker.port }, ...clientConfig });
+      await client.connect();
+      return { docker, client };
+    })
+  );
+
+  // First `numberOfMasters` nodes are masters (one per shard); the rest are
+  // replicas, handed out round-robin across the masters.
+  const masters = nodes.slice(0, numberOfMasters);
+  const replicasByMaster: (typeof nodes)[] = masters.map(() => []);
+  for (let i = numberOfMasters; i < nodes.length; i++) {
+    replicasByMaster[(i - numberOfMasters) % numberOfMasters].push(nodes[i]);
   }
 
-  const nodes = (await Promise.all(spawnPromises)).flat(),
-    meetPromises: Array<Promise<unknown>> = [];
+  for (let i = 0; i < numberOfMasters; i++) {
+    const fromSlot = i * slotsPerNode,
+      toSlot = i === numberOfMasters - 1 ? SLOTS : fromSlot + slotsPerNode,
+      range: Array<number> = [];
+    for (let s = fromSlot; s < toSlot; s++) range.push(s);
+    await masters[i].client.clusterAddSlots(range);
+  }
+
+  const meetPromises: Array<Promise<unknown>> = [];
   for (let i = 1; i < nodes.length; i++) {
     meetPromises.push(
       nodes[i].client.clusterMeet('127.0.0.1', nodes[0].docker.port)
     );
   }
-
   await Promise.all(meetPromises);
 
+  // Wait for gossip to cover all slots before replicating -- this only needs
+  // the masters to be visible, not the (not-yet-configured) replicas, so it
+  // must happen *before* clusterReplicate below, not after.
   await Promise.all(
     nodes.map(async ({ client }) => {
       while (
-        totalNodes(await client.clusterSlots()) !== nodes.length ||
         !(await client.sendCommand<string>(['CLUSTER', 'INFO'])).startsWith('cluster_state:ok') // TODO
         ) {
         await setTimeout(50);
       }
-
-      client.destroy();
     })
   );
 
-  return nodes.map(({ docker }) => docker);
+  for (let i = 0; i < numberOfMasters; i++) {
+    for (const replica of replicasByMaster[i]) {
+      const requirePassIndex = serverArguments.findIndex((x) => x === '--requirepass');
+      if (requirePassIndex !== -1) {
+        const password = serverArguments[requirePassIndex + 1];
+        await replica.client.configSet({ 'masterauth': password });
+      }
+      await replica.client.clusterReplicate(await masters[i].client.clusterMyId());
+    }
+  }
+
+  // Now that replicas are attached, wait for every node to see the full
+  // node count (masters + replicas) before handing the cluster back.
+  await Promise.all(
+    nodes.map(async ({ client }) => {
+      while (totalNodes(await client.clusterSlots()) !== nodes.length) {
+        await setTimeout(50);
+      }
+    })
+  );
+
+  for (const { client } of nodes) {
+    client.destroy();
+  }
+
+  return dockers;
 }
 
-// TODO: type ClusterSlotsReply
-function totalNodes(slots: any) {
+type ClusterSlotsReply = Awaited<ReturnType<ReturnType<typeof createClient>['clusterSlots']>>;
+
+function totalNodes(slots: ClusterSlotsReply) {
   let total = slots.length;
   for (const slot of slots) {
     total += slot.replicas.length;

--- a/packages/test-utils/lib/dockers.ts
+++ b/packages/test-utils/lib/dockers.ts
@@ -485,11 +485,14 @@ async function spawnClusterNetworkNode(
   if (networkOwnerId) {
     dockerArgs.push('--network', `container:${networkOwnerId}`);
   } else {
+    // Only the client port needs to be reachable from the host -- the
+    // cluster bus port is only ever dialed by sibling nodes over loopback
+    // inside this shared namespace, so it doesn't need (and shouldn't get)
+    // a host mapping. Publishing it anyway is both pointless and unsafe:
+    // `port + CLUSTER_BUS_PORT_OFFSET` can exceed 65535 for high ports,
+    // which makes Docker reject the whole `docker run`.
     for (const p of ownerPorts!) {
-      dockerArgs.push(
-        '-p', `${p}:${p}`,
-        '-p', `${p + CLUSTER_BUS_PORT_OFFSET}:${p + CLUSTER_BUS_PORT_OFFSET}`
-      );
+      dockerArgs.push('-p', `${p}:${p}`);
     }
   }
 

--- a/packages/test-utils/lib/dockers.ts
+++ b/packages/test-utils/lib/dockers.ts
@@ -444,11 +444,19 @@ export type RedisClusterDockersConfig = RedisServerDockerOptions & {
 }
 
 const CLUSTER_BUS_PORT_OFFSET = 10000;
+// Cluster nodes announce `port + CLUSTER_BUS_PORT_OFFSET` as their bus port
+// (see spawnClusterNetworkNode below), so client ports reserved for a
+// cluster must leave enough headroom for that to stay a valid TCP port.
+const MAX_CLUSTER_CLIENT_PORT = 65535 - CLUSTER_BUS_PORT_OFFSET;
 
-async function reservePorts(count: number): Promise<number[]> {
+async function reservePorts(count: number, maxPort = 65535): Promise<number[]> {
   const ports: number[] = [];
   for (let i = 0; i < count; i++) {
-    ports.push((await portIterator.next()).value);
+    let port: number;
+    do {
+      port = (await portIterator.next()).value;
+    } while (port > maxPort);
+    ports.push(port);
   }
   return ports;
 }
@@ -532,7 +540,7 @@ async function spawnRedisClusterDockers(
 
   // All ports must be known up-front: the network "owner" node has to
   // publish every port the cluster will use in its single `docker run`.
-  const ports = await reservePorts(totalNodeCount);
+  const ports = await reservePorts(totalNodeCount, MAX_CLUSTER_CLIENT_PORT);
   const nodeArguments = [...serverArguments, '--cluster-enabled', 'yes', '--cluster-node-timeout', '5000'];
 
   const ownerDocker = await spawnClusterNetworkNode(dockersConfig, nodeArguments, ports[0], ports, undefined);


### PR DESCRIPTION
### Description

Related to #2358 ("Running test suits only works on Linux hosts") -- specifically the cluster portion. Not marking this as "Fixes" since Sentinel test spawning still uses `--network host` and is presumably still broken on macOS (out of scope here, separate follow-up needed).

**Context**

`--network host` doesn't expose container ports to the real host on macOS/Windows Docker Desktop (only to the hidden VM), so the host test process can't connect to spawned nodes at all.

This exact fix was actually already suggested in this issue back in 2023:

> [@K4ST0R]: You can replace `--network host` with `-p <port>:<port>`. Works fine on my Mac :)

> [@leibale]: This won't work for cluster (cause the nodes won't be able to communicate)

That rebuttal is very close, but the precise failure mode is slightly different: with plain `-p`, sibling containers *can* still reach each other fine over the default bridge network (that never needed publishing) -- the actual problem is that a Redis Cluster node can only announce **one** address for itself, and no single address is valid for both the host (needs the published port) and sibling nodes (need the bridge-internal address). Whichever one a node announces, the other audience can't use it.

**Approach**

Instead of finding one address that satisfies both audiences, this puts every node in a cluster group into the *same* Docker network namespace via `--network container:<id>`, so there's only one address space to worry about:

- The first node spawned ("owner") gets a normal network and publishes every client port the whole group will use. The cluster bus port (client port + 10000) is deliberately *not* published -- it's only ever dialed by sibling nodes over loopback inside the shared namespace, and reserved client ports are capped below `65535 - 10000` so the announced bus port always stays a valid TCP port.
- Every other node joins the owner's namespace instead of getting its own bridge address.
- All nodes announce `--cluster-announce-ip 127.0.0.1` with their own `--cluster-announce-port`/`--cluster-announce-bus-port`.

Since every node now shares one namespace, `127.0.0.1:<port>` means the same thing to the host *and* to every sibling node.

`--network container:<id>` is a standard Docker Engine feature (not Mac-specific), so this doesn't need any OS branching -- same code path for macOS and Linux.

**Verified locally (macOS)**

- Reproduced the original host-unreachable failure against unmodified `main` first, before writing any fix.
- Manually validated the core idea (2 plain containers, shared namespace, `CLUSTER MEET`, checked `CLUSTER NODES` on both sides) before touching the real spawning code.
- Full `packages/client/lib/cluster/index.spec.ts` cluster suite: 34 passing, including resharding, PubSub slot-migration, and topology tests -- exercised by the existing suite rather than new dedicated unit tests for the spawning code itself.
- Checked container teardown ordering isn't an issue: concurrent `docker rm -f` on owner + dependents in random order cleans up correctly with no errors.
- The 3 unrelated failures I see locally (`FUNCTION LOAD`, generic `Client` tests, "before all" timeouts) reproduce identically on unmodified `main` too -- pre-existing local Docker resource-contention flakiness, not introduced by this change.

**Out of scope / known gaps**

- Sentinel spawning (`spawnRedisServer`/sentinel path) is untouched and likely still broken on macOS.

I'd especially welcome feedback on the approach itself (network namespace sharing) given the history on this issue -- happy to adjust if there's a reason this doesn't fit.

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new/changed code exercised by tests? (via the existing cluster suite, not new isolated unit tests for the spawning logic itself)
- [ ] Documentation update -- this is internal test infra, not a public API, so nothing user-facing to document.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only test-utils Docker orchestration but reorders cluster bring-up and networking; regressions could show up as CI flakiness or broken cluster suites on Linux as well as macOS.
> 
> **Overview**
> **Redis cluster test Docker spawning** no longer relies on per-shard `--network host` containers. It now reserves all node ports up front, starts an **owner** container that publishes those client ports, and attaches every other node with `--network container:<owner>` so host and siblings both use `127.0.0.1` with `--cluster-announce-*`.
> 
> Cluster bootstrap is **flattened**: all masters and replicas are created together, slots are assigned per master, nodes `CLUSTER MEET`, the suite waits for `cluster_state:ok` **before** `CLUSTER REPLICATE`, then waits until `CLUSTER SLOTS` reflects the full master+replica count. Bus ports stay inside the shared namespace (not published) and client ports are capped so `port + 10000` stays valid.
> 
> `totalNodes` now uses a proper `ClusterSlotsReply` type instead of `any`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad2b5bcb891aff13e97cd0d9a2f043319797e0cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

