### PR TITLE
fix(client): XGROUP CREATE/SETID with ENTRIESREAD 0 must emit the argument

### DIFF
--- a/packages/client/lib/commands/XGROUP_CREATE.spec.ts
+++ b/packages/client/lib/commands/XGROUP_CREATE.spec.ts
@@ -29,6 +29,15 @@ describe('XGROUP CREATE', () => {
         ['XGROUP', 'CREATE', 'key', 'group', '$', 'ENTRIESREAD', '1']
       );
     });
+
+    it('with ENTRIESREAD 0', () => {
+      assert.deepEqual(
+        parseArgs(XGROUP_CREATE, 'key', 'group', '$', {
+          ENTRIESREAD: 0
+        }),
+        ['XGROUP', 'CREATE', 'key', 'group', '$', 'ENTRIESREAD', '0']
+      );
+    });
   });
 
   testUtils.testAll('xGroupCreate', async client => {

--- a/packages/client/lib/commands/XGROUP_CREATE.ts
+++ b/packages/client/lib/commands/XGROUP_CREATE.ts
@@ -32,7 +32,7 @@ export default {
       parser.push('MKSTREAM');
     }
 
-    if (options?.ENTRIESREAD) {
+    if (options?.ENTRIESREAD !== undefined) {
       parser.push('ENTRIESREAD', options.ENTRIESREAD.toString());
     }
   },

--- a/packages/client/lib/commands/XGROUP_SETID.spec.ts
+++ b/packages/client/lib/commands/XGROUP_SETID.spec.ts
@@ -11,6 +11,15 @@ describe('XGROUP SETID', () => {
     );
   });
 
+  it('transformArguments with ENTRIESREAD 0', () => {
+    assert.deepEqual(
+      parseArgs(XGROUP_SETID, 'key', 'group', '0', {
+        ENTRIESREAD: 0
+      }),
+      ['XGROUP', 'SETID', 'key', 'group', '0', 'ENTRIESREAD', '0']
+    );
+  });
+
   testUtils.testAll('xGroupSetId', async client => {
     const [, reply] = await Promise.all([
       client.xGroupCreate('key', 'group', '$', {

--- a/packages/client/lib/commands/XGROUP_SETID.ts
+++ b/packages/client/lib/commands/XGROUP_SETID.ts
@@ -24,7 +24,7 @@ export default {
     parser.pushKey(key);
     parser.push(group, id);
 
-    if (options?.ENTRIESREAD) {
+    if (options?.ENTRIESREAD !== undefined) {
       parser.push('ENTRIESREAD', options.ENTRIESREAD.toString());
     }
   },


### PR DESCRIPTION
### Description

`XGROUP CREATE key group id ENTRIESREAD 0` and `XGROUP SETID key group id ENTRIESREAD 0` silently drop the `ENTRIESREAD` argument when the value is `0`. Both argument builders guard it with a truthy check (`if (options?.ENTRIESREAD)`), so an explicit `0` never reaches the server.

`ENTRIESREAD 0` is a valid value: it sets a consumer group's entries-read counter (used for lag tracking) to zero, for example when resetting the group. With the current code the argument is omitted, so the counter is left unset instead of `0`.

The fix guards on `!== undefined` in both `XGROUP_CREATE` and `XGROUP_SETID`, so an explicit `0` is forwarded. This matches the recent `XSETID ENTRIESADDED 0` fix (#3324) and `RESTORE IDLETIME/FREQ 0` (#3323).

Added an `ENTRIESREAD 0` `transformArguments` test to both command specs.

### Checklist

- [x] Lint (`eslint --max-warnings=0`), type-check (`tsc --build`), and the `transformArguments` unit tests pass locally. The full `npm test` integration suite runs against Dockerized Redis, which I don't have set up locally, so I relied on CI for that.
- [x] Is the new or changed code fully tested? Added `ENTRIESREAD 0` argument tests for both commands.
- [ ] Documentation update: not applicable, no API surface change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small argument-building fix with added unit tests; no auth, data, or API contract changes beyond correct command encoding.
> 
> **Overview**
> **XGROUP CREATE** and **XGROUP SETID** no longer drop `ENTRIESREAD` when the value is `0`. Both commands now append `ENTRIESREAD` whenever the option is set (`!== undefined`) instead of using a truthy check, so resetting the consumer group entries-read counter to zero reaches Redis as intended.
> 
> Unit tests assert that `transformArguments` includes `ENTRIESREAD` `'0'` for both commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3904d4526669411cf4d90a101f6ec1aba2c5b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->