### PR TITLE
feat(time-series): add TS.QUERYLABELS (LABELS and VALUES forms)

### DIFF
--- a/packages/time-series/lib/commands/QUERYLABELS.spec.ts
+++ b/packages/time-series/lib/commands/QUERYLABELS.spec.ts
@@ -1,0 +1,90 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import QUERYLABELS from './QUERYLABELS';
+import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
+
+describe('TS.QUERYLABELS LABELS', () => {
+  describe('transformArguments', () => {
+    it('without filter', () => {
+      assert.deepEqual(
+        parseArgs(QUERYLABELS),
+        ['TS.QUERYLABELS', 'LABELS']
+      );
+    });
+
+    it('single filter', () => {
+      assert.deepEqual(
+        parseArgs(QUERYLABELS, 'type=sensor'),
+        ['TS.QUERYLABELS', 'LABELS', 'FILTER', 'type=sensor']
+      );
+    });
+
+    it('multiple filters', () => {
+      assert.deepEqual(
+        parseArgs(QUERYLABELS, ['type=sensor', 'location=Kitchen']),
+        ['TS.QUERYLABELS', 'LABELS', 'FILTER', 'type=sensor', 'location=Kitchen']
+      );
+    });
+
+    it('throws on an explicitly empty filter list', () => {
+      assert.throws(() => parseArgs(QUERYLABELS, []));
+    });
+  });
+
+  testUtils.testWithClient('client.ts.queryLabels (with filter)', async client => {
+    await Promise.all([
+      client.ts.create('ts1', { LABELS: { type: 'sensor', location: 'LivingRoom', sensortype: 'temp' } }),
+      client.ts.create('ts2', { LABELS: { type: 'sensor', location: 'Kitchen', sensortype: 'temp' } }),
+      client.ts.create('ts3', { LABELS: { type: 'gauge', location: 'BedRoom' } })
+    ]);
+
+    const reply = await client.ts.queryLabels(['type=sensor']);
+    assert.deepEqual(
+      [...reply].sort(),
+      ['location', 'sensortype', 'type']
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.queryLabels (no filter)', async client => {
+    await client.ts.create('ts1', { LABELS: { type: 'sensor', location: 'LivingRoom' } });
+
+    const reply = await client.ts.queryLabels();
+    assert.deepEqual(
+      [...reply].sort(),
+      ['location', 'type']
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.queryLabels (empty result is not an error)', async client => {
+    await client.ts.create('ts1', { LABELS: { type: 'sensor' } });
+
+    const reply = await client.ts.queryLabels(['type=nonexistent']);
+    assert.deepEqual([...reply], []);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.queryLabels (RESP2 flat array)', async client => {
+    await client.ts.create('ts1', { LABELS: { type: 'sensor', location: 'LivingRoom' } });
+
+    const reply = await client.ts.queryLabels(['type=sensor']);
+    assert.deepEqual(
+      [...reply].sort(),
+      ['location', 'type']
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    clientOptions: {
+      ...GLOBAL.SERVERS.OPEN.clientOptions,
+      RESP: 2
+    },
+    minimumDockerVersion: [8, 10]
+  });
+});

--- a/packages/time-series/lib/commands/QUERYLABELS.ts
+++ b/packages/time-series/lib/commands/QUERYLABELS.ts
@@ -1,0 +1,23 @@
+import { CommandParser } from '@redis/client/dist/lib/client/parser';
+import { ArrayReply, BlobStringReply, SetReply, Command } from '@redis/client/dist/lib/RESP/types';
+import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
+import { parseQueryLabelsFilterArgument } from './helpers';
+
+/**
+ * `TS.QUERYLABELS LABELS [FILTER filterExpr ...]` — the set of all label names
+ * present on at least one matching (and readable) time series. Added in
+ * RedisTimeSeries 8.10. Keyless; in cluster mode the server performs the
+ * cluster-wide fan-out and returns a single merged, deduplicated reply.
+ */
+export default {
+  NOT_KEYED_COMMAND: true,
+  IS_READ_ONLY: true,
+  parseCommand(parser: CommandParser, filter?: RedisVariadicArgument) {
+    parser.push('TS.QUERYLABELS', 'LABELS');
+    parseQueryLabelsFilterArgument(parser, filter);
+  },
+  transformReply: {
+    2: undefined as unknown as () => ArrayReply<BlobStringReply>,
+    3: undefined as unknown as () => SetReply<BlobStringReply>
+  }
+} as const satisfies Command;

--- a/packages/time-series/lib/commands/QUERYLABELS_VALUES.spec.ts
+++ b/packages/time-series/lib/commands/QUERYLABELS_VALUES.spec.ts
@@ -1,0 +1,76 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import QUERYLABELS_VALUES from './QUERYLABELS_VALUES';
+import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
+
+describe('TS.QUERYLABELS VALUES', () => {
+  describe('transformArguments', () => {
+    it('without filter', () => {
+      assert.deepEqual(
+        parseArgs(QUERYLABELS_VALUES, 'location'),
+        ['TS.QUERYLABELS', 'VALUES', 'location']
+      );
+    });
+
+    it('single filter', () => {
+      assert.deepEqual(
+        parseArgs(QUERYLABELS_VALUES, 'location', 'type=sensor'),
+        ['TS.QUERYLABELS', 'VALUES', 'location', 'FILTER', 'type=sensor']
+      );
+    });
+
+    it('multiple filters', () => {
+      assert.deepEqual(
+        parseArgs(QUERYLABELS_VALUES, 'location', ['type=sensor', 'sensortype=temp']),
+        ['TS.QUERYLABELS', 'VALUES', 'location', 'FILTER', 'type=sensor', 'sensortype=temp']
+      );
+    });
+
+    it('throws on an explicitly empty filter list', () => {
+      assert.throws(() => parseArgs(QUERYLABELS_VALUES, 'location', []));
+    });
+  });
+
+  testUtils.testWithClient('client.ts.queryLabelValues (with filter)', async client => {
+    await Promise.all([
+      client.ts.create('ts1', { LABELS: { type: 'sensor', location: 'LivingRoom' } }),
+      client.ts.create('ts2', { LABELS: { type: 'sensor', location: 'Kitchen' } }),
+      client.ts.create('ts3', { LABELS: { type: 'gauge', location: 'BedRoom' } })
+    ]);
+
+    const reply = await client.ts.queryLabelValues('location', ['type=sensor']);
+    assert.deepEqual(
+      [...reply].sort(),
+      ['Kitchen', 'LivingRoom']
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.queryLabelValues (no filter)', async client => {
+    await Promise.all([
+      client.ts.create('ts1', { LABELS: { location: 'LivingRoom' } }),
+      client.ts.create('ts2', { LABELS: { location: 'Kitchen' } })
+    ]);
+
+    const reply = await client.ts.queryLabelValues('location');
+    assert.deepEqual(
+      [...reply].sort(),
+      ['Kitchen', 'LivingRoom']
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.queryLabelValues (unknown label is empty, not an error)', async client => {
+    await client.ts.create('ts1', { LABELS: { type: 'sensor', location: 'LivingRoom' } });
+
+    const reply = await client.ts.queryLabelValues('nope', ['type=sensor']);
+    assert.deepEqual([...reply], []);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+});

--- a/packages/time-series/lib/commands/QUERYLABELS_VALUES.ts
+++ b/packages/time-series/lib/commands/QUERYLABELS_VALUES.ts
@@ -1,0 +1,24 @@
+import { CommandParser } from '@redis/client/dist/lib/client/parser';
+import { RedisArgument, ArrayReply, BlobStringReply, SetReply, Command } from '@redis/client/dist/lib/RESP/types';
+import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
+import { parseQueryLabelsFilterArgument } from './helpers';
+
+/**
+ * `TS.QUERYLABELS VALUES label [FILTER filterExpr ...]` — the set of all values
+ * assigned to `label` across matching (and readable) time series. Added in
+ * RedisTimeSeries 8.10. The `label` is matched byte-exactly and is not
+ * normalized. Keyless; in cluster mode the server performs the cluster-wide
+ * fan-out and returns a single merged, deduplicated reply.
+ */
+export default {
+  NOT_KEYED_COMMAND: true,
+  IS_READ_ONLY: true,
+  parseCommand(parser: CommandParser, label: RedisArgument, filter?: RedisVariadicArgument) {
+    parser.push('TS.QUERYLABELS', 'VALUES', label);
+    parseQueryLabelsFilterArgument(parser, filter);
+  },
+  transformReply: {
+    2: undefined as unknown as () => ArrayReply<BlobStringReply>,
+    3: undefined as unknown as () => SetReply<BlobStringReply>
+  }
+} as const satisfies Command;

--- a/packages/time-series/lib/commands/helpers.ts
+++ b/packages/time-series/lib/commands/helpers.ts
@@ -308,6 +308,27 @@ export function parseSelectedLabelsArguments(
   parser.pushVariadic(selectedLabels);
 }
 
+/**
+ * Pushes the optional `FILTER filterExpr [filterExpr ...]` tail shared by the
+ * `TS.QUERYLABELS` forms. Omitting `filter` queries all indexed series; passing
+ * an explicitly empty array is a local usage error rather than a silent widen to
+ * all series (the server also rejects a bare `FILTER` token). Expressions are
+ * sent verbatim — not parsed, reordered, or deduplicated.
+ */
+export function parseQueryLabelsFilterArgument(
+  parser: CommandParser,
+  filter?: RedisVariadicArgument
+) {
+  if (filter === undefined) return;
+
+  if (Array.isArray(filter) && filter.length === 0) {
+    throw new Error('FILTER was given an empty filter expression list; omit it to query all indexed series');
+  }
+
+  parser.push('FILTER');
+  parser.pushVariadic(filter);
+}
+
 export type RawLabelValue = BlobStringReply | NullReply;
 
 export type RawLabels<T extends RawLabelValue> = ArrayReply<TuplesReply<[

--- a/packages/time-series/lib/commands/index.ts
+++ b/packages/time-series/lib/commands/index.ts
@@ -32,6 +32,8 @@ import MREVRANGE_WITHLABELS_GROUPBY from './MREVRANGE_WITHLABELS_GROUPBY';
 import MREVRANGE_WITHLABELS from './MREVRANGE_WITHLABELS';
 import MREVRANGE from './MREVRANGE';
 import QUERYINDEX from './QUERYINDEX';
+import QUERYLABELS from './QUERYLABELS';
+import QUERYLABELS_VALUES from './QUERYLABELS_VALUES';
 import READ from './READ';
 import RANGE_MULTIAGGR from './RANGE_MULTIAGGR';
 import RANGE from './RANGE';
@@ -550,6 +552,32 @@ export default {
    * @param filter - Filter to match time series labels
    */
   queryIndex: QUERYINDEX,
+  /**
+   * Returns all label names present on time series matching a filter (or all indexed series when the filter is omitted).
+   * Added since Redis 8.10.
+   * @param filter - Optional filter expression(s) (same language as `TS.QUERYINDEX`); omit to query all indexed series
+   */
+  QUERYLABELS,
+  /**
+   * Returns all label names present on time series matching a filter (or all indexed series when the filter is omitted).
+   * Added since Redis 8.10.
+   * @param filter - Optional filter expression(s) (same language as `TS.QUERYINDEX`); omit to query all indexed series
+   */
+  queryLabels: QUERYLABELS,
+  /**
+   * Returns all values assigned to a label across time series matching a filter (or all indexed series when the filter is omitted).
+   * Added since Redis 8.10.
+   * @param label - Label name whose values are collected; matched byte-exactly
+   * @param filter - Optional filter expression(s) (same language as `TS.QUERYINDEX`); omit to query all indexed series
+   */
+  QUERYLABELS_VALUES,
+  /**
+   * Returns all values assigned to a label across time series matching a filter (or all indexed series when the filter is omitted).
+   * Added since Redis 8.10.
+   * @param label - Label name whose values are collected; matched byte-exactly
+   * @param filter - Optional filter expression(s) (same language as `TS.QUERYINDEX`); omit to query all indexed series
+   */
+  queryLabelValues: QUERYLABELS_VALUES,
   /**
    * Reads a batch of samples with timestamp at or after a cursor, in ascending timestamp order.
    * With `BLOCK`, waits until at least `minCount` samples qualify or the timeout elapses.


### PR DESCRIPTION
This pull request adds client support for `TS.QUERYLABELS`, introduced in RedisTimeSeries 8.10. The command returns label metadata for time series matching a filter: the set of all label names (`LABELS`), or the set of all values of one label name (`VALUES label`). It completes the Grafana-style drill-down flow alongside the existing `TS.QUERYINDEX`.

Two methods are exposed so the mandatory `label` argument of the `VALUES` form is enforced by the signature:
- `client.ts.queryLabels(filter?)` → `TS.QUERYLABELS LABELS [FILTER ...]`
- `client.ts.queryLabelValues(label, filter?)` → `TS.QUERYLABELS VALUES label [FILTER ...]`

The command is keyless and read-only; in cluster mode the receiving shard performs the cluster-wide fan-out and returns a single merged, deduplicated reply, so clients use default keyless routing with no client-side aggregation. Filter expressions reuse the existing `TS.QUERYINDEX` filter representation and are sent verbatim (not parsed, reordered, or deduplicated). The reply is a flat array under RESP2 and a set under RESP3; an empty reply is a valid success.

Behavior notes:
- `FILTER` is optional in both forms; omitting it queries all indexed series.
- Passing an explicitly empty filter array raises a local usage error rather than silently widening to all series (a bare `FILTER` token is rejected by the server).
- The reply is unordered and already deduplicated; documented and tested as such.
- Not eligible for client-side caching (server advertises the `dont_cache` tip).

New `QUERYLABELS.ts` / `QUERYLABELS_VALUES.ts` (+ co-located specs), a shared `parseQueryLabelsFilterArgument` helper in `helpers.ts`, and registry entries with JSDoc in `commands/index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only command bindings and tests only; no changes to existing command behavior.
> 
> **Overview**
> Adds client support for **RedisTimeSeries 8.10** `TS.QUERYLABELS`, exposing **`queryLabels(filter?)`** (`LABELS` — distinct label names) and **`queryLabelValues(label, filter?)`** (`VALUES` — distinct values for one label). Both are keyless, read-only commands with RESP2 array / RESP3 set replies, matching the existing `QUERYINDEX` pattern.
> 
> Optional filters reuse the same expression style as `TS.QUERYINDEX` and are appended via a new shared **`parseQueryLabelsFilterArgument`** helper; an explicitly empty filter array throws locally instead of widening to all series. Registry entries and integration tests cover argument encoding, filtered/unfiltered queries, empty results, and RESP2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80d6724a9727994dd598695172daf17a4026262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->