### PR TITLE
ci(release): skip throwaway workspace update during staggered release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Packages are released one workspace at a time starting with @redis/client.
+          # `npm version` runs a workspace-update install after the bump; because the sibling
+          # packages still pin "@redis/client" to the pre-bump range until their own bumpers
+          # run, that install ERESOLVEs. This is most visible on a pre-release bump (e.g.
+          # 6.2.0-beta.0), which semver excludes from a plain "^6.1.0" range even though a
+          # non-pre 6.2.0 would satisfy it. The post-bump install is throwaway (each package
+          # publishes from its own dist), so skip it entirely — this avoids the resolve
+          # altogether, rather than relaxing peer checks (which would pull the stale client
+          # from the registry) and leaves the lockfile untouched.
+          NPM_CONFIG_WORKSPACES_UPDATE: "false"


### PR DESCRIPTION
## Problem

The release workflow releases one workspace at a time, starting with `@redis/client`. `npm version` runs a **workspace-update install** after bumping the version. Because the sibling packages still pin `@redis/client` to the pre-bump range until their own `release-it` bumpers run, that install fails with `ERESOLVE`, aborting the release before anything is published or tagged.

It surfaced on a pre-release beta minor (`6.1.0 → 6.2.0-beta.0`): semver excludes a pre-release from a plain `^6.1.0` range (a pre-release only matches a range carrying a pre-release at the same `major.minor.patch`), even though a non-pre-release `6.2.0` would satisfy it.

Reproduced locally with `npm version 6.2.0-beta.0 -w @redis/client` → ERESOLVE on the post-bump workspace update.

## Fix

Set `NPM_CONFIG_WORKSPACES_UPDATE=false` on the release step so `npm version` skips the post-bump workspace-update install. That install is throwaway — each package publishes from its own `dist/`, and each `release-it` bumper writes the correct dependency/peer ranges at publish time.

Verified locally: `npm version 6.2.0-beta.0 --workspaces-update=false -w @redis/client` completes with no ERESOLVE and leaves `package-lock.json` untouched.

## Why not `--legacy-peer-deps`

`legacy-peer-deps` also clears the ERESOLVE, but it only ignores `peerDependencies` — the later `redis` workspace still pins non-peer `@redis/client: "6.1.0"`, so the resolve pulls the **stale 6.1.0 client from the registry** and churns the lockfile. Skipping the throwaway update avoids the resolve entirely instead of papering over it.

## Also fixes major releases

Same mechanism applies to a major bump (siblings pin `^6.x`, client to `7.0.0`), so this unblocks that path too and removes the need for the manual peer-range widening previously used before a major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)