### PR TITLE
feat(client): support replicas-only read load balancing in Redis Cluster

### DIFF
--- a/packages/client/lib/cluster/cluster-slots.spec.ts
+++ b/packages/client/lib/cluster/cluster-slots.spec.ts
@@ -98,5 +98,38 @@ describe('RedisClusterSlots', () => {
         assert.strictEqual(node.readonly, true);
       }
     });
+
+    it('should fall back to master node when replicas array becomes empty in "only" mode', () => {
+      const slots = new RedisClusterSlots({
+        rootNodes: [],
+        useReplicas: 'only'
+      }, () => true, 'client-id');
+      
+      const masterNode = { address: '127.0.0.1:7000', host: '127.0.0.1', port: 7000, id: 'master', readonly: false };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal stub node
+      slots.masters.push(masterNode as any);
+
+      // Call getRandomNode when replicas is empty
+      const node = slots.getRandomNode();
+      assert.strictEqual(node.address, masterNode.address);
+    });
+
+    it('should return master node for getRandomMasterNode', () => {
+      const slots = new RedisClusterSlots({
+        rootNodes: [],
+        useReplicas: 'only'
+      }, () => true, 'client-id');
+      
+      const masterNode = { address: '127.0.0.1:7000', host: '127.0.0.1', port: 7000, id: 'master', readonly: false };
+      const replicaNode = { address: '127.0.0.1:7001', host: '127.0.0.1', port: 7001, id: 'replica', readonly: true };
+      
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal stub node
+      slots.masters.push(masterNode as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal stub node
+      slots.replicas.push(replicaNode as any);
+
+      const node = slots.getRandomMasterNode();
+      assert.strictEqual(node.address, masterNode.address);
+    });
   });
 });

--- a/packages/client/lib/cluster/cluster-slots.spec.ts
+++ b/packages/client/lib/cluster/cluster-slots.spec.ts
@@ -48,9 +48,55 @@ describe('RedisClusterSlots', () => {
     it('should not enter infinite loop when no nodes', () => {
         const slots = new RedisClusterSlots({
           rootNodes: []
-        }, () => true)
+        }, () => true, 'client-id')
         slots.getRandomNode()
         slots.getRandomNode()
       });
+
+    it('should only return replica nodes when useReplicas is "only"', () => {
+      const slots = new RedisClusterSlots({
+        rootNodes: [],
+        useReplicas: 'only'
+      }, () => true, 'client-id');
+      
+      const masterNode = { address: '127.0.0.1:7000', host: '127.0.0.1', port: 7000, id: 'master', readonly: false };
+      const replicaNode1 = { address: '127.0.0.1:7001', host: '127.0.0.1', port: 7001, id: 'replica1', readonly: true };
+      const replicaNode2 = { address: '127.0.0.1:7002', host: '127.0.0.1', port: 7002, id: 'replica2', readonly: true };
+      
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal stub nodes
+      slots.masters.push(masterNode as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal stub nodes
+      slots.replicas.push(replicaNode1 as any, replicaNode2 as any);
+      
+      for (let i = 0; i < 20; i++) {
+        const node = slots.getRandomNode();
+        assert.notEqual(node.address, masterNode.address);
+        assert.strictEqual(node.readonly, true);
+      }
+    });
+
+    it('should only return replica nodes for a slot when useReplicas is "only"', () => {
+      const slots = new RedisClusterSlots({
+        rootNodes: [],
+        useReplicas: 'only'
+      }, () => true, 'client-id');
+      
+      const masterNode = { address: '127.0.0.1:7000', host: '127.0.0.1', port: 7000, id: 'master', readonly: false };
+      const replicaNode1 = { address: '127.0.0.1:7001', host: '127.0.0.1', port: 7001, id: 'replica1', readonly: true };
+      const replicaNode2 = { address: '127.0.0.1:7002', host: '127.0.0.1', port: 7002, id: 'replica2', readonly: true };
+      
+      slots.slots[0] = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal stub nodes
+        master: masterNode as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal stub nodes
+        replicas: [replicaNode1 as any, replicaNode2 as any]
+      };
+      
+      for (let i = 0; i < 20; i++) {
+        const node = slots.getSlotRandomNode(0);
+        assert.notEqual(node.address, masterNode.address);
+        assert.strictEqual(node.readonly, true);
+      }
+    });
   });
 });

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -828,8 +828,11 @@ export default class RedisClusterSlots<
     this.#assertReady();
 
     if (!firstKey) {
+      const node = isReadonly === false ?
+        this.getRandomMasterNode() :
+        this.getRandomNode();
       return {
-        client: await this.nodeClient(this.getRandomNode())
+        client: await this.nodeClient(node)
       };
     }
 
@@ -870,8 +873,14 @@ export default class RedisClusterSlots<
       } while (++i < this.replicas.length);
 
       while (true) {
-        for (const replica of this.replicas) {
-          yield replica;
+        if (this.replicas.length > 0) {
+          for (const replica of this.replicas) {
+            yield replica;
+          }
+        } else {
+          for (const master of this.masters) {
+            yield master;
+          }
         }
       }
     }
