### PR TITLE
fix(client): reject in-flight connect attempt when socket dies during initiator

### DIFF
--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -137,6 +137,88 @@ describe('Socket', () => {
         await new Promise<void>(resolve => server.close(() => resolve()));
       }
     });
+
+    it('should retry (not crash) when the initiator throws synchronously', async () => {
+      const server = net.createServer();
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address() as net.AddressInfo;
+
+      // A synchronous throw must be routed through the socket-death race and
+      // turned into a rejected attempt. If it escapes #initiateWhileSocketAlive
+      // before the race is built, the socketDied listeners leak and the reject
+      // they fire on the subsequent destroy() surfaces as an unhandled rejection.
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        let attempts = 0;
+        const socket = new RedisSocket(() => {
+          attempts += 1;
+          if (attempts === 1) throw new Error('sync initiator failure');
+          return Promise.resolve();
+        }, CLIENT_ID, {
+          host: '127.0.0.1',
+          port,
+          reconnectStrategy: 0
+        });
+        socket.on('error', () => { /* ignore */ });
+
+        await socket.connect();
+
+        assert.equal(attempts, 2, 'initiator must run again after a synchronous throw');
+        assert.equal(socket.isReady, true, 'socket.isReady');
+
+        socket.destroy();
+        // let any leaked listener / stray rejection settle before asserting
+        await setTimeout(0);
+        assert.deepEqual(unhandled, [], 'must not produce an unhandled rejection');
+      } finally {
+        process.removeListener('unhandledRejection', onUnhandled);
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    });
+
+    it('should not emit error/reconnecting when destroyed while the initiator is suspended', async () => {
+      const connections: net.Socket[] = [];
+      const server = net.createServer(conn => {
+        conn.on('error', () => { /* ignore */ });
+        connections.push(conn);
+      });
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address() as net.AddressInfo;
+
+      try {
+        let suspended!: () => void;
+        const initiatorSuspended = new Promise<void>(resolve => { suspended = resolve; });
+        const socket = new RedisSocket(() => {
+          // Suspend forever so the destroy() below races an in-flight initiator.
+          suspended();
+          return new Promise(() => { /* never settles */ });
+        }, CLIENT_ID, {
+          host: '127.0.0.1',
+          port,
+          reconnectStrategy: 0
+        });
+
+        const events: string[] = [];
+        for (const event of ['error', 'reconnecting'] as const) {
+          socket.on(event, () => events.push(event));
+        }
+        socket.on('error', () => { /* ignore */ });
+
+        const connectPromise = socket.connect();
+        await initiatorSuspended;
+        socket.destroy();
+
+        await assert.rejects(connectPromise);
+        assert.deepEqual(events, [], 'must not emit error/reconnecting on intentional destroy');
+        assert.equal(socket.isOpen, false, 'socket.isOpen');
+      } finally {
+        for (const conn of connections) conn.destroy();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    });
   });
 
   describe('write', () => {

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -87,6 +87,58 @@ describe('Socket', () => {
     });
   });
 
