### PR TITLE
fix(json): unwrap RESP3 array reply for JSON.TYPE

### DIFF
--- a/packages/json/lib/commands/TYPE.spec.ts
+++ b/packages/json/lib/commands/TYPE.spec.ts
@@ -22,6 +22,24 @@ describe('JSON.TYPE', () => {
     });
   });
 
+  describe('transformReply', () => {
+    describe('RESP3', () => {
+      type Resp3ReplyParam = Parameters<typeof TYPE.transformReply[3]>[0];
+
+      it('unwraps single element array response', () => {
+        assert.equal(TYPE.transformReply[3](['object'] as unknown as Resp3ReplyParam), 'object');
+      });
+
+      it('unwraps array of types when path is provided', () => {
+        assert.deepEqual(TYPE.transformReply[3]([['string']] as unknown as Resp3ReplyParam), ['string']);
+      });
+
+      it('returns null for non-existent key', () => {
+        assert.equal(TYPE.transformReply[3]([null] as unknown as Resp3ReplyParam), null);
+      });
+    });
+  });
+
   testUtils.testWithClient('client.json.type', async client => {
     assert.equal(
       await client.json.type('key'),

--- a/packages/json/lib/commands/TYPE.ts
+++ b/packages/json/lib/commands/TYPE.ts
@@ -17,9 +17,11 @@ export default {
   },
   transformReply: {
     2: undefined as unknown as () => NullReply | BlobStringReply | ArrayReply<BlobStringReply | NullReply>,
-    // TODO: RESP3 wraps the response in another array, but only returns 1 
+    /**
+     * Unwraps the top-level array wrapper returned by RedisJSON under RESP3 protocol
+     */
     3: (reply: UnwrapReply<ArrayReply<NullReply | BlobStringReply | ArrayReply<BlobStringReply | NullReply>>>) => {
-      return reply[0];
+      return Array.isArray(reply) ? reply[0] : reply;
     }
   },
 } as const satisfies Command;


### PR DESCRIPTION
### Description

This pull request resolves an inline maintainer TODO in `packages/json/lib/commands/TYPE.ts` (`// TODO: RESP3 wraps the response in another array, but only returns 1`).

Under the RESP3 protocol, RedisJSON wraps JSONPath command replies in a top-level array. Previously, the transformer rigidly accessed `reply[0]`, which lacked runtime safety and could crash (`TypeError: Cannot read properties of null`) if the response was unexpectedly `null` or scalar. 

This change:
1. Implements safe unwrapping (`Array.isArray(reply) ? reply[0] : reply`).
2. Introduces a dedicated `transformReply` unit test suite in `TYPE.spec.ts` to verify the exact RESP3 behavior for single elements, mapped arrays, and non-existent keys.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to JSON.TYPE RESP3 parsing with added unit tests; no auth, persistence, or broad API surface impact.
> 
> **Overview**
> **JSON.TYPE** RESP3 reply handling no longer always indexes `reply[0]`. The transformer now unwraps RedisJSON’s top-level array only when the value is an array, and passes through scalars unchanged so `null` or unexpected shapes do not throw at runtime.
> 
> Unit tests were added for the RESP3 `transformReply` path: single-type unwrap, JSONPath multi-match (`[['string']]`), and missing keys (`[null]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7da8f2ce6d2c53a1ccb93b2a403ed8eadda450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->