### PR TITLE
chore(skills): emit maintainer comments without blockquote markers

### DIFF
--- a/.agents/skills/maintainer-review/SKILL.md
+++ b/.agents/skills/maintainer-review/SKILL.md
@@ -192,7 +192,7 @@ For PRs, put `Need evidence` before the code recommendation. When the need is no
 
 When existing functionality or a better alternative materially affects the decision, state it explicitly in the evidence and recommendation. Name the exact supported path, what it does and does not cover, and why it is preferable. Do not bury a `Not worth completing` or `Supersede with a simpler alternative` conclusion beneath praise for implementation quality.
 
-When recommending closure, more evidence, focused changes, or superseding a PR, append a polite, complete, copy-paste-ready English maintainer comment. Include only merge-blocking work in its required-action paragraph. Do not produce a line-by-line review unless requested, equate passing tests with merge-worthiness, or equate a logically correct patch with practical value.
+When recommending closure, more evidence, focused changes, or superseding a PR, append a polite, complete, copy-paste-ready English maintainer comment. Write the comment as plain markdown without blockquote (`>`) prefixes or other wrapper markers, so it can be pasted verbatim. Include only merge-blocking work in its required-action paragraph. Do not produce a line-by-line review unless requested, equate passing tests with merge-worthiness, or equate a logically correct patch with practical value.
 
 ## Resource
 


### PR DESCRIPTION
## Summary

Draft maintainer comments produced by the `maintainer-review` skill were wrapped in blockquote (`>`) prefixes, which had to be stripped manually before pasting into GitHub. This updates the skill's reporting step to require plain markdown without blockquote or other wrapper markers, so the comment is paste-ready verbatim.

## Changes

- `.agents/skills/maintainer-review/SKILL.md`: one-line addition to step 7 (report the decision and action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill; no runtime, API, or security impact.
> 
> **Overview**
> Updates **maintainer-review** step 7 so drafted maintainer comments must be **plain markdown**—no blockquote (`>`) or other wrappers—so they can be pasted into GitHub as-is.
> 
> Previously, generated comments often used `>` prefixes and needed manual cleanup before posting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7cf8e54f7048fa72ccbd564d9821c8bbe9d815f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->