### PR TITLE
test(client): fix flaky cluster PubSub listener-move test

### DIFF
--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -400,15 +400,24 @@ describe('Cluster', () => {
         end: 16383
       };
 
-      // TODO: is there a better way to migrate slots without causing CLUSTERDOWN?
-      const promises: Array<Promise<unknown>> = [];
+      // reassigning slots with `CLUSTER SETSLOT .. NODE` can leave the nodes in a
+      // transient `cluster_state:fail` state, so claim the slots on the importing
+      // node first, then release them on the migrating node, and wait for both
+      // nodes to report a healthy cluster before going on
+      const importingPromises: Array<Promise<unknown>> = [],
+        migratingPromises: Array<Promise<unknown>> = [];
       for (let i = range.start; i <= range.end; i++) {
-        promises.push(
-          migratingClient.clusterSetSlot(i, 'NODE', importing.id),
-          importingClient.clusterSetSlot(i, 'NODE', importing.id)
-        );
+        importingPromises.push(importingClient.clusterSetSlot(i, 'NODE', importing.id));
+        migratingPromises.push(migratingClient.clusterSetSlot(i, 'NODE', importing.id));
       }
-      await Promise.all(promises);
+      await Promise.all(importingPromises);
+      await Promise.all(migratingPromises);
+
+      for (const client of [migratingClient, importingClient]) {
+        while (!(await client.clusterInfo()).startsWith('cluster_state:ok')) {
+          await setTimeout(25);
+        }
+      }
 
       // make sure to cause `MOVED` error
       await cluster.get(range.key);


### PR DESCRIPTION
## Description

Fixes a flaky test: `Cluster > PubSub > should move listeners when PubSub node disconnects from the cluster` intermittently fails in CI with:

```
Error: CLUSTERDOWN The cluster is down
```

The test reassigns all 8192 slots of the PubSub node with `CLUSTER SETSLOT <slot> NODE <id>`, interleaving the commands to the migrating and the importing node. While the two nodes converge on the new slot ownership, they can pass through a transient `cluster_state:fail` window, and any command served during that window fails with `CLUSTERDOWN The cluster is down`. The test itself already carried a `TODO: is there a better way to migrate slots without causing CLUSTERDOWN?` comment.

This pull request resolves the flakiness by:
- claiming the slots on the importing node first, then releasing them on the migrating node (instead of interleaving the two), and
- waiting for both nodes to report `cluster_state:ok` via `CLUSTER INFO` before triggering the `MOVED` redirect.

Test-only change; no runtime behavior is affected. The test passed 10/10 consecutive runs with this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to slot-migration setup in one spec; no runtime or library behavior is affected.
> 
> **Overview**
> Fixes intermittent **`CLUSTERDOWN The cluster is down`** failures in the cluster PubSub test that simulates a node leaving the cluster by reassigning thousands of slots.
> 
> The test no longer **interleaves** `CLUSTER SETSLOT … NODE` on the migrating and importing masters. It **claims slots on the importing node first**, then **releases them on the migrating node**, and **polls `CLUSTER INFO` until both nodes report `cluster_state:ok`** before issuing the `GET` that triggers `MOVED` and the publish/assert path.
> 
> Test-only change; no production client behavior is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69b8bbfab3b5d3e595da05fad0a25b7a5e280b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->