@@ -909,6 +918,14 @@ export default class RedisClusterSlots<
     return this._randomNodeIterator.next().value as ShardNode<M, F, S, RESP, TYPE_MAPPING>;
   }
 
+  getRandomMasterNode() {
+    if (this.masters.length === 0) {
+      return this.getRandomNode();
+    }
+    const index = Math.floor(Math.random() * this.masters.length);
+    return this.masters[index];
+  }
+
   *#slotNodesIterator(slot: ShardWithReplicas<M, F, S, RESP, TYPE_MAPPING>) {
     if (this.#options.useReplicas === 'only') {
       let i = Math.floor(Math.random() * slot.replicas.length);
@@ -917,8 +934,12 @@ export default class RedisClusterSlots<
       } while (++i < slot.replicas.length);
 
       while (true) {
-        for (const replica of slot.replicas) {
-          yield replica;
+        if (slot.replicas.length > 0) {
+          for (const replica of slot.replicas) {
+            yield replica;
+          }
+        } else {
+          yield slot.master;
         }
       }
     }

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -863,6 +863,18 @@ export default class RedisClusterSlots<
 
   *#iterateAllNodes() {
     if(this.masters.length + this.replicas.length === 0) return
+    if (this.#options.useReplicas === 'only' && this.replicas.length > 0) {
+      let i = Math.floor(Math.random() * this.replicas.length);
+      do {
+        yield this.replicas[i];
+      } while (++i < this.replicas.length);
+
+      while (true) {
+        for (const replica of this.replicas) {
+          yield replica;
+        }
+      }
+    }
     let i = Math.floor(Math.random() * (this.masters.length + this.replicas.length));
     if (i < this.masters.length) {
       do {
@@ -898,6 +910,18 @@ export default class RedisClusterSlots<
   }
 
   *#slotNodesIterator(slot: ShardWithReplicas<M, F, S, RESP, TYPE_MAPPING>) {
+    if (this.#options.useReplicas === 'only') {
+      let i = Math.floor(Math.random() * slot.replicas.length);
+      do {
+        yield slot.replicas[i];
+      } while (++i < slot.replicas.length);
+
+      while (true) {
+        for (const replica of slot.replicas) {
+          yield replica;
+        }
+      }
+    }
     let i = Math.floor(Math.random() * (1 + slot.replicas.length));
     if (i < slot.replicas.length) {
       do {

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -89,10 +89,10 @@ export interface RedisClusterOptions<
    */
   minimizeConnections?: boolean;
   /**
-   * When `true`, distribute load by executing readonly commands (such as `GET`, `GEOSEARCH`, etc.) across all cluster nodes. When `false`, only use master nodes.
+   * When `true`, distribute load by executing readonly commands (such as `GET`, `GEOSEARCH`, etc.) across all cluster nodes.
+   * When `'only'`, execute readonly commands exclusively on replica nodes. When `false`, only use master nodes.
    */
-  // TODO: replicas only mode?
-  useReplicas?: boolean;
+  useReplicas?: boolean | 'only';
   /**
    * The maximum number of times a command will be redirected due to `MOVED` or `ASK` errors.
    */

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -90,7 +90,8 @@ export interface RedisClusterOptions<
   minimizeConnections?: boolean;
   /**
    * When `true`, distribute load by executing readonly commands (such as `GET`, `GEOSEARCH`, etc.) across all cluster nodes.
-   * When `'only'`, execute readonly commands exclusively on replica nodes. When `false`, only use master nodes.
+   * When `'only'`, execute readonly commands on replica nodes (falling back to master nodes if a slot or cluster has no replicas).
+   * When `false`, only use master nodes.
    */
   useReplicas?: boolean | 'only';
   /**


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

This pull request resolves an architectural TODO by adding support for `'only'` mode in `useReplicas` cluster configuration (`useReplicas?: boolean | 'only'`).

When configured in high-throughput Redis Cluster environments, this mode ensures that readonly commands (such as `GET`, `HGETALL`, `SCAN`) are routed exclusively to replica shards, allowing primary (master) nodes to dedicate 100% of their compute and network bandwidth to writes and replication.

If a shard temporarily has no healthy replicas attached, routing gracefully falls back to the master node to prevent application downtime during failovers or topology transitions.

Two new unit tests have been added to `cluster-slots.spec.ts` to verify global and slot-specific replica-only routing behavior.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster command routing for a new config value; incorrect routing could send writes to replicas or overload masters, though behavior is covered by new unit tests and existing `true`/`false` paths are unchanged.
> 
> **Overview**
> Adds **`useReplicas: 'only'`** so readonly cluster commands are routed to replica nodes only, with fallback to masters when a shard or the cluster has no replicas.
> 
> **`RedisClusterSlots`** now branches in `#iterateAllNodes` and `#slotNodesIterator` for that mode, exposes **`getRandomMasterNode()`**, and uses it in **`getClientAndSlotNumber`** when there is no key and the command is not readonly (so writes do not pick a random replica). The **`useReplicas`** option type and docs in **`index.ts`** are updated accordingly.
> 
> Unit tests cover global/slot replica-only selection, master fallback with no replicas, and **`getRandomMasterNode`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fd10cda02380447c0f8da7b5d58f2e11b4071d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->