### PR TITLE
fix(sentinel): reject connect() instead of hanging when the resolved master is unreachable

### DIFF
--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -868,6 +868,69 @@ describe('legacy tests', () => {
       );
     });
 
+    // Regression test for https://github.com/redis/node-redis/issues/3066
+    //
+    // When sentinel discovery succeeds but the resolved master is not
+    // reachable (e.g. a TLS misconfiguration, or a firewalled address), the
+    // master clients keep the default `reconnectStrategy` and retry forever,
+    // so their `connect()` promises never settle and `connect()` used to hang
+    // indefinitely with nothing to observe or catch. It should reject once
+    // the connect retry loop gives up.
+    it('connect() rejects instead of hanging when the resolved master is unreachable', async function () {
+      this.timeout(60000);
+
+      const masterPort = await frame.getMasterPort();
+
+      sentinel = frame.getSentinelClient({
+        // Remap only the master to an address nothing listens on, so master
+        // connection attempts fail while sentinel discovery stays healthy,
+        // matching the reported scenario.
+        nodeAddressMap: (address: string) => {
+          const [host, portStr] = address.split(':');
+          if (Number(portStr) === masterPort) {
+            return { host: '127.0.0.1', port: 1 };
+          }
+          return { host, port: Number(portStr) };
+        },
+        // Keep the test fast: give up after two rediscover attempts.
+        maxCommandRediscovers: 2
+      }, false);
+
+      sentinel.on('error', () => { });
+
+      await assert.rejects(sentinel.connect());
+
+      // The failed connect must tear everything down: master clients keep
+      // reconnecting per their `reconnectStrategy` after a failed first
+      // attempt, and must not stay alive in the background once `connect()`
+      // has rejected.
+      assert.strictEqual(sentinel.isOpen, false);
+
+      const lateErrors: Array<unknown> = [];
+      sentinel.on('client-error', (err: unknown) => lateErrors.push(err));
+      await setTimeout(1000);
+      assert.strictEqual(lateErrors.length, 0);
+    });
+
+    // Same regression, reproducing the exact failure mode reported in #3066:
+    // a TLS misconfiguration on the master clients. Connecting with TLS to a
+    // plaintext Redis makes the handshake fail (while sentinel discovery,
+    // which doesn't use `nodeClientOptions`, stays healthy) - no certificate
+    // setup needed.
+    it('connect() rejects when the master is unreachable over TLS', async function () {
+      this.timeout(60000);
+
+      sentinel = frame.getSentinelClient({
+        nodeClientOptions: { socket: { tls: true, rejectUnauthorized: false } },
+        maxCommandRediscovers: 2
+      }, false);
+
+      sentinel.on('error', () => { });
+
+      await assert.rejects(sentinel.connect());
+      assert.strictEqual(sentinel.isOpen, false);
+    });
+
     // stops master to force sentinel to update
     it('stop master', async function () {
       this.timeout(60000);

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -915,6 +915,31 @@ export class RedisSentinelInternal<
   }
 
   /**
+   * Waits for a node client's `connect()`, rejecting on the first connection
+   * error instead of waiting for the client to settle.
+   *
+   * Master and replica clients keep the caller's `reconnectStrategy`, which by
+   * default retries forever, so when the resolved node is unreachable (e.g. a
+   * TLS misconfiguration, or a firewalled address — see #3066) their
+   * `connect()` promise never settles and `transform()` would await it
+   * indefinitely. Rejecting on the first connection error hands the failure to
+   * `#connect()`'s retry loop, which re-discovers the topology and, while not
+   * yet ready, gives up after `maxCommandRediscovers` attempts so the public
+   * `connect()` rejects instead of hanging. Per-attempt errors are still
+   * surfaced through the existing `client-error` event (and `error` with
+   * `passthroughClientErrorEvents`), unchanged.
+   */
+  #connectOrFail(client: RedisClientType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping>) {
+    return new Promise<unknown>((resolve, reject) => {
+      const onError = (err: Error) => reject(err);
+      client.once('error', onError);
+      client.connect()
+        .then(resolve, reject)
+        .finally(() => client.off('error', onError));
+    });
+  }
+
+  /**
    * Gets a client lease from the master client pool
    *
    * @returns A client info object or a promise that resolves to a client info object
@@ -964,9 +989,17 @@ export class RedisSentinelInternal<
       this.#connectPromise = this.#connect();
       await this.#connectPromise;
       this.#isReady = true;
+    } catch (err) {
+      // The initial connect gave up. Tear down whatever was created along the
+      // way: clients whose first connection attempt failed keep reconnecting
+      // per their `reconnectStrategy`, and would otherwise stay alive in the
+      // background (holding sockets and timers) after `connect()` rejected.
+      this.#connectPromise = undefined;
+      await this.destroy();
+      throw err;
     } finally {
       this.#connectPromise = undefined;
-      if (this.#scanInterval > 0) {
+      if (this.#isReady && this.#scanInterval > 0) {
         this.#scanTimer = setInterval(this.#reset.bind(this), this.#scanInterval);
       }
     }
@@ -999,9 +1032,6 @@ export class RedisSentinelInternal<
           throw e;
         }
 
-        if (err.message !== 'no valid master node') {
-          console.log(e);
-        }
         await setTimeout(1000);
       } finally {
         this.#trace("finished connect");
@@ -1478,7 +1508,7 @@ export class RedisSentinelInternal<
           client.setDirtyWatch("sentinel config changed in middle of a WATCH Transaction");
         }
         this.#masterClients.push(client);
-        masterPromises.push(client.connect());
+        masterPromises.push(this.#connectOrFail(client));
 
         this.#trace(`created master client to ${analyzed.masterToOpen.host}:${analyzed.masterToOpen.port}`);
       }
@@ -1547,7 +1577,7 @@ export class RedisSentinelInternal<
           });
 
           this.#replicaClients.push(client);
-          promises.push(client.connect());
+          promises.push(this.#connectOrFail(client));
 
           this.#trace(`created replica client to ${node.host}:${node.port}`);
         }


### PR DESCRIPTION
### Description

Fixes #3066. Follow-up to #3329, implementing the approach suggested in its [closing review](https://github.com/redis/node-redis/pull/3329#issuecomment-4933984889): making initial master connection failure observable to `#connect()` so `connect()` rejects instead of hanging.

**Root cause.** When sentinel discovery succeeds but the resolved master is unreachable (a TLS misconfiguration in the original report; equally a firewalled/NATed address), the master clients keep the caller's `reconnectStrategy` — which by default retries forever — so their `connect()` promises never settle. `transform()` awaits them in `Promise.all` indefinitely, `#connect()`'s existing retry/give-up loop is never reached (nothing throws), and the public `connect()` hangs with nothing to observe, catch, or time out on.

**Fix.** `#connectOrFail()` races each master/replica `connect()` against that client's first `'error'` event — which the socket already emits once per failed attempt. This provides both kinds of awareness the review asked for:

- *failure awareness*: immediately-observable failures (ECONNREFUSED, TLS handshake) reject within milliseconds;
- *timeout awareness*: attempts that hit `connectTimeout` surface as a `ConnectionTimeoutError` through the same `'error'` event and reject the same way (exercised by the TLS regression test below).

A rejected round feeds `#connect()`'s existing retry loop, which re-discovers the topology each round — picking up a newly promoted master mid-failover, arguably more correct than retrying a possibly-stale address inside the client — and, while not yet ready, gives up after `maxCommandRediscovers` attempts so `connect()` rejects with the underlying socket error. This mirrors the fail-fast behavior sentinel discovery clients already have via `reconnectStrategy: false`; the retry policy for the initial connect lives in the (already configurable) outer loop rather than inside each node client. An overall initial-connect timeout was considered instead, but it would need a new tunable and would delay detection of immediately-observable failures by a full window per round — happy to rework toward that shape if you'd prefer it.

**Teardown on final failure.** Between rounds, `transform()`'s existing "destroy old clients before opening new ones" step disposes of the previous round's still-retrying clients. On the *final* failure there is no next round, so the internal `connect()` now tears everything down (`destroy()`) before rethrowing — after the rejection nothing keeps reconnecting in the background, no timers hold the event loop open, and the instance is back in a closed state from which `connect()` can be retried. The topology-scan timer is also no longer started for a `connect()` that failed (previously it was started unconditionally in the `finally`, keeping the event loop alive while `#reset()` no-ops when not ready).

**Scope: replicas included.** Replica connections are awaited in the same `Promise.all` and previously hung the exact same way when a replica was unreachable, so the same one-line treatment is applied there. This does not make replicas "more required" than before — the initial connect always awaited them; the change only converts an unbounded hang into the same bounded retry/reject behavior.

**Known limitation (unchanged behavior).** A server that accepts the TCP connection but never responds to the handshake produces no `'error'` event and is not covered here — that is the province of the existing `socketTimeout` option, and standalone `createClient()` behaves identically today.

`console.log(e)` in `#connect()`'s catch is removed rather than converted to an `'error'` emission (per the review of #3329, an unguarded emit in the retry loop can throw `ERR_UNHANDLED_ERROR`): the trace line above it already records the failure, per-attempt errors still flow through the existing `'client-error'` event (and `'error'` with `passthroughClientErrorEvents`), and the terminal failure is now the rejection itself.

**Tests.** Two docker-backed regression tests, both asserting `connect()` rejects and the instance is fully closed afterwards:

1. `nodeAddressMap` remaps only the resolved master to an unreachable address, so sentinel discovery stays healthy throughout (immediate-refusal path). Also asserts no `client-error` events arrive after the rejection, i.e. nothing is left reconnecting in the background.
2. `nodeClientOptions: { socket: { tls: true } }` against the plaintext test topology — reproducing the exact failure mode reported in #3066 (sentinel connects fine, master clients fail TLS) with no certificate setup, and exercising the per-attempt `connectTimeout` path.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)? — `tsc --build` and lint are clean; the full docker-based sentinel suite passes locally on macOS (93 passing, 1 pending) using the Docker Desktop host-networking setup documented in #3330.
- [x] Is the new or changed code fully tested? — two regression tests added and verified passing, plus the full sentinel suite for regressions.
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? — N/A: no API change; `connect()` rejecting on failure is the already-documented contract.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes initial Sentinel connection and teardown behavior on failure; bounded risk to connect/topology paths but affects a critical entry point for all Sentinel users.
> 
> **Overview**
> Fixes **#3066**: when Sentinel discovery works but master/replica nodes cannot be reached, **`connect()` now rejects** instead of hanging forever.
> 
> **`#connectOrFail`** wraps each master/replica `connect()` so the first socket **`error`** rejects immediately (default **`reconnectStrategy`** would otherwise leave those promises pending). Failures feed the existing **`#connect()`** rediscover/retry loop and, after **`maxCommandRediscovers`**, surface as a rejected public **`connect()`**.
> 
> On final connect failure, the client **`destroy()`**s background node clients, leaves **`isOpen` false**, and the topology **scan timer** only starts when connect actually succeeded. A stray **`console.log`** in the connect retry path is removed.
> 
> Docker regression tests cover an unreachable remapped master and TLS-to-plaintext master misconfiguration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04aac8f342fba9c5b336ddb13cf3bbad8b996ce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

