### PR TITLE
feat(search): add FT.ALIASLIST command

### DIFF
--- a/packages/search/lib/commands/ALIASLIST.spec.ts
+++ b/packages/search/lib/commands/ALIASLIST.spec.ts
@@ -13,30 +13,32 @@ describe('FT.ALIASLIST', () => {
   });
 
   testUtils.testWithClient('client.ft.aliasList on index without aliases', async client => {
-    await client.ft.create('index', {
-      field: SCHEMA_FIELD_TYPE.TEXT
-    });
+    const [, reply] = await Promise.all([
+      client.ft.create('index', {
+        field: SCHEMA_FIELD_TYPE.TEXT
+      }),
+      client.ft.aliasList('index')
+    ]);
 
-    assert.deepEqual(
-      await client.ft.aliasList('index'),
-      []
-    );
-  }, GLOBAL.SERVERS.OPEN);
+    assert.deepEqual(reply, []);
+  }, { ...GLOBAL.SERVERS.OPEN, minimumDockerVersion: [8, 10] });
 
   testUtils.testWithClient('client.ft.aliasList with aliases', async client => {
-    await client.ft.create('index', {
-      field: SCHEMA_FIELD_TYPE.TEXT
-    });
-    await client.ft.aliasAdd('alias1', 'index');
-    await client.ft.aliasAdd('alias2', 'index');
+    const [, , , reply] = await Promise.all([
+      client.ft.create('index', {
+        field: SCHEMA_FIELD_TYPE.TEXT
+      }),
+      client.ft.aliasAdd('alias1', 'index'),
+      client.ft.aliasAdd('alias2', 'index'),
+      client.ft.aliasList('index')
+    ]);
 
-    const reply = await client.ft.aliasList('index');
     // ordering is not part of the contract
     assert.deepEqual(
       [...reply].sort(),
       ['alias1', 'alias2']
     );
-  }, GLOBAL.SERVERS.OPEN);
+  }, { ...GLOBAL.SERVERS.OPEN, minimumDockerVersion: [8, 10] });
 
   testUtils.testWithClient('client.ft.aliasList on missing index rejects with index-not-found', async client => {
     await assert.rejects(
@@ -50,5 +52,5 @@ describe('FT.ALIASLIST', () => {
         return true;
       }
     );
-  }, GLOBAL.SERVERS.OPEN);
+  }, { ...GLOBAL.SERVERS.OPEN, minimumDockerVersion: [8, 10] });
 });

