### PR TITLE
test(client): add message assertion test for XCLAIM JUSTID

### DIFF
--- a/packages/client/lib/commands/XCLAIM_JUSTID.spec.ts
+++ b/packages/client/lib/commands/XCLAIM_JUSTID.spec.ts
@@ -11,15 +11,23 @@ describe('XCLAIM JUSTID', () => {
     );
   });
 
-  // TODO: test with messages
-  testUtils.testWithClient('client.xClaimJustId', async client => {
-    const [, reply] = await Promise.all([
-      client.xGroupCreate('key', 'group', '$', {
-        MKSTREAM: true
-      }),
-      client.xClaimJustId('key', 'group', 'consumer', 1, '0-0')
-    ]);
+  testUtils.testAll('xClaimJustId', async client => {
+    const message = { field: 'value' };
 
-    assert.deepEqual(reply, []);
-  }, GLOBAL.SERVERS.OPEN);
+    await client.xGroupCreate('key', 'group', '$', {
+      MKSTREAM: true
+    });
+    await client.xAdd('key', '1-0', message);
+    await client.xAdd('key', '2-0', message);
+    await client.xReadGroup('group', 'consumer1', {
+      key: 'key',
+      id: '>'
+    });
+    const reply = await client.xClaimJustId('key', 'group', 'consumer2', 0, ['1-0', '2-0']);
+
+    assert.deepEqual(reply, ['1-0', '2-0']);
+  }, {
+    client: GLOBAL.SERVERS.OPEN,
+    cluster: GLOBAL.CLUSTERS.OPEN
+  });
 });


### PR DESCRIPTION
This pull request updates `packages/client/lib/commands/XCLAIM_JUSTID.spec.ts` to resolve the inline maintainer TODO (`// TODO: test with messages`).

Previously, the unit test only asserted behavior against an empty stream (`[]`). This change adds an end-to-end test case that populates stream entries, moves them to pending status via `xReadGroup`, claims them using `xClaimJustId`, and verifies that the returned array of message IDs matches (`['1-0', '2-0']`). The test is also updated to run across both standalone client and cluster topologies via `testUtils.testAll`.

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
