### PR TITLE
fix(cluster): rebind abort/timeout listeners when a command moves to another queue

### DIFF
--- a/packages/client/lib/client/commands-queue.spec.ts
+++ b/packages/client/lib/client/commands-queue.spec.ts
@@ -180,11 +180,13 @@ describe('RedisCommandsQueue', () => {
         new AbortController(),
         new AbortController(),
       ];
+      const settled = [false, false, false];
 
-      const promises = controllers.map((controller, i) =>
-        source.addCommand([`CMD${i}`], { abortSignal: controller.signal }),
-      );
-      promises.forEach(promise => promise.catch(() => {}));
+      const promises = controllers.map((controller, i) => {
+        const promise = source.addCommand([`CMD${i}`], { abortSignal: controller.signal });
+        promise.catch(() => {}).finally(() => { settled[i] = true; });
+        return promise;
+      });
 
       const commands = source.extractAllCommands();
       assert.strictEqual(commands.length, 3);
@@ -199,19 +201,26 @@ describe('RedisCommandsQueue', () => {
 
       // Abort out of order (middle, then last, then first) to confirm each
       // command's listener was independently rebound to its own node in the
-      // destination queue, and that removing one doesn't corrupt the
-      // destination's linked list for the others still queued.
+      // destination queue, and that cancelling one doesn't settle or corrupt
+      // the others still queued.
       controllers[1].abort();
       await assert.rejects(promises[1], AbortError);
+      assert.deepStrictEqual(settled, [false, true, false]);
       assert.strictEqual(destination.pendingCount, 2);
 
       controllers[2].abort();
       await assert.rejects(promises[2], AbortError);
+      assert.deepStrictEqual(settled, [false, true, true]);
       assert.strictEqual(destination.pendingCount, 1);
 
       controllers[0].abort();
       await assert.rejects(promises[0], AbortError);
-      assert.strictEqual(destination.pendingCount, 0);
+      assert.deepStrictEqual(settled, [true, true, true]);
+
+      // Check the destination queue by actually traversing it (not just its
+      // length counter), to confirm the linked list itself wasn't corrupted
+      // by the three removals above.
+      assert.strictEqual(destination.extractAllCommands().length, 0);
 
       // None of the cancellations should have reached back into the
       // already-drained source queue.

--- a/packages/client/lib/client/commands-queue.spec.ts
+++ b/packages/client/lib/client/commands-queue.spec.ts
@@ -171,5 +171,51 @@ describe('RedisCommandsQueue', () => {
       assert.strictEqual(source.extractAllCommands().length, 1);
       assert.strictEqual(destination.extractAllCommands().length, 0);
     });
+
+    it('rebinds listeners for every command when extractAllCommands returns multiple commands', async () => {
+      const source = createQueue();
+      const destination = createQueue();
+      const controllers = [
+        new AbortController(),
+        new AbortController(),
+        new AbortController(),
+      ];
+
+      const promises = controllers.map((controller, i) =>
+        source.addCommand([`CMD${i}`], { abortSignal: controller.signal }),
+      );
+      promises.forEach(promise => promise.catch(() => {}));
+
+      const commands = source.extractAllCommands();
+      assert.strictEqual(commands.length, 3);
+      assert.deepStrictEqual(
+        commands.map(command => command.args?.[0]),
+        ['CMD0', 'CMD1', 'CMD2'],
+      );
+
+      destination.prependCommandsToWrite(commands);
+      assert.strictEqual(destination.pendingCount, 3);
+      assert.strictEqual(source.pendingCount, 0);
+
+      // Abort out of order (middle, then last, then first) to confirm each
+      // command's listener was independently rebound to its own node in the
+      // destination queue, and that removing one doesn't corrupt the
+      // destination's linked list for the others still queued.
+      controllers[1].abort();
+      await assert.rejects(promises[1], AbortError);
+      assert.strictEqual(destination.pendingCount, 2);
+
+      controllers[2].abort();
+      await assert.rejects(promises[2], AbortError);
+      assert.strictEqual(destination.pendingCount, 1);
+
+      controllers[0].abort();
+      await assert.rejects(promises[0], AbortError);
+      assert.strictEqual(destination.pendingCount, 0);
+
+      // None of the cancellations should have reached back into the
+      // already-drained source queue.
+      assert.strictEqual(source.extractAllCommands().length, 0);
+    });
   });
 });

