### PR TITLE
feat(client): add LMOVEM and BLMOVEM commands

### DIFF
--- a/packages/client/lib/commands/BLMOVEM.spec.ts
+++ b/packages/client/lib/commands/BLMOVEM.spec.ts
@@ -4,6 +4,8 @@ import BLMOVEM from './BLMOVEM';
 import { parseArgs } from './generic-transformers';
 
 describe('BLMOVEM', () => {
+  testUtils.isVersionGreaterThanHook([8, 10]);
+
   describe('transformArguments', () => {
     it('simple', () => {
       assert.deepEqual(

--- a/packages/client/lib/commands/BLMOVEM.spec.ts
+++ b/packages/client/lib/commands/BLMOVEM.spec.ts
@@ -1,0 +1,59 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL, BLOCKING_MIN_VALUE } from '../test-utils';
+import BLMOVEM from './BLMOVEM';
+import { parseArgs } from './generic-transformers';
+
+describe('BLMOVEM', () => {
+  describe('transformArguments', () => {
+    it('simple', () => {
+      assert.deepEqual(
+        parseArgs(BLMOVEM, 'source', 'destination', 'LEFT', 'RIGHT', 0),
+        ['BLMOVEM', 'source', 'destination', 'LEFT', 'RIGHT', '0']
+      );
+    });
+
+    it('with COUNT and ORDER', () => {
+      assert.deepEqual(
+        parseArgs(BLMOVEM, 'source', 'destination', 'LEFT', 'LEFT', 0, {
+          COUNT: 3,
+          ORDER: 'OBO'
+        }),
+        ['BLMOVEM', 'source', 'destination', 'LEFT', 'LEFT', '0', 'COUNT', '3', 'OBO']
+      );
+    });
+
+    it('with EXACTLY and ORDER', () => {
+      assert.deepEqual(
+        parseArgs(BLMOVEM, 'source', 'destination', 'LEFT', 'RIGHT', 0, {
+          EXACTLY: 2,
+          ORDER: 'BULK'
+        }),
+        ['BLMOVEM', 'source', 'destination', 'LEFT', 'RIGHT', '0', 'EXACTLY', '2', 'BULK']
+      );
+    });
+  });
+
+  testUtils.testAll('blMoveM - null on timeout', async client => {
+    assert.equal(
+      await client.blMoveM('{tag}source', '{tag}destination', 'LEFT', 'RIGHT', BLOCKING_MIN_VALUE),
+      null
+    );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('blMoveM - with elements', async client => {
+    const [, reply] = await Promise.all([
+      client.rPush('{tag}source', ['1', '2', '3']),
+      client.blMoveM('{tag}source', '{tag}destination', 'LEFT', 'LEFT', BLOCKING_MIN_VALUE, {
+        COUNT: 2,
+        ORDER: 'BULK'
+      })
+    ]);
+    assert.deepEqual(reply, ['1', '2']);
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/BLMOVEM.ts
+++ b/packages/client/lib/commands/BLMOVEM.ts
@@ -1,7 +1,7 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, Command } from '../RESP/types';
 import { ListSide } from './generic-transformers';
-import LMOVEM, { LMoveMOptions } from './LMOVEM';
+import LMOVEM, { LMoveMOptions, parseLMoveMOptions } from './LMOVEM';
 
 export default {
   IS_READ_ONLY: false,
@@ -17,18 +17,7 @@ export default {
     parser.push('BLMOVEM');
     parser.pushKeys([source, destination]);
     parser.push(sourceSide, destinationSide, timeout.toString());
-
-    if (options) {
-      if ('EXACTLY' in options) {
-        parser.push('EXACTLY', options.EXACTLY.toString());
-      } else {
-        parser.push('COUNT', options.COUNT.toString());
-      }
-
-      if (options.ORDER !== undefined) {
-        parser.push(options.ORDER);
-      }
-    }
+    parseLMoveMOptions(parser, options);
   },
   transformReply: LMOVEM.transformReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/BLMOVEM.ts
+++ b/packages/client/lib/commands/BLMOVEM.ts
@@ -1,0 +1,34 @@
+import { CommandParser } from '../client/parser';
+import { RedisArgument, Command } from '../RESP/types';
+import { ListSide } from './generic-transformers';
+import LMOVEM, { LMoveMOptions } from './LMOVEM';
+
+export default {
+  IS_READ_ONLY: false,
+  parseCommand(
+    parser: CommandParser,
+    source: RedisArgument,
+    destination: RedisArgument,
+    sourceSide: ListSide,
+    destinationSide: ListSide,
+    timeout: number,
+    options?: LMoveMOptions
+  ) {
+    parser.push('BLMOVEM');
+    parser.pushKeys([source, destination]);
+    parser.push(sourceSide, destinationSide, timeout.toString());
+
+    if (options) {
+      if ('EXACTLY' in options) {
+        parser.push('EXACTLY', options.EXACTLY.toString());
+      } else {
+        parser.push('COUNT', options.COUNT.toString());
+      }
+
+      if (options.ORDER !== undefined) {
+        parser.push(options.ORDER);
+      }
+    }
+  },
+  transformReply: LMOVEM.transformReply
+} as const satisfies Command;

--- a/packages/client/lib/commands/LMOVEM.spec.ts
+++ b/packages/client/lib/commands/LMOVEM.spec.ts
@@ -4,6 +4,8 @@ import LMOVEM from './LMOVEM';
 import { parseArgs } from './generic-transformers';
 
 describe('LMOVEM', () => {
+  testUtils.isVersionGreaterThanHook([8, 10]);
+
   describe('transformArguments', () => {
     it('simple', () => {
       assert.deepEqual(

--- a/packages/client/lib/commands/LMOVEM.spec.ts
+++ b/packages/client/lib/commands/LMOVEM.spec.ts
@@ -1,0 +1,94 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import LMOVEM from './LMOVEM';
+import { parseArgs } from './generic-transformers';
+
+describe('LMOVEM', () => {
+  describe('transformArguments', () => {
+    it('simple', () => {
+      assert.deepEqual(
+        parseArgs(LMOVEM, 'source', 'destination', 'LEFT', 'RIGHT'),
+        ['LMOVEM', 'source', 'destination', 'LEFT', 'RIGHT']
+      );
+    });
+
+    it('with COUNT', () => {
+      assert.deepEqual(
+        parseArgs(LMOVEM, 'source', 'destination', 'LEFT', 'RIGHT', {
+          COUNT: 3
+        }),
+        ['LMOVEM', 'source', 'destination', 'LEFT', 'RIGHT', 'COUNT', '3']
+      );
+    });
+
+    it('with COUNT and ORDER', () => {
+      assert.deepEqual(
+        parseArgs(LMOVEM, 'source', 'destination', 'LEFT', 'LEFT', {
+          COUNT: 3,
+          ORDER: 'OBO'
+        }),
+        ['LMOVEM', 'source', 'destination', 'LEFT', 'LEFT', 'COUNT', '3', 'OBO']
+      );
+    });
+
+    it('with EXACTLY and ORDER', () => {
+      assert.deepEqual(
+        parseArgs(LMOVEM, 'source', 'destination', 'LEFT', 'RIGHT', {
+          EXACTLY: 2,
+          ORDER: 'BULK'
+        }),
+        ['LMOVEM', 'source', 'destination', 'LEFT', 'RIGHT', 'EXACTLY', '2', 'BULK']
+      );
+    });
+  });
+
+  testUtils.testAll('lMoveM - null when source empty', async client => {
+    assert.equal(
+      await client.lMoveM('{tag}source', '{tag}destination', 'LEFT', 'RIGHT'),
+      null
+    );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('lMoveM - COUNT with OBO ordering', async client => {
+    await client.rPush('{tag}source', ['1', '2', '3', '4', '5']);
+    assert.deepEqual(
+      await client.lMoveM('{tag}source', '{tag}destination', 'LEFT', 'LEFT', {
+        COUNT: 3,
+        ORDER: 'OBO'
+      }),
+      ['3', '2', '1']
+    );
+    assert.deepEqual(
+      await client.lRange('{tag}destination', 0, -1),
+      ['3', '2', '1']
+    );
+    assert.deepEqual(
+      await client.lRange('{tag}source', 0, -1),
+      ['4', '5']
+    );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('lMoveM - COUNT with BULK ordering', async client => {
+    await client.rPush('{tag}source', ['1', '2', '3', '4', '5']);
+    assert.deepEqual(
+      await client.lMoveM('{tag}source', '{tag}destination', 'LEFT', 'LEFT', {
+        COUNT: 3,
+        ORDER: 'BULK'
+      }),
+      ['1', '2', '3']
+    );
+    assert.deepEqual(
+      await client.lRange('{tag}destination', 0, -1),
+      ['1', '2', '3']
+    );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/LMOVEM.spec.ts
+++ b/packages/client/lib/commands/LMOVEM.spec.ts
@@ -93,4 +93,52 @@ describe('LMOVEM', () => {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN
   });
+
+  testUtils.testAll('lMoveM - no options moves a single element as an array', async client => {
+    await client.rPush('{tag}source', ['1', '2', '3']);
+    assert.deepEqual(
+      await client.lMoveM('{tag}source', '{tag}destination', 'LEFT', 'RIGHT'),
+      ['1']
+    );
+    assert.deepEqual(
+      await client.lRange('{tag}source', 0, -1),
+      ['2', '3']
+    );
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('lMoveM - COUNT clamps to available elements', async client => {
+    await client.rPush('{tag}source', ['1', '2', '3']);
+    assert.deepEqual(
+      await client.lMoveM('{tag}source', '{tag}destination', 'LEFT', 'LEFT', {
+        COUNT: 10,
+        ORDER: 'BULK'
+      }),
+      ['1', '2', '3']
+    );
+    assert.equal(await client.exists('{tag}source'), 0);
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
+
+  testUtils.testAll('lMoveM - EXACTLY with too few elements moves nothing', async client => {
+    await client.rPush('{tag}source', ['1', '2']);
+    await assert.rejects(
+      client.lMoveM('{tag}source', '{tag}destination', 'LEFT', 'RIGHT', {
+        EXACTLY: 3,
+        ORDER: 'BULK'
+      })
+    );
+    assert.deepEqual(
+      await client.lRange('{tag}source', 0, -1),
+      ['1', '2']
+    );
+    assert.equal(await client.exists('{tag}destination'), 0);
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
 });

--- a/packages/client/lib/commands/LMOVEM.spec.ts
+++ b/packages/client/lib/commands/LMOVEM.spec.ts
@@ -126,11 +126,12 @@ describe('LMOVEM', () => {
 
   testUtils.testAll('lMoveM - EXACTLY with too few elements moves nothing', async client => {
     await client.rPush('{tag}source', ['1', '2']);
-    await assert.rejects(
-      client.lMoveM('{tag}source', '{tag}destination', 'LEFT', 'RIGHT', {
+    assert.equal(
+      await client.lMoveM('{tag}source', '{tag}destination', 'LEFT', 'RIGHT', {
         EXACTLY: 3,
         ORDER: 'BULK'
-      })
+      }),
+      null
     );
     assert.deepEqual(
       await client.lRange('{tag}source', 0, -1),

--- a/packages/client/lib/commands/LMOVEM.spec.ts
+++ b/packages/client/lib/commands/LMOVEM.spec.ts
@@ -14,15 +14,6 @@ describe('LMOVEM', () => {
       );
     });
 
-    it('with COUNT', () => {
-      assert.deepEqual(
-        parseArgs(LMOVEM, 'source', 'destination', 'LEFT', 'RIGHT', {
-          COUNT: 3
-        }),
-        ['LMOVEM', 'source', 'destination', 'LEFT', 'RIGHT', 'COUNT', '3']
-      );
-    });
-
     it('with COUNT and ORDER', () => {
       assert.deepEqual(
         parseArgs(LMOVEM, 'source', 'destination', 'LEFT', 'LEFT', {

--- a/packages/client/lib/commands/LMOVEM.ts
+++ b/packages/client/lib/commands/LMOVEM.ts
@@ -21,30 +21,6 @@ export type LMoveMOptions = {
   ORDER?: LMoveMOrder;
 };
 
-export function parseLMoveMArguments(
-  parser: CommandParser,
-  source: RedisArgument,
-  destination: RedisArgument,
-  sourceSide: ListSide,
-  destinationSide: ListSide,
-  options?: LMoveMOptions
-) {
-  parser.pushKeys([source, destination]);
-  parser.push(sourceSide, destinationSide);
-
-  if (options) {
-    if ('EXACTLY' in options) {
-      parser.push('EXACTLY', options.EXACTLY.toString());
-    } else {
-      parser.push('COUNT', options.COUNT.toString());
-    }
-
-    if (options.ORDER !== undefined) {
-      parser.push(options.ORDER);
-    }
-  }
-}
-
 export default {
   IS_READ_ONLY: false,
   parseCommand(
@@ -56,7 +32,20 @@ export default {
     options?: LMoveMOptions
   ) {
     parser.push('LMOVEM');
-    parseLMoveMArguments(parser, source, destination, sourceSide, destinationSide, options);
+    parser.pushKeys([source, destination]);
+    parser.push(sourceSide, destinationSide);
+
+    if (options) {
+      if ('EXACTLY' in options) {
+        parser.push('EXACTLY', options.EXACTLY.toString());
+      } else {
+        parser.push('COUNT', options.COUNT.toString());
+      }
+
+      if (options.ORDER !== undefined) {
+        parser.push(options.ORDER);
+      }
+    }
   },
   transformReply: undefined as unknown as () => ArrayReply<BlobStringReply> | NullReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/LMOVEM.ts
+++ b/packages/client/lib/commands/LMOVEM.ts
@@ -16,7 +16,7 @@ export type LMoveMOptions = {
   COUNT: number;
   ORDER?: LMoveMOrder;
 } | {
-  /** Move exactly `EXACTLY` elements; if the source has fewer, move nothing. */
+  /** Move exactly `EXACTLY` elements; if the source has fewer, move nothing and reply with null. */
   EXACTLY: number;
   ORDER?: LMoveMOrder;
 };

--- a/packages/client/lib/commands/LMOVEM.ts
+++ b/packages/client/lib/commands/LMOVEM.ts
@@ -1,0 +1,62 @@
+import { CommandParser } from '../client/parser';
+import { RedisArgument, ArrayReply, BlobStringReply, NullReply, Command } from '../RESP/types';
+import { ListSide } from './generic-transformers';
+
+/**
+ * Ordering of the moved elements at the destination.
+ *
+ * - `OBO` (one-by-one): push each element as it is popped, reversing the
+ *   moved block's relative order (stack semantics).
+ * - `BULK`: preserve the moved block's original relative order (queue semantics).
+ */
+export type LMoveMOrder = 'OBO' | 'BULK';
+
+export type LMoveMOptions = {
+  /** Move up to `COUNT` elements (fewer if the source has fewer). */
+  COUNT: number;
+  ORDER?: LMoveMOrder;
+} | {
+  /** Move exactly `EXACTLY` elements; if the source has fewer, move nothing. */
+  EXACTLY: number;
+  ORDER?: LMoveMOrder;
+};
+
+export function parseLMoveMArguments(
+  parser: CommandParser,
+  source: RedisArgument,
+  destination: RedisArgument,
+  sourceSide: ListSide,
+  destinationSide: ListSide,
+  options?: LMoveMOptions
+) {
+  parser.pushKeys([source, destination]);
+  parser.push(sourceSide, destinationSide);
+
+  if (options) {
+    if ('EXACTLY' in options) {
+      parser.push('EXACTLY', options.EXACTLY.toString());
+    } else {
+      parser.push('COUNT', options.COUNT.toString());
+    }
+
+    if (options.ORDER !== undefined) {
+      parser.push(options.ORDER);
+    }
+  }
+}
+
+export default {
+  IS_READ_ONLY: false,
+  parseCommand(
+    parser: CommandParser,
+    source: RedisArgument,
+    destination: RedisArgument,
+    sourceSide: ListSide,
+    destinationSide: ListSide,
+    options?: LMoveMOptions
+  ) {
+    parser.push('LMOVEM');
+    parseLMoveMArguments(parser, source, destination, sourceSide, destinationSide, options);
+  },
+  transformReply: undefined as unknown as () => ArrayReply<BlobStringReply> | NullReply
+} as const satisfies Command;

--- a/packages/client/lib/commands/LMOVEM.ts
+++ b/packages/client/lib/commands/LMOVEM.ts
@@ -21,6 +21,25 @@ export type LMoveMOptions = {
   ORDER?: LMoveMOrder;
 };
 
+/**
+ * Pushes the trailing `[<COUNT|EXACTLY> count [OBO|BULK]]` arguments shared by
+ * LMOVEM and BLMOVEM. Kept separate from the command bodies because BLMOVEM's
+ * `timeout` sits between the sides and these options, so only the tail is shared.
+ */
+export function parseLMoveMOptions(parser: CommandParser, options?: LMoveMOptions) {
+  if (options) {
+    if ('EXACTLY' in options) {
+      parser.push('EXACTLY', options.EXACTLY.toString());
+    } else {
+      parser.push('COUNT', options.COUNT.toString());
+    }
+
+    if (options.ORDER !== undefined) {
+      parser.push(options.ORDER);
+    }
+  }
+}
+
 export default {
   IS_READ_ONLY: false,
   parseCommand(
@@ -34,18 +53,7 @@ export default {
     parser.push('LMOVEM');
     parser.pushKeys([source, destination]);
     parser.push(sourceSide, destinationSide);
-
-    if (options) {
-      if ('EXACTLY' in options) {
-        parser.push('EXACTLY', options.EXACTLY.toString());
-      } else {
-        parser.push('COUNT', options.COUNT.toString());
-      }
-
-      if (options.ORDER !== undefined) {
-        parser.push(options.ORDER);
-      }
-    }
+    parseLMoveMOptions(parser, options);
   },
   transformReply: undefined as unknown as () => ArrayReply<BlobStringReply> | NullReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/LMOVEM.ts
+++ b/packages/client/lib/commands/LMOVEM.ts
@@ -14,17 +14,19 @@ export type LMoveMOrder = 'OBO' | 'BULK';
 export type LMoveMOptions = {
   /** Move up to `COUNT` elements (fewer if the source has fewer). */
   COUNT: number;
-  ORDER?: LMoveMOrder;
+  ORDER: LMoveMOrder;
 } | {
   /** Move exactly `EXACTLY` elements; if the source has fewer, move nothing and reply with null. */
   EXACTLY: number;
-  ORDER?: LMoveMOrder;
+  ORDER: LMoveMOrder;
 };
 
 /**
- * Pushes the trailing `[<COUNT|EXACTLY> count [OBO|BULK]]` arguments shared by
+ * Pushes the trailing `[<COUNT|EXACTLY> count <OBO|BULK>]` arguments shared by
  * LMOVEM and BLMOVEM. Kept separate from the command bodies because BLMOVEM's
  * `timeout` sits between the sides and these options, so only the tail is shared.
+ * `ORDER` is required whenever the block is present: Redis rejects the trailer
+ * without it as a syntax error.
  */
 export function parseLMoveMOptions(parser: CommandParser, options?: LMoveMOptions) {
   if (options) {
@@ -34,9 +36,7 @@ export function parseLMoveMOptions(parser: CommandParser, options?: LMoveMOption
       parser.push('COUNT', options.COUNT.toString());
     }
 
-    if (options.ORDER !== undefined) {
-      parser.push(options.ORDER);
-    }
+    parser.push(options.ORDER);
   }
 }
 

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -961,6 +961,7 @@ export default {
    * @param destinationSide - Side of destination list to push to (LEFT or RIGHT)
    * @param timeout - Timeout in seconds, 0 to block indefinitely
    * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   * @since 8.10
    */
   BLMOVEM,
   /**
@@ -971,6 +972,7 @@ export default {
    * @param destinationSide - Side of destination list to push to (LEFT or RIGHT)
    * @param timeout - Timeout in seconds, 0 to block indefinitely
    * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   * @since 8.10
    */
   blMoveM: BLMOVEM,
   /**
@@ -3067,6 +3069,7 @@ export default {
    * @param sourceSide - The side to pop from (LEFT or RIGHT)
    * @param destinationSide - The side to push to (LEFT or RIGHT)
    * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   * @since 8.10
    */
   LMOVEM,
   /**
@@ -3077,6 +3080,7 @@ export default {
    * @param sourceSide - The side to pop from (LEFT or RIGHT)
    * @param destinationSide - The side to push to (LEFT or RIGHT)
    * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   * @since 8.10
    */
   lMoveM: LMOVEM,
   /**

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -42,6 +42,7 @@ import BITFIELD from './BITFIELD';
 import BITOP from './BITOP';
 import BITPOS from './BITPOS';
 import BLMOVE from './BLMOVE';
+import BLMOVEM from './BLMOVEM';
 import BLMPOP from './BLMPOP';
 import BLPOP from './BLPOP';
 import BRPOP from './BRPOP';
@@ -208,6 +209,7 @@ import LINDEX from './LINDEX';
 import LINSERT from './LINSERT';
 import LLEN from './LLEN';
 import LMOVE from './LMOVE';
+import LMOVEM from './LMOVEM';
 import LMPOP from './LMPOP';
 import LOLWUT from './LOLWUT';
 import LPOP_COUNT from './LPOP_COUNT';
@@ -951,6 +953,26 @@ export default {
    * @param timeout - Timeout in seconds, 0 to block indefinitely
    */
   blMove: BLMOVE,
+  /**
+   * Moves multiple elements from one list to another, blocking until enough elements are available
+   * @param source - Key of the source list
+   * @param destination - Key of the destination list
+   * @param sourceSide - Side of source list to pop from (LEFT or RIGHT)
+   * @param destinationSide - Side of destination list to push to (LEFT or RIGHT)
+   * @param timeout - Timeout in seconds, 0 to block indefinitely
+   * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   */
+  BLMOVEM,
+  /**
+   * Moves multiple elements from one list to another, blocking until enough elements are available
+   * @param source - Key of the source list
+   * @param destination - Key of the destination list
+   * @param sourceSide - Side of source list to pop from (LEFT or RIGHT)
+   * @param destinationSide - Side of destination list to push to (LEFT or RIGHT)
+   * @param timeout - Timeout in seconds, 0 to block indefinitely
+   * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   */
+  blMoveM: BLMOVEM,
   /**
    * Pops elements from multiple lists; blocks until elements are available
    * @param timeout - Timeout in seconds, 0 to block indefinitely
@@ -3037,6 +3059,26 @@ export default {
    * @see https://redis.io/commands/lmove/
    */
   lMove: LMOVE,
+  /**
+   * Moves multiple elements from one list to another
+   *
+   * @param source - The source list key
+   * @param destination - The destination list key
+   * @param sourceSide - The side to pop from (LEFT or RIGHT)
+   * @param destinationSide - The side to push to (LEFT or RIGHT)
+   * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   */
+  LMOVEM,
+  /**
+   * Moves multiple elements from one list to another
+   *
+   * @param source - The source list key
+   * @param destination - The destination list key
+   * @param sourceSide - The side to pop from (LEFT or RIGHT)
+   * @param destinationSide - The side to push to (LEFT or RIGHT)
+   * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   */
+  lMoveM: LMOVEM,
   /**
    * Constructs the LMPOP command
    *

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -954,24 +954,26 @@ export default {
    */
   blMove: BLMOVE,
   /**
-   * Moves multiple elements from one list to another, blocking until enough elements are available
+   * Moves multiple elements from one list to another; or blocks until the source has elements to move
    * @param source - Key of the source list
    * @param destination - Key of the destination list
    * @param sourceSide - Side of source list to pop from (LEFT or RIGHT)
    * @param destinationSide - Side of destination list to push to (LEFT or RIGHT)
    * @param timeout - Timeout in seconds, 0 to block indefinitely
    * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   * @see https://redis.io/commands/blmovem/
    * @since 8.10
    */
   BLMOVEM,
   /**
-   * Moves multiple elements from one list to another, blocking until enough elements are available
+   * Moves multiple elements from one list to another; or blocks until the source has elements to move
    * @param source - Key of the source list
    * @param destination - Key of the destination list
    * @param sourceSide - Side of source list to pop from (LEFT or RIGHT)
    * @param destinationSide - Side of destination list to push to (LEFT or RIGHT)
    * @param timeout - Timeout in seconds, 0 to block indefinitely
    * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   * @see https://redis.io/commands/blmovem/
    * @since 8.10
    */
   blMoveM: BLMOVEM,
@@ -3069,6 +3071,7 @@ export default {
    * @param sourceSide - The side to pop from (LEFT or RIGHT)
    * @param destinationSide - The side to push to (LEFT or RIGHT)
    * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   * @see https://redis.io/commands/lmovem/
    * @since 8.10
    */
   LMOVEM,
@@ -3080,6 +3083,7 @@ export default {
    * @param sourceSide - The side to pop from (LEFT or RIGHT)
    * @param destinationSide - The side to push to (LEFT or RIGHT)
    * @param options - Optional COUNT/EXACTLY count and OBO/BULK ordering
+   * @see https://redis.io/commands/lmovem/
    * @since 8.10
    */
   lMoveM: LMOVEM,


### PR DESCRIPTION
This pull request adds the `LMOVEM` and `BLMOVEM` commands to `@redis/client`, closing the gap where only a single element could be moved between lists (`LMOVE`/`BLMOVE`) while the pop family already moved many.

- `LMOVEM source destination <LEFT|RIGHT> <LEFT|RIGHT> [<COUNT|EXACTLY> count <OBO|BULK>]` — moves up to (`COUNT`) or exactly (`EXACTLY`) N elements from one end of the source list to one end of the destination; reply is always an array of moved elements (destination order), or `null` when nothing moved.
- `BLMOVEM` — blocking variant, same options plus a `timeout` (seconds, `0` = forever).

## API

Options are modeled as a discriminated union — `{ COUNT: number, ORDER?: 'OBO' | 'BULK' }` XOR `{ EXACTLY: number, ORDER?: 'OBO' | 'BULK' }` — so `COUNT`/`EXACTLY` are mutually exclusive at the type level, and `ORDER` (OBO = stack/reversed, BULK = queue/preserved) only applies when a count is given. Omitting options moves a single element, still as an array reply. Both raw and camelCase aliases are exposed (`LMOVEM`/`lMoveM`, `BLMOVEM`/`blMoveM`).

## Considerations

- New commands (not options on `LMOVE`/`BLMOVE`) so the reply type never changes with arguments.
- Single-slot multi-key: source and destination must be hash-tag collocated in cluster mode; specs use `{tag}` prefixes.
- Commands are unreleased upstream, so behavior tests were authored but not executed locally (no server build exposing `LMOVEM`); argument serialization is type-checked and asserted via `parseArgs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive client command definitions and tests only; no changes to existing LMOVE/BLMOVE behavior or shared runtime paths beyond new exports.
> 
> **Overview**
> Adds **Redis 8.10** list commands **`LMOVEM`** and **`BLMOVEM`** to `@redis/client`, so callers can move **multiple** elements between lists (alongside existing single-element **`LMOVE`** / **`BLMOVE`**).
> 
> **`LMOVEM`** parses source/destination keys, list sides, and optional **`COUNT`** or **`EXACTLY`** plus required **`OBO`** / **`BULK`** ordering via shared **`parseLMoveMOptions`**. Replies are typed as an array of moved elements or **`null`**. **`BLMOVEM`** mirrors that with a blocking **timeout** and reuses **`LMOVEM`**’s reply handling.
> 
> The public API exposes **`LMOVEM`** / **`lMoveM`** and **`BLMOVEM`** / **`blMoveM`** on the command index with JSDoc. **`LMoveMOptions`** is a discriminated union so **`COUNT`** and **`EXACTLY`** are mutually exclusive at compile time.
> 
> Specs cover argument serialization and integration behavior (empty source, **`COUNT`** clamping, **`EXACTLY`** no-op, **`OBO`** vs **`BULK`**, blocking timeout), gated at Redis **8.10** and using hash-tagged keys for cluster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d83f9ec7e96a28c1022beb60e2c943cc3893473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->