### PR TITLE
feat(time-series): support multiple aggregators per key in TS.NRANGE/TS.NREVRANGE

### DIFF
--- a/packages/time-series/lib/commands/NRANGE.spec.ts
+++ b/packages/time-series/lib/commands/NRANGE.spec.ts
@@ -20,7 +20,7 @@ describe('TS.NRANGE', () => {
     );
   });
 
-  it('transformArguments (all options, aggregators as separate tokens)', () => {
+  it('transformArguments (all options, one aggregator per key)', () => {
     assert.deepEqual(
       parseArgs(NRANGE, ['a', 'b', 'c'], '-', '+', {
         LATEST: true,
@@ -33,9 +33,9 @@ describe('TS.NRANGE', () => {
         ALIGN: '-',
         AGGREGATION: {
           types: [
-            TIME_SERIES_AGGREGATION_TYPE.FIRST,
-            TIME_SERIES_AGGREGATION_TYPE.MAX,
-            TIME_SERIES_AGGREGATION_TYPE.MIN
+            [TIME_SERIES_AGGREGATION_TYPE.FIRST],
+            [TIME_SERIES_AGGREGATION_TYPE.MAX],
+            [TIME_SERIES_AGGREGATION_TYPE.MIN]
           ],
           timeBucket: 10000,
           BUCKETTIMESTAMP: TIME_SERIES_BUCKET_TIMESTAMP.LOW,
@@ -47,6 +47,27 @@ describe('TS.NRANGE', () => {
         'FILTER_BY_TS', '0', '1', 'FILTER_BY_VALUE', '1', '2', 'COUNT', '1',
         'ALIGN', '-', 'AGGREGATION', 'FIRST', 'MAX', 'MIN', '10000',
         'BUCKETTIMESTAMP', '-', 'EMPTY'
+      ]
+    );
+  });
+
+  it('transformArguments (multiple aggregators per key, comma-joined)', () => {
+    assert.deepEqual(
+      parseArgs(NRANGE, ['a', 'b'], '-', '+', {
+        AGGREGATION: {
+          types: [
+            [
+              TIME_SERIES_AGGREGATION_TYPE.AVG,
+              TIME_SERIES_AGGREGATION_TYPE.MAX
+            ],
+            [TIME_SERIES_AGGREGATION_TYPE.SUM]
+          ],
+          timeBucket: 1000
+        }
+      }),
+      [
+        'TS.NRANGE', '2', 'a', 'b', '-', '+',
+        'AGGREGATION', 'AVG,MAX', 'SUM', '1000'
       ]
     );
   });
@@ -88,8 +109,8 @@ describe('TS.NRANGE', () => {
     const reply = await client.ts.nRange(['{t}:1', '{t}:2'], 0, 3000, {
       AGGREGATION: {
         types: [
-          TIME_SERIES_AGGREGATION_TYPE.MAX,
-          TIME_SERIES_AGGREGATION_TYPE.MIN
+          [TIME_SERIES_AGGREGATION_TYPE.MAX],
+          [TIME_SERIES_AGGREGATION_TYPE.MIN]
         ],
         timeBucket: 1000
       }
@@ -97,6 +118,38 @@ describe('TS.NRANGE', () => {
 
     assert.deepEqual(reply, [
       { timestamp: 1000, values: [20, 5] }
+    ]);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    minimumDockerVersion: [8, 10]
+  });
+
+  testUtils.testWithClient('client.ts.nRange (multiple aggregators per key)', async client => {
+    await Promise.all([
+      client.ts.create('{t}:1'),
+      client.ts.create('{t}:2')
+    ]);
+    await Promise.all([
+      client.ts.add('{t}:1', 1000, 10),
+      client.ts.add('{t}:1', 1500, 20),
+      client.ts.add('{t}:2', 1000, 5)
+    ]);
+
+    const reply = await client.ts.nRange(['{t}:1', '{t}:2'], 0, 3000, {
+      AGGREGATION: {
+        types: [
+          [
+            TIME_SERIES_AGGREGATION_TYPE.MIN,
+            TIME_SERIES_AGGREGATION_TYPE.MAX
+          ],
+          [TIME_SERIES_AGGREGATION_TYPE.SUM]
+        ],
+        timeBucket: 1000
+      }
+    });
+
+    assert.deepEqual(reply, [
+      { timestamp: 1000, values: [10, 20, 5] }
     ]);
   }, {
     ...GLOBAL.SERVERS.OPEN,

--- a/packages/time-series/lib/commands/NRANGE.ts
+++ b/packages/time-series/lib/commands/NRANGE.ts
@@ -10,14 +10,20 @@ import {
 import { TimeSeriesBucketTimestamp } from './RANGE';
 import { TimeSeriesAggregationTypeList } from './RANGE_MULTIAGGR';
 
+/**
+ * One aggregation group per key. Each group is a non-empty list of aggregators
+ * emitted as a single comma-joined token (e.g. `avg,max`); the group list length
+ * must equal the key list length. See RedisTimeSeries#2079.
+ */
+export type TimeSeriesAggregationTypeGroups = [
+  TimeSeriesAggregationTypeList,
+  ...Array<TimeSeriesAggregationTypeList>
+];
+
 export interface TsNRangeOptions extends TsRangeCommonOptions {
   ALIGN?: Timestamp;
   AGGREGATION?: {
-    /**
-     * One aggregator per key argument; length must equal the key list length.
-     * Emitted as separate tokens (never the comma-joined form).
-     */
-    types: TimeSeriesAggregationTypeList;
+    types: TimeSeriesAggregationTypeGroups;
     timeBucket: Timestamp;
     BUCKETTIMESTAMP?: TimeSeriesBucketTimestamp;
     EMPTY?: boolean;
@@ -38,8 +44,8 @@ export function parseNRangeArguments(
     }
 
     parser.push('AGGREGATION');
-    for (const type of options.AGGREGATION.types) {
-      parser.push(type);
+    for (const group of options.AGGREGATION.types) {
+      parser.push(group.join(','));
     }
     parser.push(transformTimestampArgument(options.AGGREGATION.timeBucket));
 

--- a/packages/time-series/lib/commands/NREVRANGE.spec.ts
+++ b/packages/time-series/lib/commands/NREVRANGE.spec.ts
@@ -12,13 +12,13 @@ describe('TS.NREVRANGE', () => {
     );
   });
 
-  it('transformArguments (aggregators as separate tokens)', () => {
+  it('transformArguments (one aggregator per key)', () => {
     assert.deepEqual(
       parseArgs(NREVRANGE, ['a', 'b'], '-', '+', {
         AGGREGATION: {
           types: [
-            TIME_SERIES_AGGREGATION_TYPE.MIN,
-            TIME_SERIES_AGGREGATION_TYPE.MAX
+            [TIME_SERIES_AGGREGATION_TYPE.MIN],
+            [TIME_SERIES_AGGREGATION_TYPE.MAX]
           ],
           timeBucket: 1000
         }
@@ -26,6 +26,27 @@ describe('TS.NREVRANGE', () => {
       [
         'TS.NREVRANGE', '2', 'a', 'b', '-', '+',
         'AGGREGATION', 'MIN', 'MAX', '1000'
+      ]
+    );
+  });
+
+  it('transformArguments (multiple aggregators per key, comma-joined)', () => {
+    assert.deepEqual(
+      parseArgs(NREVRANGE, ['a', 'b'], '-', '+', {
+        AGGREGATION: {
+          types: [
+            [
+              TIME_SERIES_AGGREGATION_TYPE.MIN,
+              TIME_SERIES_AGGREGATION_TYPE.MAX
+            ],
+            [TIME_SERIES_AGGREGATION_TYPE.SUM]
+          ],
+          timeBucket: 1000
+        }
+      }),
+      [
+        'TS.NREVRANGE', '2', 'a', 'b', '-', '+',
+        'AGGREGATION', 'MIN,MAX', 'SUM', '1000'
       ]
     );
   });


### PR DESCRIPTION
This pull request updates `TS.NRANGE` and `TS.NREVRANGE` to support multiple aggregators per key, matching the semantics finalized in RedisTimeSeries#2079 (merged Jul 2) and the updated HLD.

## Background

The originally merged implementation (#3337) exposed a typed API that accepted only **one aggregator per key** (`AGGREGATION.types` was a flat `TimeSeriesAggregationTypeList`, one entry per key, emitted as separate tokens). The server and HLD now define **one aggregation token per key, where each token may hold multiple comma-separated aggregators** — e.g. `AGGREGATION avg,max sum 1000` gives key 1 both `avg` and `max`, key 2 `sum`. The merged wire format was still valid, but the typed API could not express the multi-aggregator case.

## Changes

- `NRANGE.ts`: `AGGREGATION.types` changes from `TimeSeriesAggregationTypeList` to a new `TimeSeriesAggregationTypeGroups` — an array of per-key groups (`[TimeSeriesAggregationTypeList, ...TimeSeriesAggregationTypeList[]]`). Each group is emitted as a single comma-joined token (`group.join(',')`).
- `NREVRANGE.ts`: unchanged — reuses NRANGE's parser.
- The shared `TimeSeriesAggregationTypeList` (used by single-key `TS.RANGE`) is deliberately left untouched.
- Specs updated to the grouped shape; added arg + behavior tests for the multiple-aggregators-per-key case.

## Compatibility

This is a **breaking change to the typed API introduced in #3337**. Existing callers using the flat form (`types: [MAX, MIN]`) must migrate to the grouped form (`types: [[MAX], [MIN]]`). The generated wire output for single-aggregator-per-key usage is unchanged, so no server-side behavior regresses. Since #3337 is unreleased, this only affects branch/edge consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to an unreleased typed API; wire format for one aggregator per key is preserved, but misuse of the new nested shape could send invalid AGGREGATION arguments.
> 
> **Overview**
> **`AGGREGATION.types` for `TS.NRANGE` / `TS.NREVRANGE` is now an array of per-key aggregator groups** (e.g. `[[MAX], [MIN]]` or `[[MIN, MAX], [SUM]]`) instead of a flat one-aggregator-per-key list. Each group is serialized as a **single comma-joined token** on the wire (`MIN,MAX`, `SUM`), aligning with RedisTimeSeries#2079.
> 
> Callers who used the previous flat shape must wrap each aggregator in its own inner array; **single-aggregator-per-key wire output is unchanged**. `NREVRANGE` picks up the behavior via the shared `NRANGE` argument parser. Specs add transform and integration coverage for multi-aggregator-per-key cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e959ff0b3df10e682abf9ec216cdb48e6bcb36cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->