### PR TITLE
feat(search): add RERANK parameter for HNSW vector fields

### DIFF
--- a/packages/search/lib/commands/CREATE.spec.ts
+++ b/packages/search/lib/commands/CREATE.spec.ts
@@ -207,6 +207,44 @@ describe('FT.CREATE', () => {
           );
         });
 
+        it('HNSW algorithm with RERANK', () => {
+          assert.deepEqual(
+            parseArgs(CREATE, 'index', {
+              field: {
+                type: SCHEMA_FIELD_TYPE.VECTOR,
+                ALGORITHM: SCHEMA_VECTOR_FIELD_ALGORITHM.HNSW,
+                TYPE: 'FLOAT32',
+                DIM: 2,
+                DISTANCE_METRIC: 'L2',
+                RERANK: true
+              }
+            }),
+            [
+              'FT.CREATE', 'index', 'SCHEMA', 'field', 'VECTOR', 'HNSW', '8', 'TYPE',
+              'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2', 'RERANK', 'TRUE'
+            ]
+          );
+        });
+
+        it('HNSW algorithm with RERANK false', () => {
+          assert.deepEqual(
+            parseArgs(CREATE, 'index', {
+              field: {
+                type: SCHEMA_FIELD_TYPE.VECTOR,
+                ALGORITHM: SCHEMA_VECTOR_FIELD_ALGORITHM.HNSW,
+                TYPE: 'FLOAT32',
+                DIM: 2,
+                DISTANCE_METRIC: 'L2',
+                RERANK: false
+              }
+            }),
+            [
+              'FT.CREATE', 'index', 'SCHEMA', 'field', 'VECTOR', 'HNSW', '8', 'TYPE',
+              'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2', 'RERANK', 'FALSE'
+            ]
+          );
+        });
+
         it('VAMANA algorithm', () => {
           assert.deepEqual(
             parseArgs(CREATE, 'index', {
@@ -639,6 +677,25 @@ describe('FT.CREATE', () => {
         },
       }),
       "OK"
+    );
+  }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClientIfVersionWithinRange([[8, 10], 'LATEST'], 'client.ft.create vector hnsw rerank', async client => {
+    // RERANK is only valid for disk-based vector indexes, which the OSS test
+    // server cannot create. Assert the parameter reaches the server and is
+    // recognized (rejected only for the index type, not as a syntax error).
+    await assert.rejects(
+      client.ft.create('index_hnsw_rerank', {
+        field: {
+          type: SCHEMA_FIELD_TYPE.VECTOR,
+          ALGORITHM: SCHEMA_VECTOR_FIELD_ALGORITHM.HNSW,
+          TYPE: 'FLOAT32',
+          DIM: 5,
+          DISTANCE_METRIC: 'L2',
+          RERANK: true
+        },
+      }),
+      /disk-based/
     );
   }, GLOBAL.SERVERS.OPEN);
 

--- a/packages/search/lib/commands/CREATE.ts
+++ b/packages/search/lib/commands/CREATE.ts
@@ -81,6 +81,11 @@ interface SchemaHNSWVectorField extends SchemaVectorField {
   M?: number;
   EF_CONSTRUCTION?: number;
   EF_RUNTIME?: number;
+  /**
+   * Enable reranking. Requires a disk-based vector index.
+   * available since 8.10
+   */
+  RERANK?: boolean;
 }
 
 export const VAMANA_COMPRESSION_ALGORITHM = {
@@ -291,6 +296,10 @@ export function parseSchema(parser: CommandParser, schema: RediSearchSchema) {
 
               if (fieldOptions.EF_RUNTIME !== undefined) {
                 args.push('EF_RUNTIME', fieldOptions.EF_RUNTIME.toString());
+              }
+
+              if (fieldOptions.RERANK !== undefined) {
+                args.push('RERANK', fieldOptions.RERANK ? 'TRUE' : 'FALSE');
               }
 
               break;


### PR DESCRIPTION
This pull request adds support for the `RERANK` parameter on HNSW vector field definitions in `FT.CREATE`, introduced in Redis 8.10 (RediSearch, for disk-based vector indexes).

- New optional `RERANK?: boolean` on the HNSW schema vector field type.
- When set, the client emits `RERANK TRUE` or `RERANK FALSE` as a key-value pair in the field definition.
- No default value — the parameter is only sent when explicitly provided, matching the server contract where users must specify it for disk-based indexes.

The parameter is HNSW-only; `FLAT` and `SVS-VAMANA` are unaffected and the type narrowing makes `RERANK` a compile error on those algorithms. The value is passed through as-is, so MVP (`TRUE`-only) vs later (`FALSE` allowed) validation stays server-side.

Note: creating a disk-based vector index is a server capability and is not exposed as an `FT.CREATE` client flag, so the 8.10-gated live test asserts the parameter reaches the server and is recognized (rejected only for the index type, not as a syntax error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in schema serialization in the search client only; no changes to connection, auth, or existing index defaults.
> 
> **Overview**
> Adds optional **`RERANK`** on **HNSW** vector fields in `FT.CREATE` (Redis 8.10 / disk-based indexes). When set, the client emits `RERANK TRUE` or `RERANK FALSE`; if omitted, nothing is sent.
> 
> Types limit `RERANK` to HNSW so FLAT and SVS-VAMANA schemas are unchanged. Tests cover argument transformation and a version-gated integration check that the server accepts the token (OSS tests expect a disk-based index rejection, not a syntax error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e274124f677193dac9fb04be70bd68c5b73b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->