### PR TITLE
docs(contributing): document Docker Desktop host networking requireme…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,10 @@ To run the tests, run `npm install` to install dependencies, then run `npm run b
 
 Note that the test suite assumes that [`docker`](https://www.docker.com/) is installed in your environment.
 
+#### Running the tests on macOS and Windows
+
+The test suite starts its Redis containers with `--network host`, which requires host networking support. On macOS and Windows this needs Docker Desktop 4.34 or newer with host networking enabled: **Settings → Resources → Network → Enable host networking**. Without it, the spawned containers are not reachable from the host and the dockerized tests will hang or time out.
+
 ### Submitting Code for Review
 
 The bigger the pull request, the longer it will take to review and merge. Where possible try to break down large pull requests into smaller chunks that are easier to review and merge. It is also always helpful to have some context for your pull request. What was the purpose? Why does it matter to you? What problem are you trying to solve? Tag in any relevant issues.


### PR DESCRIPTION
The test suite spawns Redis containers with --network host, which only works out of the box on Linux. Docker Desktop 4.34+ supports host networking on macOS and Windows behind an opt-in setting; with it enabled the full suite (including cluster tests) runs unchanged.

Fixes #2358

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a **Running the tests on macOS and Windows** subsection under **Testing Code** in `CONTRIBUTING.md`.
> 
> It documents that the suite uses Redis containers with `--network host`, which on macOS and Windows requires **Docker Desktop 4.34+** with **Settings → Resources → Network → Enable host networking**. Without that, dockerized tests may hang or time out because containers are not reachable from the host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f59f868aa0f762ae43549e52b867a6638722f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->