--- a/packages/client/lib/client/commands-queue.spec.ts
+++ b/packages/client/lib/client/commands-queue.spec.ts
@@ -40,8 +40,10 @@ describe('RedisCommandsQueue', () => {
     });
   });
 
-  describe('prependCommandsToWrite', () => {
-    it('rejects a command that was extracted but never prepended', async () => {
+  describe('rejectCommands', () => {
+    // Mirrors cluster-slots.ts's full-node-loss path: extractAllCommands()
+    // drains everything, then rejects it when no destination client exists.
+    it('rejects a command extracted via extractAllCommands when there is no destination', async () => {
       const source = createQueue();
       const promise = source.addCommand(['CMD'], { timeout: 1000 });
       promise.catch(() => {});
@@ -52,6 +54,25 @@ describe('RedisCommandsQueue', () => {
       await assert.rejects(promise, DisconnectsClientError);
       assert.strictEqual(source.extractAllCommands().length, 0);
     });
+
+    // Mirrors cluster-slots.ts's partial-slot-migration path:
+    // extractCommandsForSlots() pulls out only the moving slots, then rejects
+    // them when no destination client exists, leaving the rest queued.
+    it('rejects a command extracted via extractCommandsForSlots when there is no destination', async () => {
+      const source = createQueue();
+      const promise = source.addCommand(['CMD'], { slotNumber: 1, timeout: 1000 });
+      promise.catch(() => {});
+      source.addCommand(['KEEP'], { slotNumber: 2 });
+
+      const [command] = source.extractCommandsForSlots(new Set([1]));
+      source.rejectCommands([command], new DisconnectsClientError());
+
+      await assert.rejects(promise, DisconnectsClientError);
+      assert.strictEqual(source.extractAllCommands().length, 1);
+    });
+  });
+
+  describe('prependCommandsToWrite', () => {
 
     it('rebinds an abort listener so it removes the command from its new queue', async () => {
       const source = createQueue();
@@ -118,6 +139,10 @@ describe('RedisCommandsQueue', () => {
 
       const [command] = source.extractCommandsForSlots(new Set([1]));
       await wait(5);
+      // Confirm the timeout actually already fired, so prependCommandsToWrite
+      // is exercising the "reject immediately" branch below and not just
+      // rebinding a listener that happens to fire before the final assert.
+      assert.strictEqual(command.timeout?.signal.aborted, true);
       destination.prependCommandsToWrite([command]);
 
       await assert.rejects(promise, TimeoutError);
@@ -162,6 +187,10 @@ describe('RedisCommandsQueue', () => {
 
       const [command] = source.extractCommandsForSlots(new Set([1]));
       await wait(5);
+      // Confirm the timeout actually already fired before prepend, so the
+      // abort listener removed below is the one attached at addCommand time,
+      // not a listener that would have been rebound had we hit that branch.
+      assert.strictEqual(command.timeout?.signal.aborted, true);
 
       destination.prependCommandsToWrite([command]);
       await assert.rejects(promise, TimeoutError);

--- a/packages/client/lib/client/commands-queue.spec.ts
+++ b/packages/client/lib/client/commands-queue.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import RedisCommandsQueue from './commands-queue';
-import { AbortError, TimeoutError } from '../errors';
+import { AbortError, DisconnectsClientError, TimeoutError } from '../errors';
 
 describe('RedisCommandsQueue', () => {
   function createQueue() {
@@ -41,6 +41,18 @@ describe('RedisCommandsQueue', () => {
   });
 
   describe('prependCommandsToWrite', () => {
+    it('rejects a command that was extracted but never prepended', async () => {
+      const source = createQueue();
+      const promise = source.addCommand(['CMD'], { timeout: 1000 });
+      promise.catch(() => {});
+
+      const [command] = source.extractAllCommands();
+      source.rejectCommands([command], new DisconnectsClientError());
+
+      await assert.rejects(promise, DisconnectsClientError);
+      assert.strictEqual(source.extractAllCommands().length, 0);
+    });
+
     it('rebinds an abort listener so it removes the command from its new queue', async () => {
       const source = createQueue();
       const destination = createQueue();

--- a/packages/client/lib/client/commands-queue.spec.ts
+++ b/packages/client/lib/client/commands-queue.spec.ts
@@ -1,9 +1,14 @@
 import assert from 'node:assert';
 import RedisCommandsQueue from './commands-queue';
+import { AbortError, TimeoutError } from '../errors';
 
 describe('RedisCommandsQueue', () => {
   function createQueue() {
     return new RedisCommandsQueue(3, null, () => {}, 'test-client');
+  }
+
+  function wait(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   describe('extractAllCommands', () => {
@@ -21,6 +26,138 @@ describe('RedisCommandsQueue', () => {
         ['CMD0', 'CMD1', 'CMD2', 'CMD3', 'CMD4'],
       );
       assert.strictEqual(queue.extractAllCommands().length, 0);
+    });
+  });
+
+  describe('addCommand', () => {
+    it('does not keep a command if timeout listener setup fails', async () => {
+      const queue = createQueue();
+
+      const promise = queue.addCommand(['CMD'], { timeout: -1 });
+
+      await assert.rejects(promise, RangeError);
+      assert.strictEqual(queue.extractAllCommands().length, 0);
+    });
+  });
+
+  describe('prependCommandsToWrite', () => {
+    it('rebinds an abort listener so it removes the command from its new queue', async () => {
+      const source = createQueue();
+      const destination = createQueue();
+      const controller = new AbortController();
+
+      const promise = source.addCommand(['CMD'], { abortSignal: controller.signal });
+      promise.catch(() => {});
+
+      const [command] = source.extractAllCommands();
+      destination.prependCommandsToWrite([command]);
+
+      controller.abort();
+      await assert.rejects(promise, AbortError);
+
+      assert.strictEqual(destination.extractAllCommands().length, 0);
+    });
+
+    it('does not keep a command if its abort signal fired before prepend', async () => {
+      const source = createQueue();
+      const destination = createQueue();
+      const controller = new AbortController();
+
+      const promise = source.addCommand(['CMD'], {
+        abortSignal: controller.signal,
+        slotNumber: 1,
+      });
+      promise.catch(() => {});
+      source.addCommand(['KEEP'], { slotNumber: 2 });
+
+      const [command] = source.extractCommandsForSlots(new Set([1]));
+      controller.abort();
+      destination.prependCommandsToWrite([command]);
+
+      await assert.rejects(promise, AbortError);
+      assert.strictEqual(source.extractAllCommands().length, 1);
+      assert.strictEqual(destination.extractAllCommands().length, 0);
+    });
+
+    it('rebinds a timeout listener so it removes the command from its new queue', async () => {
+      const source = createQueue();
+      const destination = createQueue();
+
+      const promise = source.addCommand(['CMD'], { timeout: 10 });
+      promise.catch(() => {});
+
+      const [command] = source.extractAllCommands();
+      destination.prependCommandsToWrite([command]);
+
+      await assert.rejects(promise, TimeoutError);
+      assert.strictEqual(destination.extractAllCommands().length, 0);
+    });
+
+    it('does not keep a command if its timeout fired before prepend', async () => {
+      const source = createQueue();
+      const destination = createQueue();
+
+      const promise = source.addCommand(['CMD'], {
+        slotNumber: 1,
+        timeout: 1,
+      });
+      promise.catch(() => {});
+      source.addCommand(['KEEP'], { slotNumber: 2 });
+
+      const [command] = source.extractCommandsForSlots(new Set([1]));
+      await wait(5);
+      destination.prependCommandsToWrite([command]);
+
+      await assert.rejects(promise, TimeoutError);
+      assert.strictEqual(source.extractAllCommands().length, 1);
+      assert.strictEqual(destination.extractAllCommands().length, 0);
+    });
+
+    it('removes the timeout listener when abort wins after prepend', async () => {
+      const source = createQueue();
+      const destination = createQueue();
+      const controller = new AbortController();
+
+      const promise = source.addCommand(['CMD'], {
+        abortSignal: controller.signal,
+        timeout: 5,
+      });
+      promise.catch(() => {});
+      destination.addCommand(['KEEP']);
+
+      const [command] = source.extractAllCommands();
+      destination.prependCommandsToWrite([command]);
+
+      controller.abort();
+      await assert.rejects(promise, AbortError);
+      await wait(10);
+
+      assert.strictEqual(destination.extractAllCommands().length, 1);
+    });
+
+    it('removes the abort listener when timeout already fired before prepend', async () => {
+      const source = createQueue();
+      const destination = createQueue();
+      const controller = new AbortController();
+
+      const promise = source.addCommand(['CMD'], {
+        abortSignal: controller.signal,
+        slotNumber: 1,
+        timeout: 1,
+      });
+      promise.catch(() => {});
+      source.addCommand(['KEEP'], { slotNumber: 2 });
+
+      const [command] = source.extractCommandsForSlots(new Set([1]));
+      await wait(5);
+
+      destination.prependCommandsToWrite([command]);
+      await assert.rejects(promise, TimeoutError);
+
+      controller.abort();
+
+      assert.strictEqual(source.extractAllCommands().length, 1);
+      assert.strictEqual(destination.extractAllCommands().length, 0);
     });
   });
 });

--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -742,6 +742,19 @@ export default class RedisCommandsQueue {
   }
 
   /**
+   * Rejects commands that were extracted but could not be moved to another queue.
+   */
+  rejectCommands(commands: CommandToWrite[], err: Error) {
+    for (const command of commands) {
+      if (command.rejected) continue;
+
+      command.rejected = true;
+      RedisCommandsQueue.#removeCommandListeners(command);
+      command.reject(err);
+    }
+  }
+
+  /**
    * Prepends commands to the write queue in reverse.
    *
    * Commands arriving here (from `extractAllCommands`/`extractCommandsForSlots` on

--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -37,7 +37,10 @@ export interface CommandToWrite extends CommandWaitingForReply {
     signal: AbortSignal;
     listener: () => unknown;
     originalTimeout: number | undefined;
+    effectiveTimeout: number;
+    wasInMaintenance: boolean;
   } | undefined;
+  rejected?: boolean;
   slotNumber?: number
 }
 
@@ -118,11 +121,10 @@ export default class RedisCommandsQueue {
       const signal = AbortSignal.timeout(newTimeout);
       command.timeout = {
         signal,
-        listener: () => {
-          this.#toWrite.remove(node);
-          command.reject(new CommandTimeoutDuringMaintenanceError(newTimeout));
-        },
+        listener: this.#createTimeoutListener(node, command, newTimeout, true),
         originalTimeout: command.timeout?.originalTimeout,
+        effectiveTimeout: newTimeout,
+        wasInMaintenance: true,
       };
       signal.addEventListener("abort", command.timeout.listener, {
         once: true,
@@ -253,6 +255,45 @@ export default class RedisCommandsQueue {
     });
   }
 
+  #createAbortListener(
+    node: DoublyLinkedNode<CommandToWrite>,
+    value: CommandToWrite,
+  ) {
+    return () => {
+      this.#rejectCommand(node, value, new AbortError());
+    };
+  }
+
+  #createTimeoutListener(
+    node: DoublyLinkedNode<CommandToWrite>,
+    value: CommandToWrite,
+    effectiveTimeout: number,
+    wasInMaintenance: boolean,
+  ) {
+    return () => {
+      this.#rejectCommand(
+        node,
+        value,
+        wasInMaintenance
+          ? new CommandTimeoutDuringMaintenanceError(effectiveTimeout)
+          : new TimeoutError(),
+      );
+    };
+  }
+
+  #rejectCommand(
+    node: DoublyLinkedNode<CommandToWrite>,
+    value: CommandToWrite,
+    err: Error,
+  ) {
+    if (value.rejected) return;
+
+    value.rejected = true;
+    RedisCommandsQueue.#removeCommandListeners(value);
+    this.#toWrite.remove(node);
+    value.reject(err);
+  }
+
   addCommand<T>(
     args: ReadonlyArray<RedisArgument>,
     options?: CommandOptions,
@@ -267,8 +308,6 @@ export default class RedisCommandsQueue {
     }
 
     return new Promise((resolve, reject) => {
-      // eslint-disable-next-line prefer-const -- assigned after closures that reference it are constructed
-      let node: DoublyLinkedNode<CommandToWrite>;
       const value: CommandToWrite = {
         args,
         chainId: options?.chainId,
@@ -281,42 +320,40 @@ export default class RedisCommandsQueue {
       };
       value.slotNumber = options?.slotNumber;
 
-      // If #maintenanceCommandTimeout was explicitly set, we should
-      // use it instead of the timeout provided by the command
-      const timeout = this.#maintenanceCommandTimeout ?? options?.timeout;
-      const wasInMaintenance = this.#maintenanceCommandTimeout !== undefined;
-      if (timeout) {
-        const signal = AbortSignal.timeout(timeout);
-        value.timeout = {
-          signal,
-          listener: () => {
-            this.#toWrite.remove(node);
-            value.reject(
-              wasInMaintenance
-                ? new CommandTimeoutDuringMaintenanceError(timeout)
-                : new TimeoutError(),
-            );
-          },
-          originalTimeout: options?.timeout,
-        };
-        signal.addEventListener("abort", value.timeout.listener, {
-          once: true,
-        });
-      }
+      const node = this.#toWrite.add(value, options?.asap);
 
-      const signal = options?.abortSignal;
-      if (signal) {
-        value.abort = {
-          signal,
-          listener: () => {
-            this.#toWrite.remove(node);
-            value.reject(new AbortError());
-          },
-        };
-        signal.addEventListener("abort", value.abort.listener, { once: true });
-      }
+      try {
+        // If #maintenanceCommandTimeout was explicitly set, we should
+        // use it instead of the timeout provided by the command
+        const timeout = this.#maintenanceCommandTimeout ?? options?.timeout;
+        const wasInMaintenance = this.#maintenanceCommandTimeout !== undefined;
+        if (timeout) {
+          const signal = AbortSignal.timeout(timeout);
+          value.timeout = {
+            signal,
+            listener: this.#createTimeoutListener(node, value, timeout, wasInMaintenance),
+            originalTimeout: options?.timeout,
+            effectiveTimeout: timeout,
+            wasInMaintenance,
+          };
+          signal.addEventListener("abort", value.timeout.listener, {
+            once: true,
+          });
+        }
 
-      node = this.#toWrite.add(value, options?.asap);
+        const signal = options?.abortSignal;
+        if (signal) {
+          value.abort = {
+            signal,
+            listener: this.#createAbortListener(node, value),
+          };
+          signal.addEventListener("abort", value.abort.listener, { once: true });
+        }
+      } catch (err) {
+        RedisCommandsQueue.#removeCommandListeners(value);
+        this.#toWrite.remove(node);
+        reject(err);
+      }
     });
   }
 
@@ -598,6 +635,17 @@ export default class RedisCommandsQueue {
     );
   }
 
+  static #removeCommandListeners(command: CommandToWrite) {
+    if (command.abort) {
+      RedisCommandsQueue.#removeAbortListener(command);
+      command.abort = undefined;
+    }
+    if (command.timeout) {
+      RedisCommandsQueue.#removeTimeoutListener(command);
+      command.timeout = undefined;
+    }
+  }
+
   static #flushToWrite(toBeSent: CommandToWrite, err: Error) {
     if (toBeSent.abort) {
       RedisCommandsQueue.#removeAbortListener(toBeSent);
@@ -652,7 +700,14 @@ export default class RedisCommandsQueue {
         current.value.slotNumber !== undefined &&
         slots.has(current.value.slotNumber)
       ) {
-        result.push(current.value);
+        const command = current.value;
+        if (command.abort) {
+          RedisCommandsQueue.#removeAbortListener(command);
+        }
+        if (command.timeout) {
+          RedisCommandsQueue.#removeTimeoutListener(command);
+        }
+        result.push(command);
         const toRemove = current;
         current = current.next;
         this.#toWrite.remove(toRemove);
@@ -671,7 +726,14 @@ export default class RedisCommandsQueue {
     const result: CommandToWrite[] = [];
     let current = this.#toWrite.head;
     while (current) {
-      result.push(current.value);
+      const command = current.value;
+      if (command.abort) {
+        RedisCommandsQueue.#removeAbortListener(command);
+      }
+      if (command.timeout) {
+        RedisCommandsQueue.#removeTimeoutListener(command);
+      }
+      result.push(command);
       const toRemove = current;
       current = current.next;
       this.#toWrite.remove(toRemove);
@@ -681,6 +743,12 @@ export default class RedisCommandsQueue {
 
   /**
    * Prepends commands to the write queue in reverse.
+   *
+   * Commands arriving here (from `extractAllCommands`/`extractCommandsForSlots` on
+   * another queue, e.g. during cluster slot migration) may still carry abort/timeout
+   * listeners bound to the node and queue they were removed from. Those listeners would
+   * reject the caller's promise without actually removing the command from this queue,
+   * so they're rebound to the node created here.
    */
   prependCommandsToWrite(commands: CommandToWrite[]) {
     if (!commands.length) {
@@ -688,7 +756,49 @@ export default class RedisCommandsQueue {
     }
 
     for (let i = commands.length - 1; i >= 0; i--) {
-      this.#toWrite.unshift(commands[i]);
+      const value = commands[i];
+      const node = this.#toWrite.unshift(value);
+
+      if (value.rejected) {
+        this.#toWrite.remove(node);
+        continue;
+      }
+
+      if (value.timeout) {
+        RedisCommandsQueue.#removeTimeoutListener(value);
+        if (value.timeout.signal.aborted) {
+          this.#rejectCommand(
+            node,
+            value,
+            value.timeout.wasInMaintenance
+              ? new CommandTimeoutDuringMaintenanceError(value.timeout.effectiveTimeout)
+              : new TimeoutError(),
+          );
+          continue;
+        } else {
+          value.timeout.listener = this.#createTimeoutListener(
+            node,
+            value,
+            value.timeout.effectiveTimeout,
+            value.timeout.wasInMaintenance,
+          );
+          value.timeout.signal.addEventListener("abort", value.timeout.listener, {
+            once: true,
+          });
+        }
+      }
+
+      if (value.abort) {
+        RedisCommandsQueue.#removeAbortListener(value);
+        if (value.abort.signal.aborted) {
+          this.#rejectCommand(node, value, new AbortError());
+        } else {
+          value.abort.listener = this.#createAbortListener(node, value);
+          value.abort.signal.addEventListener("abort", value.abort.listener, {
+            once: true,
+          });
+        }
+      }
     }
   }
 }

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -1,5 +1,5 @@
 import type { RedisClusterClientOptions, RedisClusterOptions } from '.';
-import { ClientClosedError, ClientOfflineError, RootNodesUnavailableError } from '../errors';
+import { ClientClosedError, ClientOfflineError, DisconnectsClientError, RootNodesUnavailableError } from '../errors';
 import RedisClient, { RedisClientOptions, RedisClientType } from '../client';
 import { EventEmitter } from 'node:stream';
 import { ChannelListeners, PUBSUB_TYPE, PubSubListeners, PubSubTypeListeners } from '../client/pub-sub';
@@ -385,8 +385,13 @@ export default class RedisClusterSlots<
 
           // 4. Extract commands for this destination's slots and prepend to destination queue
           const commandsForDestination = sourceNode.client._getQueue().extractCommandsForSlots(destinationSlots);
-          destMasterNode.client?._getQueue().prependCommandsToWrite(commandsForDestination);
-          dbgMaintenance(`[CSlots]: Extracted ${commandsForDestination.length} commands for ${destinationSlots.size} slots, prepended to ${destMasterNode.address}`);
+          if (destMasterNode.client) {
+            destMasterNode.client._getQueue().prependCommandsToWrite(commandsForDestination);
+            dbgMaintenance(`[CSlots]: Extracted ${commandsForDestination.length} commands for ${destinationSlots.size} slots, prepended to ${destMasterNode.address}`);
+          } else {
+            sourceNode.client._getQueue().rejectCommands(commandsForDestination, new DisconnectsClientError());
+            dbgMaintenance(`[CSlots]: Rejected ${commandsForDestination.length} commands for ${destinationSlots.size} slots because ${destMasterNode.address} has no client`);
+          }
 
           // 5. Unpause destination
           destMasterNode.client?._unpause();
@@ -427,11 +432,16 @@ export default class RedisClusterSlots<
         } else {
           // Source has no slots left - move remaining slotless commands and cleanup
           const remainingCommands = sourceNode.client._getQueue().extractAllCommands();
-          if (remainingCommands.length > 0 && lastDestNode) {
-            lastDestNode.client?._getQueue().prependCommandsToWrite(remainingCommands);
-            // Trigger write scheduling since commands were added after destination was unpaused
-            lastDestNode.client?._unpause();
-            dbgMaintenance(`[CSlots]: Moved ${remainingCommands.length} remaining slotless commands to ${lastDestNode.address}`);
+          if (remainingCommands.length > 0) {
+            if (lastDestNode?.client) {
+              lastDestNode.client._getQueue().prependCommandsToWrite(remainingCommands);
+              // Trigger write scheduling since commands were added after destination was unpaused
+              lastDestNode.client._unpause();
+              dbgMaintenance(`[CSlots]: Moved ${remainingCommands.length} remaining slotless commands to ${lastDestNode.address}`);
+            } else {
+              sourceNode.client._getQueue().rejectCommands(remainingCommands, new DisconnectsClientError());
+              dbgMaintenance(`[CSlots]: Rejected ${remainingCommands.length} remaining commands because no destination client was available`);
+            }
           }
 
           if ('pubSub' in sourceNode) {


### PR DESCRIPTION
Fixes #3365.

During cluster slot migration, queued commands can move from one node queue to another. The abort and timeout listeners used to keep pointing at the original queue and linked-list node.

After a command moved, cancellation could reject the caller while leaving the command in the destination queue. The command could then still be sent.

This rebinds the listeners when commands are prepended to a new queue. If a signal has already fired, the command is rejected and removed instead. Extracted commands are also rejected when no destination client is available.

Tests cover abort and timeout after a move, signals that fired before prepend, listener cleanup, and the extracted-but-not-prepended case.

This branch overlaps #3364's extractAllCommands() change and will be rebased after #3364 merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core command-queue lifecycle during cluster SMIGRATED handling; incorrect listener binding could still send aborted/timed-out commands, but behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes cluster slot migration so queued commands stay consistent when they move between node write queues.
> 
> **`RedisCommandsQueue`** now centralizes cancellation in `#rejectCommand` (with a `rejected` guard), detaches abort/timeout listeners when commands are extracted, and **`prependCommandsToWrite`** rebinds those listeners to the destination queue’s linked-list nodes. If abort or timeout already fired before prepend, the command is rejected and dropped instead of staying queued. **`rejectCommands`** handles extracted commands that cannot be forwarded. **`addCommand`** enrolls the command in the queue before attaching listeners and rolls back on setup failure (e.g. invalid timeout).
> 
> **`cluster-slots`** rejects migrated or leftover commands with **`DisconnectsClientError`** when no destination client exists, instead of prepending into a missing client.
> 
> Broad unit tests cover migration-style extract/reject paths and abort/timeout behavior after moves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f61ee5dde19ab63a432ced3b583b8f9ed223375d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->