--- a/packages/search/lib/commands/ALIASLIST.spec.ts
+++ b/packages/search/lib/commands/ALIASLIST.spec.ts
@@ -1,0 +1,40 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import ALIASLIST from './ALIASLIST';
+import { SCHEMA_FIELD_TYPE } from './CREATE';
+import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
+
+describe('FT.ALIASLIST', () => {
+  it('transformArguments', () => {
+    assert.deepEqual(
+      parseArgs(ALIASLIST, 'index'),
+      ['FT.ALIASLIST', 'index']
+    );
+  });
+
+  testUtils.testWithClient('client.ft.aliasList on index without aliases', async client => {
+    await client.ft.create('index', {
+      field: SCHEMA_FIELD_TYPE.TEXT
+    });
+
+    assert.deepEqual(
+      await client.ft.aliasList('index'),
+      []
+    );
+  }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClient('client.ft.aliasList with aliases', async client => {
+    await client.ft.create('index', {
+      field: SCHEMA_FIELD_TYPE.TEXT
+    });
+    await client.ft.aliasAdd('alias1', 'index');
+    await client.ft.aliasAdd('alias2', 'index');
+
+    const reply = await client.ft.aliasList('index');
+    // ordering is not part of the contract
+    assert.deepEqual(
+      [...reply].sort(),
+      ['alias1', 'alias2']
+    );
+  }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/search/lib/commands/ALIASLIST.spec.ts
+++ b/packages/search/lib/commands/ALIASLIST.spec.ts
@@ -37,4 +37,18 @@ describe('FT.ALIASLIST', () => {
       ['alias1', 'alias2']
     );
   }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClient('client.ft.aliasList on missing index rejects with index-not-found', async client => {
+    await assert.rejects(
+      client.ft.aliasList('nonexistent'),
+      err => {
+        assert.ok(err instanceof Error);
+        assert.ok(
+          err.message.startsWith('SEARCH_INDEX_NOT_FOUND'),
+          `expected SEARCH_INDEX_NOT_FOUND prefix, got: ${err.message}`
+        );
+        return true;
+      }
+    );
+  }, GLOBAL.SERVERS.OPEN);
 });

--- a/packages/search/lib/commands/ALIASLIST.ts
+++ b/packages/search/lib/commands/ALIASLIST.ts
@@ -1,0 +1,14 @@
+import { CommandParser } from '@redis/client/dist/lib/client/parser';
+import { RedisArgument, ArrayReply, SetReply, BlobStringReply, Command } from '@redis/client/dist/lib/RESP/types';
+
+export default {
+  NOT_KEYED_COMMAND: true,
+  IS_READ_ONLY: true,
+  parseCommand(parser: CommandParser, index: RedisArgument) {
+    parser.push('FT.ALIASLIST', index);
+  },
+  transformReply: {
+    2: undefined as unknown as () => ArrayReply<BlobStringReply>,
+    3: undefined as unknown as () => SetReply<BlobStringReply>
+  }
+} as const satisfies Command;

--- a/packages/search/lib/commands/index.ts
+++ b/packages/search/lib/commands/index.ts
@@ -4,6 +4,7 @@ import AGGREGATE_WITHCURSOR from './AGGREGATE_WITHCURSOR';
 import AGGREGATE from './AGGREGATE';
 import ALIASADD from './ALIASADD';
 import ALIASDEL from './ALIASDEL';
+import ALIASLIST from './ALIASLIST';
 import ALIASUPDATE from './ALIASUPDATE';
 import CONFIG_GET from './CONFIG_GET';
 import CONFIG_SET from './CONFIG_SET';
@@ -121,6 +122,16 @@ export default {
    * @param alias - The alias to remove
    */
   aliasDel: ALIASDEL,
+  /**
+   * Lists all aliases associated with the given index. Read-only; available from RediSearch 8.10.0.
+   * @param index - The index name (must be an index created with FT.CREATE, not an alias)
+   */
+  ALIASLIST,
+  /**
+   * Lists all aliases associated with the given index. Read-only; available from RediSearch 8.10.0.
+   * @param index - The index name (must be an index created with FT.CREATE, not an alias)
+   */
+  aliasList: ALIASLIST,
   /**
    * Updates the index pointed to by an existing alias.
    * @param alias - The existing alias to update

--- a/packages/search/lib/commands/index.ts
+++ b/packages/search/lib/commands/index.ts
@@ -123,13 +123,13 @@ export default {
    */
   aliasDel: ALIASDEL,
   /**
-   * Lists all aliases associated with the given index. Read-only; available from RediSearch 8.10.0.
-   * @param index - The index name (must be an index created with FT.CREATE, not an alias)
+   * Lists all aliases associated with the given index.
+   * @param index - The index name whose aliases to list
    */
   ALIASLIST,
   /**
-   * Lists all aliases associated with the given index. Read-only; available from RediSearch 8.10.0.
-   * @param index - The index name (must be an index created with FT.CREATE, not an alias)
+   * Lists all aliases associated with the given index.
+   * @param index - The index name whose aliases to list
    */
   aliasList: ALIASLIST,
   /**


### PR DESCRIPTION
This pull request adds the `FT.ALIASLIST` command to `@redis/search`. Given an index name, it returns all aliases currently associated with that index — making alias discovery a first-class, read-only Query Engine API instead of relying on the `FT.INFO` workaround. Available from RediSearch 8.10.0.

The command sends the fixed wire shape `FT.ALIASLIST index` with no optional arguments. It is read-only and keyless (the `index` argument is a Query Engine identifier, not a Redis key), so it runs on replicas and executes on an arbitrary shard in cluster mode with no fanout. The reply is an unordered collection of alias name strings: RESP2 returns an array of bulk strings, RESP3 returns a set — both surfaced via the client's normal RESP handling. An existing index with no aliases yields an empty collection rather than an error.

Behavior notes callers should be aware of: the server resolves the argument with no alias lookup, so passing an alias name (or a missing index) fails with `SEARCH_INDEX_NOT_FOUND Index not found: <name>`; permission failures surface as `NOPERM`. The client adds no validation and propagates server errors unchanged. Result ordering is not part of the contract and must not be relied upon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only search client command with no auth or data-path changes; behavior is delegated to RediSearch 8.10+.
> 
> **Overview**
> Adds **`FT.ALIASLIST`** to `@redis/search` so callers can list aliases for an index via **`client.ft.aliasList`** / **`ALIASLIST`**, instead of inferring them from **`FT.INFO`**.
> 
> The new command module emits **`FT.ALIASLIST index`**, is marked read-only and not keyed, and types the reply as a RESP2 array or RESP3 set of alias strings. Integration tests cover argument encoding, empty vs populated alias lists (order-agnostic), and **`SEARCH_INDEX_NOT_FOUND`** for a missing index, gated on Redis **8.10+**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1dec9478a3d575fc164747cb00255e13c981cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->