### PR TITLE
feat(search): add missing RediSearch stemmer languages

### DIFF
--- a/packages/search/lib/commands/CREATE.ts
+++ b/packages/search/lib/commands/CREATE.ts
@@ -352,6 +352,7 @@ export function parseSchema(parser: CommandParser, schema: RediSearchSchema) {
 
 export const REDISEARCH_LANGUAGE = {
   ARABIC: 'Arabic',
+  ARMENIAN: 'Armenian',
   BASQUE: 'Basque',
   CATALANA: 'Catalan',
   DANISH: 'Danish',
@@ -361,20 +362,25 @@ export const REDISEARCH_LANGUAGE = {
   FRENCH: 'French',
   GERMAN: 'German',
   GREEK: 'Greek',
+  HINDI: 'Hindi',
   HUNGARIAN: 'Hungarian',
   INDONESAIN: 'Indonesian',
   IRISH: 'Irish',
   ITALIAN: 'Italian',
   LITHUANIAN: 'Lithuanian',
+  MALAY: 'Malay',
   NEPALI: 'Nepali',
   NORWEIGAN: 'Norwegian',
   PORTUGUESE: 'Portuguese',
   ROMANIAN: 'Romanian',
   RUSSIAN: 'Russian',
+  SERBIAN: 'Serbian',
   SPANISH: 'Spanish',
   SWEDISH: 'Swedish',
+  TAGALOG: 'Tagalog',
   TAMIL: 'Tamil',
   TURKISH: 'Turkish',
+  YIDDISH: 'Yiddish',
   CHINESE: 'Chinese'
 } as const;
 


### PR DESCRIPTION
This pull request adds the RediSearch stemmer languages that were missing from the `REDISEARCH_LANGUAGE` enum in `@redis/search`.

The following languages are supported by the RediSearch Snowball stemmer but were not exposed by the client, so they could not be passed to the `LANGUAGE` / `LANGUAGE_FIELD` options of `FT.CREATE` and `FT.SEARCH` in a type-safe way:

- `Armenian`
- `Hindi`
- `Malay`
- `Serbian`
- `Tagalog`
- `Yiddish`

`Malay` and `Tagalog` ship with the 8.10 query engine. `Armenian`, `Hindi`, `Serbian` and `Yiddish` were already listed as supported languages in the [RediSearch stemming documentation](https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/stemming/).

### Notes

- `SEARCH.ts` and every other command consume the shared `RediSearchLanguage` type, so they pick up the new values automatically.
- No behavior change for existing values; this is a purely additive change to the enum.
- Existing key spellings (`CATALANA`, `INDONESAIN`, `NORWEIGAN`) are left untouched to avoid a breaking change to the public enum keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive enum entries with no runtime or API behavior changes beyond expanded TypeScript autocomplete.
> 
> **Overview**
> Extends **`REDISEARCH_LANGUAGE`** in `@redis/search` with six Snowball stemmer locales that RediSearch already supports but the client did not expose: **Armenian**, **Hindi**, **Malay**, **Serbian**, **Tagalog**, and **Yiddish**.
> 
> Because **`RediSearchLanguage`** is inferred from that enum, **`LANGUAGE`** / **`LANGUAGE_FIELD`** on **`FT.CREATE`** and related search commands can now reference these values with full type safety. Existing enum keys and string values are unchanged; this is additive typing only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d92e8b9a6a757acf571feefbcb3e485daf2e338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->