### PR TITLE
feat(client): add MaxCommandRedirectionsError for cluster redirections

### DIFF
--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -312,7 +312,8 @@ describe('Cluster', () => {
     numberOfMasters: 2,
     clusterConfiguration: {
       maxCommandRedirections: 2
-    }
+    },
+    minimumDockerVersion: [7]
   });
 
   testUtils.testWithCluster('getRandomNode should spread the the load evenly', async cluster => {

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -279,6 +279,42 @@ describe('Cluster', () => {
     }
   });
 
+  testUtils.testWithCluster('sSubscribe should throw MaxCommandRedirectionsError when exceeding maxCommandRedirections', async cluster => {
+    const channel = 'maxCommandRedirectionsErrorChannel',
+      slot = calculateSlot(channel),
+      node1 = cluster.masters[0],
+      node2 = cluster.masters[1],
+      [client1, client2] = await Promise.all([
+        cluster.nodeClient(node1),
+        cluster.nodeClient(node2)
+      ]);
+
+    // Create a MOVED loop
+    await Promise.all([
+      client1.clusterSetSlot(slot, 'NODE', node2.id),
+      client2.clusterSetSlot(slot, 'NODE', node1.id)
+    ]);
+
+    try {
+      await assert.rejects(
+        cluster.sSubscribe(channel, () => {}),
+        MaxCommandRedirectionsError
+      );
+    } finally {
+      // Revert the slot back to its original owner (node1)
+      await Promise.all([
+        client1.clusterSetSlot(slot, 'NODE', node1.id),
+        client2.clusterSetSlot(slot, 'NODE', node1.id)
+      ]);
+    }
+  }, {
+    serverArguments: [],
+    numberOfMasters: 2,
+    clusterConfiguration: {
+      maxCommandRedirections: 2
+    }
+  });
+
   testUtils.testWithCluster('getRandomNode should spread the the load evenly', async cluster => {
     const totalNodes = cluster.masters.length + cluster.replicas.length,
       ids = new Set<string>();

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -3,7 +3,7 @@ import { setTimeout } from 'node:timers/promises';
 import testUtils, { GLOBAL, waitTillBeenCalled } from '../test-utils';
 import RedisCluster from '.';
 import { SQUARE_SCRIPT } from '../client/index.spec';
-import { ClientClosedError, ClientOfflineError, RootNodesUnavailableError } from '../errors';
+import { ClientClosedError, ClientOfflineError, RootNodesUnavailableError, MaxCommandRedirectionsError } from '../errors';
 import { spy } from 'sinon';
 import RedisClient from '../client';
 import { RESP_TYPES } from '../RESP/decoder';
@@ -241,6 +241,42 @@ describe('Cluster', () => {
   }, {
     serverArguments: [],
     numberOfMasters: 2
+  });
+
+  testUtils.testWithCluster('should throw MaxCommandRedirectionsError when exceeding maxCommandRedirections', async cluster => {
+    const key = 'maxCommandRedirectionsErrorKey',
+      slot = calculateSlot(key),
+      node1 = cluster.masters[0],
+      node2 = cluster.masters[1],
+      [client1, client2] = await Promise.all([
+        cluster.nodeClient(node1),
+        cluster.nodeClient(node2)
+      ]);
+
+    // Create a MOVED loop
+    await Promise.all([
+      client1.clusterSetSlot(slot, 'NODE', node2.id),
+      client2.clusterSetSlot(slot, 'NODE', node1.id)
+    ]);
+
+    try {
+      await assert.rejects(
+        cluster.get(key),
+        MaxCommandRedirectionsError
+      );
+    } finally {
+      // Revert the slot back to its original owner (node1)
+      await Promise.all([
+        client1.clusterSetSlot(slot, 'NODE', node1.id),
+        client2.clusterSetSlot(slot, 'NODE', node1.id)
+      ]);
+    }
+  }, {
+    serverArguments: [],
+    numberOfMasters: 2,
+    clusterConfiguration: {
+      maxCommandRedirections: 2
+    }
   });
 
   testUtils.testWithCluster('getRandomNode should spread the the load evenly', async cluster => {

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -7,7 +7,7 @@ import { attachConfig, functionArgumentsPrefix, getTransformReply, scriptArgumen
 import RedisClusterSlots, { NodeAddressMap, RESUBSCRIBE_LISTENERS_EVENT, ShardNode } from './cluster-slots';
 import RedisClusterMultiCommand, { RedisClusterMultiCommandType } from './multi-command';
 import { PubSubListener, PubSubListeners } from '../client/pub-sub';
-import { ErrorReply } from '../errors';
+import { ErrorReply, MaxCommandRedirectionsError } from '../errors';
 import { RedisTcpSocketOptions } from '../client/socket';
 import { ClientSideCacheConfig, PooledClientSideCacheProvider } from '../client/cache';
 import { BasicCommandParser, CommandParser } from '../client/parser';
@@ -714,16 +714,23 @@ export default class RedisCluster<
           const err = _err as Error;
           myFn = fn;
 
-          // TODO: error class
-          if (++i > maxCommandRedirections || !(err instanceof Error)) {
-            if (err instanceof Error) {
-              publish(CHANNELS.ERROR, () => ({
-                error: err,
-                origin: 'cluster',
-                internal: false,
-                clientId: client._clientId,
-                retryCount: i,
-              }));
+          if (!(err instanceof Error)) {
+            throw err;
+          }
+
+          const isRedirect = err.message.startsWith('ASK') || err.message.startsWith('MOVED');
+
+          if (++i > maxCommandRedirections) {
+            publish(CHANNELS.ERROR, () => ({
+              error: err,
+              origin: 'cluster',
+              internal: false,
+              clientId: client._clientId,
+              retryCount: i,
+            }));
+
+            if (isRedirect) {
+              throw new MaxCommandRedirectionsError(err);
             }
             throw err;
           }
@@ -881,11 +888,20 @@ export default class RedisCluster<
       try {
         return await client.SSUBSCRIBE(channels, listener, bufferMode);
       } catch (err) {
-        if (++i > maxCommandRedirections || !(err instanceof ErrorReply)) {
+        if (!(err instanceof ErrorReply)) {
           throw err;
         }
 
-        if (err.message.startsWith('MOVED')) {
+        const isRedirect = err.message.startsWith('MOVED');
+
+        if (++i > maxCommandRedirections) {
+          if (isRedirect) {
+            throw new MaxCommandRedirectionsError(err);
+          }
+          throw err;
+        }
+
+        if (isRedirect) {
           await this._self._slots.rediscover(client);
           client = await this._self._slots.getShardedPubSubClient(firstChannel);
           continue;

--- a/packages/client/lib/errors.ts
+++ b/packages/client/lib/errors.ts
@@ -107,3 +107,9 @@ export class MultiErrorReply extends ErrorReply {
 }
 
 export class OpenTelemetryError extends Error { }
+
+export class MaxCommandRedirectionsError extends Error {
+  constructor(cause?: unknown) {
+    super('Too many Cluster redirections', cause === undefined ? undefined : { cause });
+  }
+}


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

This pull request resolves a `// TODO: error class` comment by adding a new `MaxCommandRedirectionsError`. 

Previously, when a cluster command exceeded the maximum number of allowed redirections (e.g., getting stuck in a `MOVED` or `ASK` loop), the client simply re-threw the last received raw Redis error. This obscured the actual cause of the failure from the developer. 

The new error class wraps the original error, making it clear that a redirection limit was hit, thereby improving debugging and observability for cluster topology issues.

**Updates in this PR:**
- Added `MaxCommandRedirectionsError` to wrap the raw routing errors.
- Fixed a minor logic flaw so that non-Error objects are properly re-thrown instead of being accidentally wrapped.
- Added a full test suite case using `testUtils.testWithCluster` that intentionally creates a `MOVED` loop to verify the `MaxCommandRedirectionsError` is correctly thrown.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling change in cluster redirect paths; behavior only differs when the redirection cap is already exceeded.
> 
> **Overview**
> When cluster command routing or sharded `sSubscribe` hits **`maxCommandRedirections`** while still seeing **`MOVED`** / **`ASK`** errors, the client now throws **`MaxCommandRedirectionsError`** (`Too many Cluster redirections`) with the last Redis error as **`cause`**, instead of surfacing only the raw redirect reply.
> 
> The general cluster **`_execute`** redirect loop also **re-throws non-`Error` values immediately** and only wraps redirect failures at the limit; integration tests induce **`MOVED`** loops (low limit) for **`GET`** and **`sSubscribe`** to assert the new error type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af0e89203bb4339672dcdf0f8c724f7ae1112527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->