### PR TITLE
fix(test): raise timeout for cluster PubSub listener-move test

### DIFF
--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -431,7 +431,10 @@ describe('Cluster', () => {
     }, {
       serverArguments: [],
       numberOfMasters: 2,
-      minimumDockerVersion: [7]
+      minimumDockerVersion: [7],
+      // reassigning all 8192 slots one-by-one plus polling both nodes for
+      // `cluster_state:ok` can exceed mocha's default 2000ms on slow CI runners
+      testTimeout: 30000
     });
 
     testUtils.testWithCluster('ssubscribe & sunsubscribe', async cluster => {

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -390,7 +390,7 @@ describe('Cluster', () => {
           cluster.nodeClient(importing)
         ]);
 
-      const range = cluster.slots[0].master === migrating ? {
+      const range = cluster.slots[0].master.address === migrating.address ? {
         key: 'bar', // 5061
         start: 0,
         end: 8191
@@ -400,18 +400,21 @@ describe('Cluster', () => {
         end: 16383
       };
 
-      // reassigning slots with `CLUSTER SETSLOT .. NODE` can leave the nodes in a
-      // transient `cluster_state:fail` state, so claim the slots on the importing
-      // node first, then release them on the migrating node, and wait for both
-      // nodes to report a healthy cluster before going on
-      const importingPromises: Array<Promise<unknown>> = [],
-        migratingPromises: Array<Promise<unknown>> = [];
-      for (let i = range.start; i <= range.end; i++) {
-        importingPromises.push(importingClient.clusterSetSlot(i, 'NODE', importing.id));
-        migratingPromises.push(migratingClient.clusterSetSlot(i, 'NODE', importing.id));
-      }
-      await Promise.all(importingPromises);
-      await Promise.all(migratingPromises);
+      // Reassign the whole slot range in one shot with DEL/ADDSLOTSRANGE
+      // instead of thousands of per-slot `CLUSTER SETSLOT .. NODE` calls,
+      // which overflowed the test timeout on slow CI runners. Release the
+      // range on both nodes first (`CLUSTER ADDSLOTS` rejects a slot that is
+      // still assigned in the node's own cluster view, and gossip has not yet
+      // propagated the migrating node's release to the importing node), then
+      // claim it on the importing node, then wait for both nodes to reconverge
+      // to a healthy cluster before going on (the reassignment leaves a
+      // transient `cluster_state:fail` window).
+      const slotRange = { start: range.start, end: range.end };
+      await Promise.all([
+        migratingClient.clusterDelSlotsRange(slotRange),
+        importingClient.clusterDelSlotsRange(slotRange)
+      ]);
+      await importingClient.clusterAddSlotsRange(slotRange);
 
       for (const client of [migratingClient, importingClient]) {
         while (!(await client.clusterInfo()).startsWith('cluster_state:ok')) {
@@ -432,8 +435,8 @@ describe('Cluster', () => {
       serverArguments: [],
       numberOfMasters: 2,
       minimumDockerVersion: [7],
-      // reassigning all 8192 slots one-by-one plus polling both nodes for
-      // `cluster_state:ok` can exceed mocha's default 2000ms on slow CI runners
+      // range reassignment plus polling both nodes for `cluster_state:ok` can
+      // exceed mocha's default 2000ms on slow CI runners
       testTimeout: 30000
     });
 

--- a/packages/test-utils/lib/index.ts
+++ b/packages/test-utils/lib/index.ts
@@ -109,6 +109,7 @@ interface CommonTestOptions {
   serverArguments: Array<string>;
   minimumDockerVersion?: Array<number>;
   skipTest?: boolean;
+  testTimeout?: number;
 }
 
 interface ClientTestOptions<
@@ -886,6 +887,7 @@ export default class TestUtils {
     }
 
     it(title, async function () {
+      if (options.testTimeout) this.timeout(options.testTimeout);
       if (options.skipTest) return this.skip();
       if (!dockersPromise) return this.skip();
       const RESP = (options.clusterConfiguration?.RESP ?? DEFAULT_RESP) as RESP;


### PR DESCRIPTION
This pull request fixes a flaky CI failure in the cluster PubSub test `should move listeners when PubSub node disconnects from the cluster`, which has been intermittently failing across many PRs with:

```
Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

**Background:** #3347 fixed the earlier `CLUSTERDOWN` flake by claiming slots on the importing node first, releasing them on the migrating node, then polling both nodes for `cluster_state:ok` before triggering the MOVED redirect. That removed the `CLUSTERDOWN` window but made the test body heavier — it reassigns all 8192 slots one-by-one and then polls each node. On slow CI runners that work exceeds mocha's default 2000ms per-test timeout.

`testWithCluster` ran its `it()` at the default timeout with no override (only the `before` hook set 30000ms, which does not apply to the test). This adds an optional `testTimeout` to the shared `CommonTestOptions`, applies it in `testWithCluster`'s `it()` when set, and raises this test's timeout to 30000ms.

**Behavior note:** the option is guarded (`if (options.testTimeout) this.timeout(...)`), so all other cluster tests keep the default timeout and are unaffected. The test typically finishes fast; the higher ceiling only covers the worst-case slow-runner path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test helpers and one cluster integration test; no production client or runtime behavior is modified.
> 
> **Overview**
> Stabilizes the cluster PubSub test **should move listeners when PubSub node disconnects from the cluster** by replacing thousands of per-slot `CLUSTER SETSLOT .. NODE` calls with **`clusterDelSlotsRange` / `clusterAddSlotsRange`** on the migrating and importing nodes, then polling until both report `cluster_state:ok`. Slot selection now compares **master addresses** instead of object identity when picking the half-cluster range to move.
> 
> **`test-utils`** gains optional **`testTimeout`** on shared cluster test options; `testWithCluster` applies it to the Mocha `it()` when set. This test uses **30s** so slow CI runners are not capped by the default 2s test timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c075f004c7966134463f5bd6db173fb61bbc0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->