### PR TITLE
fix(client): XADD/XTRIM with LIMIT 0 must emit the argument

### DIFF
--- a/packages/client/lib/commands/XADD.spec.ts
+++ b/packages/client/lib/commands/XADD.spec.ts
@@ -80,6 +80,20 @@ describe('XADD', () => {
       );
     });
 
+    it('with TRIM.limit 0', () => {
+      assert.deepEqual(
+        parseArgs(XADD, 'key', '*', {
+          field: 'value'
+        }, {
+          TRIM: {
+            threshold: 1000,
+            limit: 0
+          }
+        }),
+        ['XADD', 'key', '1000', 'LIMIT', '0', '*', 'field', 'value']
+      );
+    });
+
     it('with TRIM.policy', () => {
       assert.deepEqual(
         parseArgs(XADD, 'key', '*', {

--- a/packages/client/lib/commands/XADD.ts
+++ b/packages/client/lib/commands/XADD.ts
@@ -89,7 +89,7 @@ export function parseXAddArguments(
 
     parser.push(options.TRIM.threshold.toString());
 
-    if (options.TRIM.limit) {
+    if (options.TRIM.limit !== undefined) {
       parser.push('LIMIT', options.TRIM.limit.toString());
     }
 

--- a/packages/client/lib/commands/XTRIM.spec.ts
+++ b/packages/client/lib/commands/XTRIM.spec.ts
@@ -43,6 +43,16 @@ describe('XTRIM', () => {
       );
     });
 
+    it('with LIMIT 0', () => {
+      assert.deepEqual(
+        parseArgs(XTRIM, 'key', 'MAXLEN', 1, {
+          strategyModifier: '~',
+          LIMIT: 0
+        }),
+        ['XTRIM', 'key', 'MAXLEN', '~', '1', 'LIMIT', '0']
+      );
+    });
+
     it('with strategyModifier, LIMIT', () => {
       assert.deepEqual(
         parseArgs(XTRIM, 'key', 'MAXLEN', 1, {

--- a/packages/client/lib/commands/XTRIM.ts
+++ b/packages/client/lib/commands/XTRIM.ts
@@ -39,7 +39,7 @@ export default {
 
     parser.push(threshold.toString());
 
-    if (options?.LIMIT) {
+    if (options?.LIMIT !== undefined) {
       parser.push('LIMIT', options.LIMIT.toString());
     }
 


### PR DESCRIPTION
### Description

`XTRIM ... LIMIT` and `XADD ... TRIM.limit` are guarded by a truthy check, so passing an explicit `0` drops the argument entirely:

```js
await client.xTrim('key', 'MAXLEN', 1, { strategyModifier: '~', LIMIT: 0 });
// sends: XTRIM key MAXLEN ~ 1        <- LIMIT 0 is gone
```

That matters because `LIMIT 0` and omitting LIMIT are not the same thing. `LIMIT 0` means unlimited trimming, while omitting it caps eviction at `100 * stream-node-max-entries` (10000 with the defaults). So today a caller who explicitly asks for unlimited trimming silently gets the capped default instead.

I checked this against Redis 8.8 with a 20000-entry stream, trimming with `MAXLEN ~ 1`:

| call | command sent | entries evicted | XLEN after |
|---|---|---|---|
| `{ LIMIT: 0 }` (before) | `XTRIM key MAXLEN ~ 1` | 10000 | 10000 |
| `{ LIMIT: 0 }` (after) | `XTRIM key MAXLEN ~ 1 LIMIT 0` | 19900 | 100 |

The fix is to guard on `!== undefined` so `0` is forwarded, same as the recent `XGROUP ... ENTRIESREAD 0` fix in #3333. Both `XTRIM` and `XADD`'s `TRIM.limit` are affected, so I fixed both and added a `LIMIT 0` argument test for each.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

One caveat on the first box: I don't have Docker on this machine, so I couldn't run the full suite locally — the integration tests spin up containers. I ran the `transformArguments` assertions directly and verified the end-to-end behaviour against a local Redis 8.8 server (the table above). Happy to adjust if CI turns up anything.

No docs change — this restores the documented behaviour rather than changing the API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to command serialization with matching unit tests; behavior change only when callers pass `0`, aligning with documented Redis semantics.
> 
> **Overview**
> **XADD** (`TRIM.limit`) and **XTRIM** (`LIMIT`) now include the `LIMIT` clause when the value is `0`, by checking `!== undefined` instead of a truthy guard.
> 
> Previously, `LIMIT: 0` was dropped from the wire protocol, so Redis treated the call as “no LIMIT” (default eviction cap) rather than unlimited trimming per `LIMIT 0`. Unit tests assert the serialized argv for `limit`/`LIMIT` of `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63fe547991c411aa4df544fa0f6e017278bea3dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->