### PR TITLE
Fix hScanValuesIterator to yield values instead of field names

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -985,6 +985,30 @@ describe('Client', () => {
     minimumDockerVersion: [7, 4]
   });
 
+  testUtils.testWithClient('hScanValuesIterator', async client => {
+    const hash: Record<string, string> = {};
+    const expectedValues: Array<string> = [];
+    for (let i = 0; i < 100; i++) {
+      hash[i.toString()] = `value${i}`;
+      expectedValues.push(`value${i}`);
+    }
+
+    await client.hSet('key', hash);
+
+    const actualValues: Array<string> = [];
+    for await (const values of client.hScanValuesIterator('key')) {
+      for (const value of values) {
+        actualValues.push(value);
+      }
+    }
+
+    function sort(a: string, b: string) {
+      return Number(a.slice('value'.length)) - Number(b.slice('value'.length));
+    }
+
+    assert.deepEqual(actualValues.sort(sort), expectedValues);
+  }, GLOBAL.SERVERS.OPEN);
+
   testUtils.testWithClient('sScanIterator', async client => {
     const members = new Set<string>();
     for (let i = 0; i < 100; i++) {

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -1694,9 +1694,9 @@ export default class RedisClient<
   ) {
     let cursor = options?.cursor ?? '0';
     do {
-      const reply = await this.hScanNoValues(key, cursor, options);
+      const reply = await this.hScan(key, cursor, options);
       cursor = reply.cursor;
-      yield reply.fields;
+      yield reply.entries.map(entry => entry.value);
     } while (cursor !== '0');
   }
 


### PR DESCRIPTION
`hScanValuesIterator()` was a copy of `hScanNoValuesIterator()`: it called `hScanNoValues()` (which issues `HSCAN ... NOVALUES`, a reply that by protocol contains only field names) and yielded `reply.fields`. As a result it returned hash **field names** — byte-for-byte identical to `hScanNoValuesIterator` — instead of the **values** it is named for.

`hScanIterator` (entries) and `hScanNoValuesIterator` (field names) were both correct; only the values-only variant was wrong.

### Fix

Iterate the full `HSCAN`, exactly like `hScanIterator` already does, and yield the values:

```diff
-      const reply = await this.hScanNoValues(key, cursor, options);
+      const reply = await this.hScan(key, cursor, options);
       cursor = reply.cursor;
-      yield reply.fields;
+      yield reply.entries.map(entry => entry.value);
```

### Behavior for a hash `{ f1: 'v1', f2: 'v2' }`

| | before | after |
|---|---|---|
| `hScanValuesIterator` yields | `['f1', 'f2']` (field names) | `['v1', 'v2']` (values) |

Fixes #3343

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bugfix to a misnamed iterator with a new integration test; behavior change only affects callers that relied on the incorrect field-name output.
> 
> **Overview**
> **`hScanValuesIterator`** was implemented like **`hScanNoValuesIterator`**: it used **`hScanNoValues`** (`HSCAN … NOVALUES`) and yielded **`reply.fields`**, so callers got **field names** instead of **values**.
> 
> The iterator now uses full **`hScan`** (same pattern as **`hScanIterator`**) and yields **`reply.entries.map(entry => entry.value)`** per page.
> 
> An integration test **`hScanValuesIterator`** asserts a 100-field hash returns all expected **`valueN`** strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b57c4f50f34cd3cea8966ce6de0df55cb490b81c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->