### PR TITLE
fix: remove dangling agent symlinks that break checkout

### DIFF
--- a/.claude/agents
+++ b/.claude/agents
@@ -1,1 +1,0 @@
-../.agents/agents

--- a/.gemini/agents
+++ b/.gemini/agents
@@ -1,1 +1,0 @@
-../.agents/agents


### PR DESCRIPTION
## Problem

`.gemini/agents` and `.claude/agents` were committed in #3316 as symlinks pointing at `../.agents/agents` — a directory that was never created (only `.agents/skills` exists). Both links dangle.

GitHub Actions staging refuses dangling symlinks. Any job that checks out `redis/node-redis@master` (e.g. the redis-oss release-automation `node-redis test` job) fails during **Set up job** before any test runs:

```
##[error]Could not find file '.../node-redis-<sha>/.gemini/agents'.
```

## Fix

Remove both broken symlinks. The valid `.claude/skills` -> `../.agents/skills` link, `CLAUDE.md`, and `GEMINI.md` are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo-metadata-only deletion of invalid symlinks; no runtime, auth, or library code changes.
> 
> **Overview**
> Removes the broken `.claude/agents` and `.gemini/agents` symlinks that pointed at `../.agents/agents`, which was never added to the repo.
> 
> That fixes GitHub Actions checkouts that fail when staging refuses dangling symlinks (for example release-automation jobs that clone `master` before tests run). Other agent tooling such as `.claude/skills` → `../.agents/skills` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5266de7985be6c68a4051973108ff7cb7a3bd8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->