### PR TITLE
fix(search): preserve zero FT.CREATE scores

### DIFF
--- a/packages/search/lib/commands/CREATE.spec.ts
+++ b/packages/search/lib/commands/CREATE.spec.ts
@@ -440,6 +440,15 @@ describe('FT.CREATE', () => {
       );
     });
 
+    it('with SCORE 0', () => {
+      assert.deepEqual(
+        parseArgs(CREATE, 'index', {}, {
+          SCORE: 0
+        }),
+        ['FT.CREATE', 'index', 'SCORE', '0', 'SCHEMA']
+      );
+    });
+
     it('with SCORE_FIELD', () => {
       assert.deepEqual(
         parseArgs(CREATE, 'index', {}, {

--- a/packages/search/lib/commands/CREATE.ts
+++ b/packages/search/lib/commands/CREATE.ts
@@ -432,7 +432,7 @@ export default {
       parser.push('LANGUAGE_FIELD', options.LANGUAGE_FIELD);
     }
 
-    if (options?.SCORE) {
+    if (options?.SCORE !== undefined) {
       parser.push('SCORE', options.SCORE.toString());
     }
 


### PR DESCRIPTION
### Description

`FT.CREATE` dropped `SCORE: 0` because the parser used a truthy check. Redis accepts zero, so this forwards it and adds a regression test.

### Checklist

- [x] Search tests pass (272)
- [x] Lint, build, and command JSDoc checks pass
- [x] No docs change needed

Full suite: 3,313 passed; one unrelated socket timeout test timed out under load and passed alone.

Assisted by OpenAI Codex (GPT-5.6).
