### PR TITLE
feat(client): add SUNIONCARD and SDIFFCARD set cardinality commands

### DIFF
--- a/packages/client/lib/commands/SDIFFCARD.spec.ts
+++ b/packages/client/lib/commands/SDIFFCARD.spec.ts
@@ -1,0 +1,34 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import SDIFFCARD from './SDIFFCARD';
+import { parseArgs } from './generic-transformers';
+
+describe('SDIFFCARD', () => {
+  describe('transformArguments', () => {
+    it('simple', () => {
+      assert.deepEqual(
+        parseArgs(SDIFFCARD, ['1', '2']),
+        ['SDIFFCARD', '2', '1', '2']
+      );
+    });
+
+    it('with LIMIT', () => {
+      assert.deepEqual(
+        parseArgs(SDIFFCARD, ['1', '2'], {
+          LIMIT: 3
+        }),
+        ['SDIFFCARD', '2', '1', '2', 'LIMIT', '3']
+      );
+    });
+  });
+
+  testUtils.testAll('sDiffCard', async client => {
+    assert.equal(
+      await client.sDiffCard('key'),
+      0
+    );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/SDIFFCARD.spec.ts
+++ b/packages/client/lib/commands/SDIFFCARD.spec.ts
@@ -4,6 +4,8 @@ import SDIFFCARD from './SDIFFCARD';
 import { parseArgs } from './generic-transformers';
 
 describe('SDIFFCARD', () => {
+  testUtils.isVersionGreaterThanHook([8, 10]);
+
   describe('transformArguments', () => {
     it('simple', () => {
       assert.deepEqual(

--- a/packages/client/lib/commands/SDIFFCARD.ts
+++ b/packages/client/lib/commands/SDIFFCARD.ts
@@ -1,0 +1,25 @@
+import { CommandParser } from '../client/parser';
+import { NumberReply, Command } from '../RESP/types';
+import { RedisVariadicArgument } from './generic-transformers';
+
+/**
+ * Options for the SDIFFCARD command
+ *
+ * @property LIMIT - Cap the returned cardinality at this value; `LIMIT 0` means no limit
+ */
+export interface SDiffCardOptions {
+  LIMIT?: number;
+}
+
+export default {
+  IS_READ_ONLY: true,
+  parseCommand(parser: CommandParser, keys: RedisVariadicArgument, options?: SDiffCardOptions) {
+    parser.push('SDIFFCARD');
+    parser.pushKeysLength(keys);
+
+    if (options?.LIMIT !== undefined) {
+      parser.push('LIMIT', options.LIMIT.toString());
+    }
+  },
+  transformReply: undefined as unknown as () => NumberReply
+} as const satisfies Command;

--- a/packages/client/lib/commands/SUNIONCARD.spec.ts
+++ b/packages/client/lib/commands/SUNIONCARD.spec.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import SUNIONCARD from './SUNIONCARD';
+import { parseArgs } from './generic-transformers';
+
+describe('SUNIONCARD', () => {
+  describe('transformArguments', () => {
+    it('simple', () => {
+      assert.deepEqual(
+        parseArgs(SUNIONCARD, ['1', '2']),
+        ['SUNIONCARD', '2', '1', '2']
+      );
+    });
+
+    it('with APPROX', () => {
+      assert.deepEqual(
+        parseArgs(SUNIONCARD, ['1', '2'], {
+          APPROX: true
+        }),
+        ['SUNIONCARD', '2', '1', '2', 'APPROX']
+      );
+    });
+
+    it('with LIMIT', () => {
+      assert.deepEqual(
+        parseArgs(SUNIONCARD, ['1', '2'], {
+          LIMIT: 3
+        }),
+        ['SUNIONCARD', '2', '1', '2', 'LIMIT', '3']
+      );
+    });
+
+    it('with APPROX and LIMIT', () => {
+      assert.deepEqual(
+        parseArgs(SUNIONCARD, ['1', '2'], {
+          APPROX: true,
+          LIMIT: 3
+        }),
+        ['SUNIONCARD', '2', '1', '2', 'APPROX', 'LIMIT', '3']
+      );
+    });
+  });
+
+  testUtils.testAll('sUnionCard', async client => {
+    assert.equal(
+      await client.sUnionCard('key'),
+      0
+    );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/SUNIONCARD.spec.ts
+++ b/packages/client/lib/commands/SUNIONCARD.spec.ts
@@ -4,6 +4,8 @@ import SUNIONCARD from './SUNIONCARD';
 import { parseArgs } from './generic-transformers';
 
 describe('SUNIONCARD', () => {
+  testUtils.isVersionGreaterThanHook([8, 10]);
+
   describe('transformArguments', () => {
     it('simple', () => {
       assert.deepEqual(

--- a/packages/client/lib/commands/SUNIONCARD.ts
+++ b/packages/client/lib/commands/SUNIONCARD.ts
@@ -1,0 +1,31 @@
+import { CommandParser } from '../client/parser';
+import { NumberReply, Command } from '../RESP/types';
+import { RedisVariadicArgument } from './generic-transformers';
+
+/**
+ * Options for the SUNIONCARD command
+ *
+ * @property APPROX - When true, return an approximate cardinality using HyperLogLog
+ * @property LIMIT - Cap the returned cardinality at this value; `LIMIT 0` means no limit
+ */
+export interface SUnionCardOptions {
+  APPROX?: boolean;
+  LIMIT?: number;
+}
+
+export default {
+  IS_READ_ONLY: true,
+  parseCommand(parser: CommandParser, keys: RedisVariadicArgument, options?: SUnionCardOptions) {
+    parser.push('SUNIONCARD');
+    parser.pushKeysLength(keys);
+
+    if (options?.APPROX) {
+      parser.push('APPROX');
+    }
+
+    if (options?.LIMIT !== undefined) {
+      parser.push('LIMIT', options.LIMIT.toString());
+    }
+  },
+  transformReply: undefined as unknown as () => NumberReply
+} as const satisfies Command;

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -4059,16 +4059,20 @@ export default {
   sDiff: SDIFF,
   /**
    * Constructs the SDIFFCARD command to return the cardinality of the difference between the first set and all successive sets
+   * Added since Redis 8.10.
    *
    * @param keys - One or more set keys; the first is the minuend, the rest are subtrahends
    * @param options - Options for the SDIFFCARD command
+   * @see https://redis.io/commands/sdiffcard/
    */
   SDIFFCARD,
   /**
    * Constructs the SDIFFCARD command to return the cardinality of the difference between the first set and all successive sets
+   * Added since Redis 8.10.
    *
    * @param keys - One or more set keys; the first is the minuend, the rest are subtrahends
    * @param options - Options for the SDIFFCARD command
+   * @see https://redis.io/commands/sdiffcard/
    */
   sDiffCard: SDIFFCARD,
   /**
@@ -4473,16 +4477,20 @@ export default {
   sUnion: SUNION,
   /**
    * Constructs the SUNIONCARD command to return the cardinality of the union of all the given sets
+   * Added since Redis 8.10.
    *
    * @param keys - One or more set keys to union
    * @param options - Options for the SUNIONCARD command (APPROX, LIMIT)
+   * @see https://redis.io/commands/sunioncard/
    */
   SUNIONCARD,
   /**
    * Constructs the SUNIONCARD command to return the cardinality of the union of all the given sets
+   * Added since Redis 8.10.
    *
    * @param keys - One or more set keys to union
    * @param options - Options for the SUNIONCARD command (APPROX, LIMIT)
+   * @see https://redis.io/commands/sunioncard/
    */
   sUnionCard: SUNIONCARD,
   /**

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -276,6 +276,7 @@ import SCRIPT_FLUSH from './SCRIPT_FLUSH';
 import SCRIPT_KILL from './SCRIPT_KILL';
 import SCRIPT_LOAD from './SCRIPT_LOAD';
 import SDIFF from './SDIFF';
+import SDIFFCARD from './SDIFFCARD';
 import SDIFFSTORE from './SDIFFSTORE';
 import SET from './SET';
 import SETBIT from './SETBIT';
@@ -301,6 +302,7 @@ import SREM from './SREM';
 import SSCAN from './SSCAN';
 import STRLEN from './STRLEN';
 import SUNION from './SUNION';
+import SUNIONCARD from './SUNIONCARD';
 import SUNIONSTORE from './SUNIONSTORE';
 import SWAPDB from './SWAPDB';
 import TIME from './TIME';
@@ -4056,6 +4058,20 @@ export default {
    */
   sDiff: SDIFF,
   /**
+   * Constructs the SDIFFCARD command to return the cardinality of the difference between the first set and all successive sets
+   *
+   * @param keys - One or more set keys; the first is the minuend, the rest are subtrahends
+   * @param options - Options for the SDIFFCARD command
+   */
+  SDIFFCARD,
+  /**
+   * Constructs the SDIFFCARD command to return the cardinality of the difference between the first set and all successive sets
+   *
+   * @param keys - One or more set keys; the first is the minuend, the rest are subtrahends
+   * @param options - Options for the SDIFFCARD command
+   */
+  sDiffCard: SDIFFCARD,
+  /**
    * Constructs the SDIFFSTORE command
    *
    * @param destination - The destination key to store the result
@@ -4455,6 +4471,20 @@ export default {
    * @see https://redis.io/commands/sunion/
    */
   sUnion: SUNION,
+  /**
+   * Constructs the SUNIONCARD command to return the cardinality of the union of all the given sets
+   *
+   * @param keys - One or more set keys to union
+   * @param options - Options for the SUNIONCARD command (APPROX, LIMIT)
+   */
+  SUNIONCARD,
+  /**
+   * Constructs the SUNIONCARD command to return the cardinality of the union of all the given sets
+   *
+   * @param keys - One or more set keys to union
+   * @param options - Options for the SUNIONCARD command (APPROX, LIMIT)
+   */
+  sUnionCard: SUNIONCARD,
   /**
    * Constructs the SUNIONSTORE command to store the union of multiple sets into a destination set
    *


### PR DESCRIPTION
This pull request adds support for the Redis 8.10 set cardinality commands `SUNIONCARD` and `SDIFFCARD`.

Both commands compute the cardinality of a derived set operation in a single read-only command without materializing or returning the derived set:

- `SUNIONCARD numkeys key [key ...] [APPROX] [LIMIT limit]` — distinct-element count of the union of the given sets. Supports exact mode (default), optional `APPROX` (HyperLogLog estimate), and optional `LIMIT` cap (`LIMIT 0` = no limit). Options emitted in canonical order `APPROX` before `LIMIT`.
- `SDIFFCARD numkeys key [key ...] [LIMIT limit]` — element count of the difference between the first set and all successive sets. Exact mode with optional `LIMIT`. `APPROX` is intentionally not exposed (out of scope until server semantics are defined; the server rejects it with a syntax error).

Both use `pushKeysLength` for the `numkeys`-prefixed key list, are flagged `IS_READ_ONLY`, and return a `NumberReply`. Server errors propagate unchanged; no client-side validation is added. Registered under raw (`SUNIONCARD`/`SDIFFCARD`) and camelCase (`sUnionCard`/`sDiffCard`) names.

Behavior considerations: exact `LIMIT` returns `min(realCardinality, limit)`; `APPROX` results are approximate integers not exceeding `limit`. No backward-compatibility risk — new commands only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only command definitions mirroring SINTERCARD; no changes to existing behavior.
> 
> **Overview**
> Adds **Redis 8.10** client support for **`SUNIONCARD`** and **`SDIFFCARD`**, read-only commands that return set union or set-difference **cardinality** without materializing members.
> 
> Each command is implemented with `pushKeysLength`, `IS_READ_ONLY`, and a `NumberReply`. **`SUNIONCARD`** accepts optional **`APPROX`** (HyperLogLog) and **`LIMIT`** (emitted as `APPROX` then `LIMIT`). **`SDIFFCARD`** only exposes **`LIMIT`**; **`APPROX`** is not wired on the client. Both are registered in the command index as raw and camelCase (`sUnionCard` / `sDiffCard`). Specs cover argument encoding and integration tests gated on Redis ≥ 8.10.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105ce3fafe356355d704bbda6a96477c3d778b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->