### PR TITLE
feat(time-series): add EXCLUDEEMPTY to TS.MRANGE and TS.MREVRANGE

### DIFF
--- a/packages/time-series/lib/commands/MRANGE.spec.ts
+++ b/packages/time-series/lib/commands/MRANGE.spec.ts
@@ -34,6 +34,41 @@ describe('TS.MRANGE', () => {
     );
   });
 
+  it('transformArguments with EXCLUDEEMPTY', () => {
+    assert.deepEqual(
+      parseArgs(MRANGE, '-', '+', 'label=value', {
+        COUNT: 1,
+        EXCLUDEEMPTY: true
+      }),
+      [
+        'TS.MRANGE', '-', '+',
+        'COUNT', '1',
+        'EXCLUDEEMPTY',
+        'FILTER', 'label=value'
+      ]
+    );
+  });
+
+  testUtils.testWithClient('client.ts.mRange EXCLUDEEMPTY omits empty series', async client => {
+    await Promise.all([
+      client.ts.add('s', 100, 100, { LABELS: { sensor: '1' } }),
+      client.ts.add('t', 100, 100, { LABELS: { sensor: '1' } }),
+      client.ts.create('u', { LABELS: { sensor: '1' } })
+    ]);
+    await client.ts.add('u', 2000, 2000);
+
+    const reply = await client.ts.mRange('-', 500, 'sensor=1', {
+      EXCLUDEEMPTY: true
+    });
+
+    assert.ok('s' in reply);
+    assert.ok('t' in reply);
+    assert.ok(!('u' in reply), 'series "u" has no samples in range and must be omitted');
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
   testUtils.testWithClient('client.ts.mRange', async client => {
     const [, reply] = await Promise.all([
       client.ts.add('key', 0, 0, {

--- a/packages/time-series/lib/commands/MRANGE.ts
+++ b/packages/time-series/lib/commands/MRANGE.ts
@@ -1,8 +1,8 @@
 import { CommandParser } from '@redis/client/dist/lib/client/parser';
 import { Command, ArrayReply, BlobStringReply, Resp2Reply, MapReply, TuplesReply, TypeMapping, RedisArgument } from '@redis/client/dist/lib/RESP/types';
 import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
-import { resp2MapToValue, resp3MapToValue, SampleRawReply, Timestamp, transformSamplesReply } from './helpers';
-import { TsRangeOptions, parseRangeArguments } from './RANGE';
+import { parseExcludeEmptyArgument, resp2MapToValue, resp3MapToValue, SampleRawReply, Timestamp, transformSamplesReply } from './helpers';
+import { TsMRangeOptions, parseRangeArguments } from './RANGE';
 import { parseFilterArgument } from './MGET';
 
 export type TsMRangeRawReply2 = ArrayReply<
@@ -32,7 +32,7 @@ export function createTransformMRangeArguments(command: RedisArgument) {
     fromTimestamp: Timestamp,
     toTimestamp: Timestamp,
     filter: RedisVariadicArgument,
-    options?: TsRangeOptions
+    options?: TsMRangeOptions
   ) => {
     parser.push(command);
     parseRangeArguments(
@@ -41,7 +41,9 @@ export function createTransformMRangeArguments(command: RedisArgument) {
       toTimestamp,
       options
     );
-  
+
+    parseExcludeEmptyArgument(parser, options?.EXCLUDEEMPTY);
+
     parseFilterArgument(parser, filter);
   };
 }

--- a/packages/time-series/lib/commands/MRANGE_MULTIAGGR.spec.ts
+++ b/packages/time-series/lib/commands/MRANGE_MULTIAGGR.spec.ts
@@ -37,6 +37,27 @@ describe('TS.MRANGE_MULTIAGGR', () => {
     );
   });
 
+  it('transformArguments with EXCLUDEEMPTY', () => {
+    assert.deepEqual(
+      parseArgs(MRANGE_MULTIAGGR, '-', '+', 'label=value', {
+        AGGREGATION: {
+          types: [
+            TIME_SERIES_AGGREGATION_TYPE.MIN,
+            TIME_SERIES_AGGREGATION_TYPE.MAX
+          ],
+          timeBucket: 1
+        },
+        EXCLUDEEMPTY: true
+      }),
+      [
+        'TS.MRANGE', '-', '+',
+        'AGGREGATION', 'MIN,MAX', '1',
+        'EXCLUDEEMPTY',
+        'FILTER', 'label=value'
+      ]
+    );
+  });
+
   testUtils.testWithClient('client.ts.mRangeMultiAggr', async client => {
     await client.ts.add('mrange-multi', 1000, 0, {
       LABELS: {

--- a/packages/time-series/lib/commands/MRANGE_MULTIAGGR.ts
+++ b/packages/time-series/lib/commands/MRANGE_MULTIAGGR.ts
@@ -2,13 +2,14 @@ import { CommandParser } from '@redis/client/dist/lib/client/parser';
 import { Command, ArrayReply, BlobStringReply, Resp2Reply, MapReply, TuplesReply, TypeMapping, RedisArgument } from '@redis/client/dist/lib/RESP/types';
 import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
 import {
+  parseExcludeEmptyArgument,
   resp2MapToValue,
   resp3MapToValue,
   MultiAggregationSampleRawReply,
   Timestamp,
   transformMultiAggregationSamplesReply
 } from './helpers';
-import { TsRangeMultiAggrOptions, parseRangeMultiArguments } from './RANGE_MULTIAGGR';
+import { TsMRangeMultiAggrOptions, parseRangeMultiArguments } from './RANGE_MULTIAGGR';
 import { parseFilterArgument } from './MGET';
 
 export type TsMRangeMultiRawReply2 = ArrayReply<
@@ -38,7 +39,7 @@ export function createTransformMRangeMultiArguments(command: RedisArgument) {
     fromTimestamp: Timestamp,
     toTimestamp: Timestamp,
     filter: RedisVariadicArgument,
-    options: TsRangeMultiAggrOptions
+    options: TsMRangeMultiAggrOptions
   ) => {
     parser.push(command);
     parseRangeMultiArguments(
@@ -47,6 +48,8 @@ export function createTransformMRangeMultiArguments(command: RedisArgument) {
       toTimestamp,
       options
     );
+
+    parseExcludeEmptyArgument(parser, options?.EXCLUDEEMPTY);
 
     parseFilterArgument(parser, filter);
   };

--- a/packages/time-series/lib/commands/MRANGE_SELECTED_LABELS.ts
+++ b/packages/time-series/lib/commands/MRANGE_SELECTED_LABELS.ts
@@ -1,8 +1,8 @@
 import { CommandParser } from '@redis/client/dist/lib/client/parser';
 import { Command, ArrayReply, BlobStringReply, Resp2Reply, MapReply, TuplesReply, TypeMapping, NullReply, RedisArgument } from '@redis/client/dist/lib/RESP/types';
 import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
-import { parseSelectedLabelsArguments, resp2MapToValue, resp3MapToValue, SampleRawReply, Timestamp, transformRESP2Labels, transformSamplesReply } from './helpers';
-import { TsRangeOptions, parseRangeArguments } from './RANGE';
+import { parseExcludeEmptyArgument, parseSelectedLabelsArguments, resp2MapToValue, resp3MapToValue, SampleRawReply, Timestamp, transformRESP2Labels, transformSamplesReply } from './helpers';
+import { TsMRangeOptions, parseRangeArguments } from './RANGE';
 import { parseFilterArgument } from './MGET';
 
 export type TsMRangeSelectedLabelsRawReply2 = ArrayReply<
@@ -38,7 +38,7 @@ export function createTransformMRangeSelectedLabelsArguments(command: RedisArgum
     toTimestamp: Timestamp,
     selectedLabels: RedisVariadicArgument,
     filter: RedisVariadicArgument,
-    options?: TsRangeOptions
+    options?: TsMRangeOptions
   ) => {
     parser.push(command);
     parseRangeArguments(
@@ -47,7 +47,9 @@ export function createTransformMRangeSelectedLabelsArguments(command: RedisArgum
       toTimestamp,
       options
     );
-  
+
+    parseExcludeEmptyArgument(parser, options?.EXCLUDEEMPTY);
+
     parseSelectedLabelsArguments(parser, selectedLabels);
   
     parseFilterArgument(parser, filter);

--- a/packages/time-series/lib/commands/MRANGE_SELECTED_LABELS_MULTIAGGR.ts
+++ b/packages/time-series/lib/commands/MRANGE_SELECTED_LABELS_MULTIAGGR.ts
@@ -2,6 +2,7 @@ import { CommandParser } from '@redis/client/dist/lib/client/parser';
 import { Command, ArrayReply, BlobStringReply, Resp2Reply, MapReply, TuplesReply, TypeMapping, NullReply, RedisArgument } from '@redis/client/dist/lib/RESP/types';
 import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
 import {
+  parseExcludeEmptyArgument,
   parseSelectedLabelsArguments,
   resp2MapToValue,
   resp3MapToValue,
@@ -10,7 +11,7 @@ import {
   transformRESP2Labels,
   transformMultiAggregationSamplesReply
 } from './helpers';
-import { TsRangeMultiAggrOptions, parseRangeMultiArguments } from './RANGE_MULTIAGGR';
+import { TsMRangeMultiAggrOptions, parseRangeMultiArguments } from './RANGE_MULTIAGGR';
 import { parseFilterArgument } from './MGET';
 
 export type TsMRangeSelectedLabelsMultiRawReply2 = ArrayReply<
@@ -44,7 +45,7 @@ export function createTransformMRangeSelectedLabelsMultiArguments(command: Redis
     toTimestamp: Timestamp,
     selectedLabels: RedisVariadicArgument,
     filter: RedisVariadicArgument,
-    options: TsRangeMultiAggrOptions
+    options: TsMRangeMultiAggrOptions
   ) => {
     parser.push(command);
     parseRangeMultiArguments(
@@ -53,6 +54,8 @@ export function createTransformMRangeSelectedLabelsMultiArguments(command: Redis
       toTimestamp,
       options
     );
+
+    parseExcludeEmptyArgument(parser, options?.EXCLUDEEMPTY);
 
     parseSelectedLabelsArguments(parser, selectedLabels);
 

--- a/packages/time-series/lib/commands/MRANGE_WITHLABELS.spec.ts
+++ b/packages/time-series/lib/commands/MRANGE_WITHLABELS.spec.ts
@@ -35,6 +35,20 @@ describe('TS.MRANGE_WITHLABELS', () => {
     );
   });
 
+  it('transformArguments with EXCLUDEEMPTY', () => {
+    assert.deepEqual(
+      parseArgs(MRANGE_WITHLABELS, '-', '+', 'label=value', {
+        EXCLUDEEMPTY: true
+      }),
+      [
+        'TS.MRANGE', '-', '+',
+        'EXCLUDEEMPTY',
+        'WITHLABELS',
+        'FILTER', 'label=value'
+      ]
+    );
+  });
+
   testUtils.testWithClient('client.ts.mRangeWithLabels', async client => {
     const [, reply] = await Promise.all([
       client.ts.add('key', 0, 0, {

--- a/packages/time-series/lib/commands/MRANGE_WITHLABELS.ts
+++ b/packages/time-series/lib/commands/MRANGE_WITHLABELS.ts
@@ -1,8 +1,8 @@
 import { CommandParser } from '@redis/client/dist/lib/client/parser';
 import { Command, UnwrapReply, ArrayReply, BlobStringReply, Resp2Reply, MapReply, TuplesReply, TypeMapping, RedisArgument } from '@redis/client/dist/lib/RESP/types';
 import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
-import { resp2MapToValue, resp3MapToValue, SampleRawReply, Timestamp, transformSamplesReply } from './helpers';
-import { TsRangeOptions, parseRangeArguments } from './RANGE';
+import { parseExcludeEmptyArgument, resp2MapToValue, resp3MapToValue, SampleRawReply, Timestamp, transformSamplesReply } from './helpers';
+import { TsMRangeOptions, parseRangeArguments } from './RANGE';
 import { parseFilterArgument } from './MGET';
 
 export type TsMRangeWithLabelsRawReply2 = ArrayReply<
@@ -35,7 +35,7 @@ export function createTransformMRangeWithLabelsArguments(command: RedisArgument)
     fromTimestamp: Timestamp,
     toTimestamp: Timestamp,
     filter: RedisVariadicArgument,
-    options?: TsRangeOptions
+    options?: TsMRangeOptions
   ) => {
     parser.push(command);
     parseRangeArguments(
@@ -44,6 +44,8 @@ export function createTransformMRangeWithLabelsArguments(command: RedisArgument)
       toTimestamp,
       options
     );
+
+    parseExcludeEmptyArgument(parser, options?.EXCLUDEEMPTY);
 
     parser.push('WITHLABELS');
 

--- a/packages/time-series/lib/commands/MRANGE_WITHLABELS_MULTIAGGR.ts
+++ b/packages/time-series/lib/commands/MRANGE_WITHLABELS_MULTIAGGR.ts
@@ -2,13 +2,14 @@ import { CommandParser } from '@redis/client/dist/lib/client/parser';
 import { Command, UnwrapReply, ArrayReply, BlobStringReply, Resp2Reply, MapReply, TuplesReply, TypeMapping, RedisArgument } from '@redis/client/dist/lib/RESP/types';
 import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
 import {
+  parseExcludeEmptyArgument,
   resp2MapToValue,
   resp3MapToValue,
   MultiAggregationSampleRawReply,
   Timestamp,
   transformMultiAggregationSamplesReply
 } from './helpers';
-import { TsRangeMultiAggrOptions, parseRangeMultiArguments } from './RANGE_MULTIAGGR';
+import { TsMRangeMultiAggrOptions, parseRangeMultiArguments } from './RANGE_MULTIAGGR';
 import { parseFilterArgument } from './MGET';
 
 export type TsMRangeWithLabelsMultiRawReply2 = ArrayReply<
@@ -41,7 +42,7 @@ export function createTransformMRangeWithLabelsMultiArguments(command: RedisArgu
     fromTimestamp: Timestamp,
     toTimestamp: Timestamp,
     filter: RedisVariadicArgument,
-    options: TsRangeMultiAggrOptions
+    options: TsMRangeMultiAggrOptions
   ) => {
     parser.push(command);
     parseRangeMultiArguments(
@@ -50,6 +51,8 @@ export function createTransformMRangeWithLabelsMultiArguments(command: RedisArgu
       toTimestamp,
       options
     );
+
+    parseExcludeEmptyArgument(parser, options?.EXCLUDEEMPTY);
 
     parser.push('WITHLABELS');
 

--- a/packages/time-series/lib/commands/MREVRANGE.spec.ts
+++ b/packages/time-series/lib/commands/MREVRANGE.spec.ts
@@ -34,6 +34,41 @@ describe('TS.MREVRANGE', () => {
     );
   });
 
+  it('transformArguments with EXCLUDEEMPTY', () => {
+    assert.deepEqual(
+      parseArgs(MREVRANGE, '-', '+', 'label=value', {
+        COUNT: 1,
+        EXCLUDEEMPTY: true
+      }),
+      [
+        'TS.MREVRANGE', '-', '+',
+        'COUNT', '1',
+        'EXCLUDEEMPTY',
+        'FILTER', 'label=value'
+      ]
+    );
+  });
+
+  testUtils.testWithClient('client.ts.mRevRange EXCLUDEEMPTY omits empty series', async client => {
+    await Promise.all([
+      client.ts.add('s', 100, 100, { LABELS: { sensor: '1' } }),
+      client.ts.add('t', 100, 100, { LABELS: { sensor: '1' } }),
+      client.ts.create('u', { LABELS: { sensor: '1' } })
+    ]);
+    await client.ts.add('u', 2000, 2000);
+
+    const reply = await client.ts.mRevRange('-', 500, 'sensor=1', {
+      EXCLUDEEMPTY: true
+    });
+
+    assert.ok('s' in reply);
+    assert.ok('t' in reply);
+    assert.ok(!('u' in reply), 'series "u" has no samples in range and must be omitted');
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
   testUtils.testWithClient('client.ts.mRevRange', async client => {
     const [, reply] = await Promise.all([
       client.ts.add('key', 0, 0, {

--- a/packages/time-series/lib/commands/RANGE.ts
+++ b/packages/time-series/lib/commands/RANGE.ts
@@ -23,6 +23,20 @@ export interface TsRangeOptions extends TsRangeCommonOptions {
   };
 }
 
+/**
+ * `TS.MRANGE`/`TS.MREVRANGE` (non-`GROUPBY`) options: the single-key range options
+ * plus the multi-range-only `EXCLUDEEMPTY` flag.
+ */
+export interface TsMRangeOptions extends TsRangeOptions {
+  /**
+   * Omit matching series whose reported samples array is empty from the reply.
+   * Cannot be combined with `GROUPBY`.
+   *
+   * @since Redis 8.10
+   */
+  EXCLUDEEMPTY?: boolean;
+}
+
 export function parseRangeArguments(
   parser: CommandParser,
   fromTimestamp: Timestamp,

--- a/packages/time-series/lib/commands/RANGE_MULTIAGGR.ts
+++ b/packages/time-series/lib/commands/RANGE_MULTIAGGR.ts
@@ -24,6 +24,20 @@ export interface TsRangeMultiAggrOptions extends TsRangeCommonOptions {
   };
 }
 
+/**
+ * `TS.MRANGE`/`TS.MREVRANGE` multi-aggregation (non-`GROUPBY`) options: the
+ * multi-aggregation range options plus the multi-range-only `EXCLUDEEMPTY` flag.
+ */
+export interface TsMRangeMultiAggrOptions extends TsRangeMultiAggrOptions {
+  /**
+   * Omit matching series whose reported samples array is empty from the reply.
+   * Cannot be combined with `GROUPBY`.
+   *
+   * @since Redis 8.10
+   */
+  EXCLUDEEMPTY?: boolean;
+}
+
 export function parseRangeMultiArguments(
   parser: CommandParser,
   fromTimestamp: Timestamp,

--- a/packages/time-series/lib/commands/helpers.ts
+++ b/packages/time-series/lib/commands/helpers.ts
@@ -118,6 +118,19 @@ export function parseRangeCommonArguments(
   }
 }
 
+/**
+ * Pushes the bare `EXCLUDEEMPTY` flag for `TS.MRANGE`/`TS.MREVRANGE` when requested.
+ * The flag omits matching series with an empty samples array from the reply. It is
+ * not valid on single-key `TS.RANGE`/`TS.REVRANGE` nor combinable with `GROUPBY`.
+ *
+ * @since Redis 8.10
+ */
+export function parseExcludeEmptyArgument(parser: CommandParser, excludeEmpty?: boolean) {
+  if (excludeEmpty) {
+    parser.push('EXCLUDEEMPTY');
+  }
+}
+
 export type Labels = {
   [label: string]: string;
 };


### PR DESCRIPTION
This pull request adds support for the `EXCLUDEEMPTY` flag on `TS.MRANGE` and `TS.MREVRANGE`, introduced in Redis 8.10. When set, the server omits from the top-level reply any matching time series whose samples array is empty for the queried range and options. The default behavior (empty series included) is unchanged and fully backward compatible.

The flag is exposed as an `EXCLUDEEMPTY?: boolean` option on the non-`GROUPBY` multi-range helpers (base, `WITHLABELS`, `SELECTED_LABELS`, and their multi-aggregation counterparts), for both forward (`mRange`) and reverse (`mRevRange`) commands. It is emitted as a bare flag with no value, placed among the range options before `FILTER`.

Key design points:
- `EXCLUDEEMPTY` lives on new `TsMRangeOptions` / `TsMRangeMultiAggrOptions` types, so single-key `TS.RANGE`/`TS.REVRANGE` never offer an invalid option.
- `EXCLUDEEMPTY` is mutually exclusive with `GROUPBY`. Because `GROUPBY` is a separate set of command variants that do not expose the option, the illegal combination is unrepresentable in the typed API. Raw `sendCommand` users who combine them still receive the server error (`TSDB: EXCLUDEEMPTY is not allowed with GROUPBY`) unchanged.
- The response parser is unchanged — the server simply returns fewer entries. No client-side filtering, no extra commands, routing unchanged.

Behavior tests are gated to server `>= 8.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only command argument and typing changes with default behavior unchanged; no reply parsing or security-sensitive logic.
> 
> **Overview**
> Adds Redis 8.10 **`EXCLUDEEMPTY`** support on non-`GROUPBY` **`TS.MRANGE`** / **`TS.MREVRANGE`** client helpers so callers can omit matching series with no samples in the queried range.
> 
> The option is **`EXCLUDEEMPTY?: boolean`** on new **`TsMRangeOptions`** and **`TsMRangeMultiAggrOptions`** (extending the existing range option types so single-key **`TS.RANGE`** does not expose it). **`parseExcludeEmptyArgument`** emits the bare **`EXCLUDEEMPTY`** token after range options and before **`FILTER`** / label modifiers across base, **`WITHLABELS`**, **`SELECTED_LABELS`**, and multi-aggregation parsers. Reply handling is unchanged; the server returns fewer keys.
> 
> Tests cover argument serialization for several variants and integration checks on **`mRange`** / **`mRevRange`** (gated to server **≥ 8.10**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c1815155a74242c4936afd39e34742d5ad1019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->