### PR TITLE
fix(cluster): make extractAllCommands drain the write queue

### DIFF
--- a/packages/client/lib/client/commands-queue.spec.ts
+++ b/packages/client/lib/client/commands-queue.spec.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert';
+import RedisCommandsQueue from './commands-queue';
+
+describe('RedisCommandsQueue', () => {
+  function createQueue() {
+    return new RedisCommandsQueue(3, null, () => {}, 'test-client');
+  }
+
+  describe('extractAllCommands', () => {
+    it('returns and removes every queued command, not just the first one', () => {
+      const queue = createQueue();
+      for (let i = 0; i < 5; i++) {
+        queue.addCommand([`CMD${i}`]).catch(() => {});
+      }
+
+      const extracted = queue.extractAllCommands();
+
+      assert.strictEqual(extracted.length, 5);
+      assert.deepStrictEqual(
+        extracted.map(command => command.args?.[0]),
+        ['CMD0', 'CMD1', 'CMD2', 'CMD3', 'CMD4'],
+      );
+      assert.strictEqual(queue.extractAllCommands().length, 0);
+    });
+  });
+});

--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -665,15 +665,16 @@ export default class RedisCommandsQueue {
   }
 
   /**
-   * Gets all commands from the write queue without removing them.
+   * Extracts all commands from the write queue.
    */
   extractAllCommands(): CommandToWrite[] {
     const result: CommandToWrite[] = [];
     let current = this.#toWrite.head;
     while (current) {
       result.push(current.value);
-      this.#toWrite.remove(current);
+      const toRemove = current;
       current = current.next;
+      this.#toWrite.remove(toRemove);
     }
     return result;
   }


### PR DESCRIPTION
Fixes #3363.

`extractAllCommands()` removed the current linked-list node before reading
`current.next`. `DoublyLinkedList.remove()` clears the removed node's links, so
the loop stopped after the first command and left the rest in the write queue.

This stores the next node before removing the current one, matching the pattern
used by `extractCommandsForSlots()`.

Also corrected the method comment, since this method does remove the commands it
returns.

Test added for extracting multiple queued commands and leaving the queue empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cluster slot migration relies on extractAllCommands to relocate slotless commands; the prior bug could leave commands stranded on a node with no slots.
> 
> **Overview**
> Fixes a bug in **`extractAllCommands()`** where only the first pending write-queue command was returned. The loop called **`remove()`** before advancing **`current`**, and **`DoublyLinkedList.remove()`** clears the removed node’s links, so **`current.next`** was lost and the rest of the queue stayed behind.
> 
> The implementation now saves the next node, then removes the current one—the same pattern as **`extractCommandsForSlots()`**—so the full write queue is extracted and drained. The method comment is updated to state that commands are removed, not merely read.
> 
> A unit test queues five commands and asserts they are all returned in order and that a second **`extractAllCommands()`** yields an empty queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf393bdaf0164b79109a3dcafca108730a8f900a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->