+  describe('initiator interruption (#3346)', () => {
+    it('should keep retrying when the socket dies while the initiator is suspended', async () => {
+      const connections: net.Socket[] = [];
+      const server = net.createServer(conn => {
+        conn.on('error', () => { /* ignore */ });
+        connections.push(conn);
+      });
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address() as net.AddressInfo;
+      const firstConnection = once(server, 'connection') as Promise<[net.Socket]>;
+
+      try {
+        let attempts = 0;
+        const socket = new RedisSocket(() => {
+          attempts += 1;
+          if (attempts === 1) {
+            // Simulate an initiator suspended on async work (DNS resolution,
+            // credentials provider) when the server drops the connection: the
+            // returned promise never settles on its own, just like handshake
+            // commands enqueued after the socket already died.
+            firstConnection.then(([conn]) => conn.destroy());
+            return new Promise(() => { /* never settles */ });
+          }
+          return Promise.resolve();
+        }, CLIENT_ID, {
+          host: '127.0.0.1',
+          port,
+          reconnectStrategy: 0
+        });
+
+        const events: string[] = [];
+        for (const event of ['error', 'reconnecting', 'ready'] as const) {
+          socket.on(event, () => events.push(event));
+        }
+        socket.on('error', () => { /* ignore */ });
+
+        // Without the in-flight failure guard this never resolves: the retry
+        // loop stays suspended inside the abandoned initiator forever.
+        await socket.connect();
+
+        assert.equal(attempts, 2, 'initiator must run again on the new socket');
+        assert.equal(socket.isReady, true, 'socket.isReady');
+        assert.ok(events.includes('reconnecting'), 'must emit reconnecting');
+
+        socket.destroy();
+      } finally {
+        for (const conn of connections) conn.destroy();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    });
+  });
+
   describe('write', () => {
     function captureUnderlyingSocket() {
       const original = net.createConnection;

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -120,7 +120,7 @@ export default class RedisSocket extends EventEmitter {
     if (strategy) {
       return (retries, cause) => {
         try {
-          const retryIn = strategy(retries, cause);
+const retryIn = strategy(retries, cause);
           if (retryIn !== false && !(retryIn instanceof Error) && typeof retryIn !== 'number') {
             throw new TypeError(`Reconnect strategy should return \`false | Error | number\`, got ${retryIn} instead`);
           }
@@ -261,7 +261,9 @@ export default class RedisSocket extends EventEmitter {
             continue;
           }
         } catch (err) {
-          this.#socket.destroy();
+          // #socket may already be undefined if the client was destroyed while
+          // the initiator was suspended (destroySocket cleared it).
+          this.#socket?.destroy();
           this.#socket = undefined;
           throw err;
         }
@@ -275,6 +277,11 @@ export default class RedisSocket extends EventEmitter {
         }));
         this.emit('ready');
       } catch (err) {
+        // The client was closed while connecting (e.g. destroy()/quit() raced
+        // an async initiator). Abort the attempt without emitting error/
+        // reconnecting or scheduling a retry — the shutdown is intentional.
+        if (!this.#isOpen) throw err;
+
         const retryIn = this.#shouldReconnect(retries++, err as Error);
         if (typeof retryIn !== 'number') {
           throw retryIn;
@@ -310,7 +317,11 @@ export default class RedisSocket extends EventEmitter {
       socket.once('close', onSocketDied);
     });
 
-    const initiated = Promise.resolve(this.#initiator());
+    // Defer into a microtask so a synchronous throw from the initiator becomes
+    // a rejection routed through the race below, instead of escaping before the
+    // socketDied listeners are registered and cleaned up (which would leak them
+    // and surface the raced rejection as an unhandled rejection).
+    const initiated = Promise.resolve().then(() => this.#initiator());
     // an abandoned initiator can still reject later (its stranded commands get
     // flushed on a subsequent failure) — the raced error already drove the retry
     initiated.catch(() => {});

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -246,11 +246,11 @@ export default class RedisSocket extends EventEmitter {
     do {
       try {
         const connectStartTime = performance.now();
-        this.#socket = await this.#createSocket();
+        const socket = this.#socket = await this.#createSocket();
         this.emit('connect');
 
         try {
-          await this.#initiator();
+          await this.#initiateWhileSocketAlive(socket);
 
           // Check if socket was closed/destroyed during initiator execution
           if (!this.#socket || this.#socket.destroyed || !this.#socket.readable || !this.#socket.writable) {
@@ -291,6 +291,34 @@ export default class RedisSocket extends EventEmitter {
         this.emit('reconnecting');
       }
     } while (this.#isOpen && !this.#isReady);
+  }
+
+  /**
+   * Awaits the initiator, rejecting as soon as the socket errors or closes.
+   * If the socket dies while the initiator is suspended (e.g. on DNS
+   * resolution or an async credentials provider), commands it enqueues
+   * afterwards are never written nor flushed — without this guard `#connect`
+   * would stay suspended forever without emitting a terminal event.
+   */
+  #initiateWhileSocketAlive(socket: net.Socket | tls.TLSSocket) {
+    let onSocketDied!: (err?: unknown) => void;
+    const socketDied = new Promise<never>((_, reject) => {
+      onSocketDied = (err?: unknown) => {
+        reject(err instanceof Error ? err : new SocketClosedUnexpectedlyError());
+      };
+      socket.once('error', onSocketDied);
+      socket.once('close', onSocketDied);
+    });
+
+    const initiated = Promise.resolve(this.#initiator());
+    // an abandoned initiator can still reject later (its stranded commands get
+    // flushed on a subsequent failure) — the raced error already drove the retry
+    initiated.catch(() => {});
+
+    return Promise.race([initiated, socketDied]).finally(() => {
+      socket.removeListener('error', onSocketDied);
+      socket.removeListener('close', onSocketDied);
+    });
   }
 
   setMaintenanceTimeout(ms?: number) {


### PR DESCRIPTION
### Description

This pull request resolves #3346.

When the socket errors or closes while the connection initiator is suspended on asynchronous work — the DNS lookup performed by the maintenance-notifications handshake when the host is a hostname (the default on RESP3), or an async/streaming credentials provider — the handshake commands the initiator enqueues afterwards are written to an already-dead socket. `RedisSocket.write` silently skips unwritable sockets, and the earlier error had already flushed the queue, so those commands are never sent and never rejected. The reconnect loop then stays suspended inside the initiator forever: the client reports `isOpen: true, isReady: false`, emits no further lifecycle events, never consults `reconnectStrategy` again, and `connect()` rejects with `Socket already opened` — a silent, unrecoverable zombie state typically observed as "the pod never reconnects after a Redis failover".

The fix races the initiator against the socket's `error`/`close` events, so a socket death during initiation always rejects the in-flight attempt and the retry loop continues per `reconnectStrategy`. A regression test reproduces the interleaving deterministically with a local TCP server and an initiator suspended at the moment the connection drops; without the fix, the test hangs indefinitely.

No public API or behavior changes beyond restoring the documented reconnect semantics.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection/reconnect logic in `RedisSocket`; behavior change is limited to failure paths during connect but affects all clients on handshake/async initiator races.
> 
> **Overview**
> Fixes a **zombie connect state** where the client stayed `isOpen` but never `isReady` if the TCP socket died while the connection **initiator** was still waiting on async work (DNS, credentials, handshake). The reconnect loop could hang forever with no `reconnecting` / `reconnectStrategy` and `connect()` failing with “Socket already opened”.
> 
> **`RedisSocket`** now runs the initiator via **`#initiateWhileSocketAlive`**, racing it against the socket’s **`error`** and **`close`** so a dead socket always fails the attempt and the existing retry path runs. Synchronous initiator throws are deferred through a microtask so listeners are cleaned up and retries work without unhandled rejections. If **`destroy()`** races a suspended initiator, the outer catch **bails out when `#isOpen` is false** so intentional shutdown does not emit **`error`** / **`reconnecting`** or schedule another retry.
> 
> Adds **three local TCP server tests** for suspended initiator + dropped connection, sync throw + retry, and destroy-while-suspended behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b78289d54a328f2efa5761cab51470063cb54dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->