### PR TITLE
chore(tests): bump default docker test image to 8.10-rc2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
             version: "8.4"
           - tag: "8.8.0"
             version: "8.8"
-          - tag: "custom-28772936538-debian"
+          - tag: "8.10-rc2"
             version: "8.10"
     steps:
       - uses: actions/checkout@v6

--- a/packages/bloom/lib/test-utils.ts
+++ b/packages/bloom/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default  TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
+  defaultDockerVersion: { tag: '8.10-rc2', version: '8.10' }
 });
 
 export const GLOBAL = {

--- a/packages/client/lib/sentinel/test-util.ts
+++ b/packages/client/lib/sentinel/test-util.ts
@@ -175,7 +175,7 @@ export class SentinelFramework extends DockerBase {
       dockerImageName: 'redislabs/client-libs-test',
       dockerImageTagArgument: 'redis-tag',
       dockerImageVersionArgument: 'redis-version',
-      defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
+      defaultDockerVersion: { tag: '8.10-rc2', version: '8.10' }
     });
     this.#nodeMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelNodes']>>>>();
     this.#sentinelMap = new Map<string, ArrayElement<Awaited<ReturnType<SentinelFramework['spawnRedisSentinelSentinels']>>>>();

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -10,7 +10,7 @@ const utils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
+  defaultDockerVersion: { tag: '8.10-rc2', version: '8.10' }
 });
 
 export default utils;

--- a/packages/entraid/lib/test-utils.ts
+++ b/packages/entraid/lib/test-utils.ts
@@ -7,7 +7,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
+  defaultDockerVersion: { tag: '8.10-rc2', version: '8.10' }
 });
 
 const DEBUG_MODE_ARGS = testUtils.isVersionGreaterThan([7]) ?

--- a/packages/json/lib/test-utils.ts
+++ b/packages/json/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
+  defaultDockerVersion: { tag: '8.10-rc2', version: '8.10' }
 });
 
 export const GLOBAL = {

--- a/packages/search/lib/test-utils.ts
+++ b/packages/search/lib/test-utils.ts
@@ -6,7 +6,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
+  defaultDockerVersion: { tag: '8.10-rc2', version: '8.10' }
 });
 
 export const GLOBAL = {

--- a/packages/test-utils/lib/test-utils.ts
+++ b/packages/test-utils/lib/test-utils.ts
@@ -4,7 +4,7 @@ export const testUtils = TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
+  defaultDockerVersion: { tag: '8.10-rc2', version: '8.10' }
 });
 
 

--- a/packages/time-series/lib/test-utils.ts
+++ b/packages/time-series/lib/test-utils.ts
@@ -5,7 +5,7 @@ export default TestUtils.createFromConfig({
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: 'custom-28772936538-debian', version: '8.10' }
+  defaultDockerVersion: { tag: '8.10-rc2', version: '8.10' }
 });
 
 export const GLOBAL = {


### PR DESCRIPTION
Bump default Redis test image from custom-28772936538-debian to 8.10-rc2 across all package test-utils, and update the 8.10 CI matrix entry to the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI configuration only; no production client or runtime behavior changes.
> 
> **Overview**
> Updates the **default Redis test Docker image** for local and package integration tests from `custom-28772936538-debian` to **`8.10-rc2`** (still version `8.10`) across `packages/*/lib/test-utils.ts`, including client, sentinel, entraid, and the shared `@redis/test-utils` config.
> 
> The **GitHub Actions test matrix** entry for Redis `8.10` is aligned to use tag **`8.10-rc2`** instead of the previous custom tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a68a202fe60b2907f803acbd45114c8d52f99a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->