### PR TITLE
bump metrics exporter

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -56,11 +56,12 @@ runs:
     - name: Self Report Metrics
       if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && inputs.otel-authorization-token != ''
       id: self-report-metrics
-      uses: redis-developer/cae-otel-ci-visibility@v3
+      uses: redis-developer/cae-otel-ci-visibility@v4
       with:
         junit-xml-folder: "junit-results"
         otlp-endpoint: "https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/metrics"
         otlp-headers: "Authorization=Basic ${{inputs.otel-authorization-token}}"
+        server-version: ${{ inputs.redis-version }}
       env:
         OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
         ACTIONS_STEP_DEBUG: "true"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI workflow-only change with no application runtime impact; risk is limited to metrics reporting behavior if the new action input is misconfigured.
> 
> **Overview**
> Updates the **Self Report Metrics** step in the composite `run-tests` action to use `redis-developer/cae-otel-ci-visibility@v4` (from v3) and passes **`server-version`** from the existing `redis-version` input so OTLP metrics can be attributed to the Redis version under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe24f0db9949024551746a31ab64bca7417336ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->