### PR TITLE
chore(tests): bump default docker test image to 8.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
             version: "8.4"
           - tag: "8.8.0"
             version: "8.8"
-          - tag: "8.10-rc2"
+          - tag: "custom-30445126297-debian"
             version: "8.10"
     steps:
       - uses: actions/checkout@v6

--- a/packages/test-utils/lib/index.ts
+++ b/packages/test-utils/lib/index.ts
@@ -102,7 +102,7 @@ export const DEFAULT_DOCKER_CONFIG: TestUtilsConfig = {
   dockerImageName: 'redislabs/client-libs-test',
   dockerImageTagArgument: 'redis-tag',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: { tag: '8.10-rc2', version: '8.10' }
+  defaultDockerVersion: { tag: 'custom-30445126297-debian', version: '8.10' }
 };
 
 interface CommonTestOptions {


### PR DESCRIPTION
Bump the default Redis test image from 8.10-rc2 to custom-30445126297-debian
(Redis 8.10) in DEFAULT_DOCKER_CONFIG, and update the 8.10 entry in the CI
matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only configuration; no production or library runtime behavior changes.
> 
> **Overview**
> Updates the Redis **8.10** test Docker tag from `8.10-rc2` to `custom-30445126297-debian` while keeping the logical version at **8.10**.
> 
> The same tag change is applied in **`DEFAULT_DOCKER_CONFIG`** (local/default test runs) and in the **CI tests matrix** so GitHub Actions and package tests pull the new image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c1f9f744bd1fa0766ee8c2422d043cee3e3518d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->