### PR TITLE
docs: update end event description to reference close() and destroy()

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ The Node Redis client class is an Nodejs EventEmitter and it emits an event each
 | ----------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | `connect`               | Initiating a connection to the server                                              | _No arguments_                                            |
 | `ready`                 | Client is ready to use                                                             | _No arguments_                                            |
-| `end`                   | Connection has been closed (via `.disconnect()`)                                   | _No arguments_                                            |
+| `end`                   | Connection has been closed (via `.close()` or `.destroy()`)                        | _No arguments_                                            |
 | `error`                 | An error has occurred—usually a network issue such as "Socket closed unexpectedly" | `(error: Error)`                                          |
 | `reconnecting`          | Client is trying to reconnect to the server                                        | _No arguments_                                            |
 | `sharded-channel-moved` | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event)                          | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event) |


### PR DESCRIPTION
### Description

The events table describes the `end` event as fired "via `.disconnect()`", but `disconnect()` was deprecated in v5 in favour of `destroy()` (and `quit()` in favour of `close()`), as documented in the Disconnecting section of the same README.

Tracing the source, `end` is emitted from `destroySocket()` in `packages/client/lib/client/socket.ts`, which is reached by both `close()` and `destroy()`. `disconnect()` only triggers it indirectly, by forwarding to `destroy()`.

This updates the event description to reference the current methods rather than the deprecated alias.

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)? — README-only change; `npm run lint` reports no JS/TS files to lint. (Note: `npm run build:tests-tools` from CONTRIBUTING.md doesn't exist as a script.)
- [ ] Is the new or changed code fully tested? — N/A, no code changed
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? — this PR is the docs update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation change with no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Events** table in the README so the `end` row matches the v5 disconnect API.
> 
> The `end` event is now described as firing when the connection closes via **`.close()`** or **`.destroy()`**, replacing the outdated **`.disconnect()`** wording. This aligns with the Disconnecting section (`close`/`destroy` replace `quit`/`disconnect`) and with `destroySocket()` in the client, which emits `end` on those paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a15d269c5f5f526c5fdafd4f533ed4f4bdb88ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->