### PR TITLE
ci: fix release-drafter Maintenance category key

### DIFF
--- a/.github/release-drafter/bloom-config.yml
+++ b/.github/release-drafter/bloom-config.yml
@@ -28,7 +28,7 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    label:
+    labels:
       - 'chore'
       - 'maintenance'
       - 'documentation'

--- a/.github/release-drafter/entraid-config.yml
+++ b/.github/release-drafter/entraid-config.yml
@@ -28,7 +28,7 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    label:
+    labels:
       - 'chore'
       - 'maintenance'
       - 'documentation'

--- a/.github/release-drafter/json-config.yml
+++ b/.github/release-drafter/json-config.yml
@@ -28,7 +28,7 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    label:
+    labels:
       - 'chore'
       - 'maintenance'
       - 'documentation'

--- a/.github/release-drafter/search-config.yml
+++ b/.github/release-drafter/search-config.yml
@@ -28,7 +28,7 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    label:
+    labels:
       - 'chore'
       - 'maintenance'
       - 'documentation'

--- a/.github/release-drafter/time-series-config.yml
+++ b/.github/release-drafter/time-series-config.yml
@@ -28,7 +28,7 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    label:
+    labels:
       - 'chore'
       - 'maintenance'
       - 'documentation'


### PR DESCRIPTION
## Description

The `update_release_draft` workflow fails on `master` because every module release-drafter config uses the singular `label:` key with a **list** of values in the Maintenance category. release-drafter's schema expects `label` to be a single string and `labels` to be the array form, so config parsing fails Zod validation:

```
categories[3].label: expected "string", invalid_type
```

([failing run](https://github.com/redis/node-redis/actions/runs/29844596031/job/88681838237))

## Fix

Rename `label:` → `labels:` in the Maintenance category of all five configs (bloom, entraid, json, search, time-series). The other three categories in each file already correctly use `labels:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only YAML schema fix with no runtime or application behavior changes.
> 
> **Overview**
> Fixes failing **`update_release_draft`** runs by correcting the Maintenance category in five module release-drafter configs (`bloom`, `entraid`, `json`, `search`, `time-series`).
> 
> Each file had **`label:`** with a list of values under **🧰 Maintenance**, which breaks release-drafter’s schema (`categories[3].label` expected a string). The key is renamed to **`labels:`**, matching the other categories in the same files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e6f7b9acb5a56b9fbdfa71702df37bbb8cfb2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->