### PR TITLE
fix(sentinel): emit error when the resolved master is unreachable

### DIFF
--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -903,6 +903,44 @@ describe('legacy tests', () => {
       assert.notEqual(masterNode!.port, newMaster.port);
     });
 
+    // Regression: when sentinel discovery succeeds but the resolved master is
+    // unreachable (e.g. #3066 - TLS misconfiguration, or a firewalled/NATed
+    // address), #connect()'s retry loop used to silently `console.log` the
+    // failure on every attempt with nothing an application could observe or
+    // catch, leaving `connect()` looking hung until it eventually gave up
+    // after `maxCommandRediscovers` attempts. It should emit `'error'` on
+    // every retry attempt instead.
+    it('emits error while retrying an unreachable master', async function () {
+      this.timeout(60000);
+
+      const masterPort = await frame.getMasterPort();
+
+      sentinel = frame.getSentinelClient({
+        nodeAddressMap: (address: string) => {
+          const [host, portStr] = address.split(':');
+          // Remap only the master to an address nothing listens on, so the
+          // connection attempt fails immediately (ECONNREFUSED) without
+          // ever needing a failover - sentinel itself stays healthy the
+          // whole time, matching the reported scenario.
+          if (Number(portStr) === masterPort) {
+            return { host: '127.0.0.1', port: 1 };
+          }
+          return { host, port: Number(portStr) };
+        }
+      }, false);
+
+      const errors: Array<Error> = [];
+      sentinel.on('error', (err: Error) => errors.push(err));
+
+      const connectPromise = sentinel.connect();
+      connectPromise.catch(() => {});
+
+      // Wait for at least one retry attempt to surface an 'error' event
+      // instead of hanging silently.
+      await assert.doesNotReject(once(sentinel, 'error'));
+      assert.ok(errors.length > 0);
+    });
+
     // if master changes, client should make sure user knows watches are invalid
     it('watch across master change', async function () {
       this.timeout(60000);

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -1000,7 +1000,7 @@ export class RedisSentinelInternal<
         }
 
         if (err.message !== 'no valid master node') {
-          console.log(e);
+          this.emit('error', err);
         }
         await setTimeout(1000);
       } finally {


### PR DESCRIPTION
### Description

Fixes #3066.

`RedisSentinelInternal#connect()`'s retry loop discovers the current master via the Sentinel nodes (`observe()`/`analyze()`), then connects a client to it (`transform()`). If sentinel discovery succeeds but the resolved master address is actually unreachable (e.g. a TLS misconfiguration, or a firewalled/NATed address — the exact scenario in #3066), the failure was only ever `console.log`'d on every retry attempt, with nothing an application could observe, catch, or react to. Since the retry loop waits 1s between attempts and only gives up (rejecting `connect()`) after `maxCommandRediscovers` (default 16) attempts, this can look like a ~16 second silent hang with zero visibility into why.

The fix is a single line: emit `'error'` instead of `console.log`-ing it. This matches the existing convention already used elsewhere in the same class — `observe()` already emits `'error'` for a sentinel node it can't reach, and the `PubSubProxy` wiring does the same — so this isn't a new pattern, just applying the existing one to a path that had been missed. The `'no valid master node'` case remains excluded from emission, unchanged from before: that message is a normal, expected transient during a real failover (the old master is briefly flagged down before a replica is promoted), not something worth surfacing as an error.

`RedisSentinel`'s constructor already wires `this.#internal.on('error', err => this.emit('error', err))` before `connect()` can ever run, so this emission is guaranteed to have a listener and won't crash on an unhandled `'error'` event.

A regression test was added (`emits error while retrying an unreachable master`) using `nodeAddressMap` to remap only the resolved master to an unreachable address, so sentinel discovery itself stays healthy the whole time — matching the reported scenario without needing a real TLS setup. It asserts an `'error'` event fires during the retry loop instead of the connect attempt going silent.

**Local verification note**: I was not able to get the full docker-based sentinel test suite running end-to-end in my local environment to watch this specific new test go green (an environment issue on my end — an *existing, unmodified* sentinel test hits the same `beforeEach` timeout, so it's unrelated to this change). I did verify: `tsc --build` is clean, lint is clean, and the existing docker-free sentinel unit tests (`commandOptions` suite) still pass. The new test's control-flow was traced by hand against `destroy()`'s teardown behavior to confirm it won't hang or leave dangling state, but I'd appreciate CI (or a maintainer) confirming it actually passes.

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)? — lint and `tsc --build` are clean; the docker-free sentinel unit tests pass; the full docker-based suite (including the new test) could not be run end-to-end locally (see note above) and needs CI to confirm.
- [ ] Is the new or changed code fully tested? — a regression test was added, but not verified passing locally (see note above).
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? — N/A, no public API change; `'error'` is an existing, documented event on `RedisSentinel`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change on an existing `error` event path; connect still fails after the same retry limit, with slightly noisier error events during retries.
> 
> **Overview**
> When Sentinel finds a master but **connecting to that address fails**, `RedisSentinelInternal#connect()` no longer only **`console.log`s** each retry—it **`emit('error', err)`** on every attempt (still skipping the expected transient **`no valid master node`** message during failover).
> 
> That surfaces failures such as TLS or NAT/firewall mismatches (#3066) while `connect()` keeps retrying up to **`maxCommandRediscovers`**, instead of a long silent wait. Errors propagate through the existing **`RedisSentinel`** internal → public **`error`** wiring.
> 
> A docker-based regression test uses **`nodeAddressMap`** to point the resolved master at an unreachable port while Sentinels stay healthy, and asserts an **`error`** event during **`connect()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6df6a298937f229783df305cdc804aaab211ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->