### PR TITLE
fix(client): MEMORY USAGE must emit SAMPLES when 0

### DIFF
--- a/packages/client/lib/commands/MEMORY_USAGE.spec.ts
+++ b/packages/client/lib/commands/MEMORY_USAGE.spec.ts
@@ -20,6 +20,15 @@ describe('MEMORY USAGE', () => {
         ['MEMORY', 'USAGE', 'key', 'SAMPLES', '1']
       );
     });
+
+    it('with SAMPLES 0 (sample all nested values)', () => {
+      assert.deepEqual(
+        parseArgs(MEMORY_USAGE, 'key', {
+          SAMPLES: 0
+        }),
+        ['MEMORY', 'USAGE', 'key', 'SAMPLES', '0']
+      );
+    });
   });
 
   testUtils.testWithClient('client.memoryUsage', async client => {

--- a/packages/client/lib/commands/MEMORY_USAGE.ts
+++ b/packages/client/lib/commands/MEMORY_USAGE.ts
@@ -2,6 +2,10 @@ import { CommandParser } from '../client/parser';
 import { NumberReply, NullReply, Command, RedisArgument } from '../RESP/types';
 
 export interface MemoryUsageOptions {
+  /**
+   * Number of sampled nested values for aggregate types. `0` samples all of
+   * them; the default is 5.
+   */
   SAMPLES?: number;
 }
 
@@ -11,7 +15,7 @@ export default {
     parser.push('MEMORY', 'USAGE');
     parser.pushKey(key);
 
-    if (options?.SAMPLES) {
+    if (options?.SAMPLES !== undefined) {
       parser.push('SAMPLES', options.SAMPLES.toString());
     }
   },


### PR DESCRIPTION
### Description

`MEMORY USAGE key SAMPLES 0` was being dropped. The `SAMPLES` option is guarded by a truthy check:

```ts
if (options?.SAMPLES) {
  parser.push('SAMPLES', options.SAMPLES.toString());
}
```

so an explicit `0` is falsy and never emitted — the command silently degrades to `MEMORY USAGE key`, which uses the server default of **5** samples.

Per the [Redis docs](https://redis.io/docs/latest/commands/memory-usage/):

> By default, this option is set to `5`. To sample the all of the nested values, use `SAMPLES 0`.

So `SAMPLES 0` means "scan **all** nested values" (an exact size) rather than estimating from 5 — observably different for aggregate types (lists/hashes/sets/zsets). Dropping it changes the returned size.

Fix: guard on `!== undefined` so an explicit `0` is forwarded. This mirrors the recent same-class fix for `RESTORE IDLETIME/FREQ 0` (#3323) and `XSETID ENTRIESADDED 0` (#3324).

Added a `transformArguments` test for `SAMPLES: 0`.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)? — the `MEMORY USAGE` spec passes (4 tests incl. the new case) and `eslint` is clean on the changed files.
- [x] Is the new or changed code fully tested? — added a `SAMPLES 0` argument test; it fails on the old truthy guard and passes with `!== undefined`.
- [ ] Is a documentation update included? — no public API change (existing `SAMPLES?: number` option); added a JSDoc note documenting the `0` semantics.

<sub>Drafted with AI assistance (Claude); reviewed and verified by me. Every line is mine to defend.</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small read-only command argument parsing fix with a regression test; no auth, data mutation, or broad API surface change.
> 
> **Overview**
> Fixes **`MEMORY USAGE`** so an explicit **`SAMPLES: 0`** is sent to Redis instead of being dropped. The parser used a truthy check on `SAMPLES`, so `0` never produced `SAMPLES 0` and the command fell back to the server default (5 samples), which changes memory estimates for aggregate keys.
> 
> The guard is now **`options?.SAMPLES !== undefined`**, matching the pattern used for other numeric options that allow `0`. **`MemoryUsageOptions`** gets a short JSDoc note that `0` means sample all nested values, and a **`transformArguments`** test asserts `['MEMORY', 'USAGE', 'key', 'SAMPLES', '0']`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8b0c431cfb84a703401197f4f49939b455264a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->