### PR TITLE
fix(client): include acquire timeout duration in pool timeout error message

### DIFF
--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { RESP_TYPES } from '../RESP/decoder';
 import { RedisClientPool } from './pool';
+import { TimeoutError } from '../errors';
 
 describe('RedisClientPool', () => {
   it('chained withCommandOptions(...).withTypeMapping(...) preserves earlier overrides at dispatch', () => {
@@ -294,5 +295,29 @@ describe('RedisClientPool', () => {
       assert.equal(hasUnhandledRejection, false);
     },
     GLOBAL.SERVERS.OPEN
+  );
+
+  testUtils.testWithClientPool(
+    'rejects with TimeoutError when acquireTimeout expires',
+    async (pool) => {
+      const longRunningTask = pool.execute(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+
+      await assert.rejects(
+        pool.execute(async () => {}),
+        (err: unknown) => {
+          assert(err instanceof TimeoutError);
+          assert.equal(err.message, 'Timeout waiting for a client after 50ms');
+          return true;
+        }
+      );
+
+      await longRunningTask;
+    },
+    {
+      ...GLOBAL.SERVERS.OPEN,
+      poolOptions: { minimum: 1, maximum: 1, acquireTimeout: 50 },
+    }
   );
 });

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -458,7 +458,7 @@ export class RedisClientPool<
           timeout = setTimeout(
             () => {
               this._self.#tasksQueue.remove(task, tail);
-              reject(new TimeoutError('Timeout waiting for a client')); // TODO: message
+              reject(new TimeoutError(`Timeout waiting for a client after ${this._self.#options.acquireTimeout}ms`));
             },
             this._self.#options.acquireTimeout
           );


### PR DESCRIPTION
### Description

This pull request addresses a maintainer TODO comment (`// TODO: message`) in `pool.ts` by formatting the `TimeoutError` message thrown when `acquireTimeout` expires while waiting for a client from the pool.

#### Background
Previously, when a task timed out waiting for an available client in `RedisClientPool`, the operation rejected with a static string `TimeoutError('Timeout waiting for a client')`. This lacked diagnostic details about the configured timeout duration.

#### Key Changes
1. **Formatted Error Message**: Updated `pool.ts` to dynamically include the configured timeout duration in milliseconds: `Timeout waiting for a client after ${acquireTimeout}ms`.
2. **Added Unit Test**: Added a test case in `pool.spec.ts` (`rejects with TimeoutError when acquireTimeout expires`) to verify that acquire timeout rejections produce a `TimeoutError` with the formatted message.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the timeout error message text changes; pool acquire logic is unchanged aside from clearer diagnostics.
> 
> **Overview**
> When `RedisClientPool` cannot hand out a client before `acquireTimeout`, the rejection now uses a **`TimeoutError`** message that includes the configured wait time (e.g. `Timeout waiting for a client after 50ms`) instead of a fixed string.
> 
> A pool integration test was added to hold the sole client busy, trigger a second `execute` with a short `acquireTimeout`, and assert the error type and message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f725826c7e01048b93af5301c81a914f290bd34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->