### PR TITLE
fix(client): throw standard errors for invalid pool connection states

### DIFF
--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -57,7 +57,7 @@ describe('RedisClientPool', () => {
     // Fire second connect while first is running / pool is marked as open
     await assert.rejects(pool.connect(), /Pool already opened/);
     // Cleanup
-    await pool.close().catch(() => {});
+    pool.destroy();
   });
 
   it('throws ClientClosedError if close is called on a closed pool', async () => {

--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { RESP_TYPES } from '../RESP/decoder';
 import { RedisClientPool } from './pool';
-import { TimeoutError } from '../errors';
+import { TimeoutError, ClientClosedError } from '../errors';
 
 describe('RedisClientPool', () => {
   it('chained withCommandOptions(...).withTypeMapping(...) preserves earlier overrides at dispatch', () => {
@@ -44,6 +44,26 @@ describe('RedisClientPool', () => {
     assert.equal(pool.HOTKEYS_STOP, undefined);
     assert.equal(pool.HOTKEYS_GET, undefined);
     assert.equal(pool.HOTKEYS_RESET, undefined);
+  });
+
+  it('throws an error if connect is called on an already open pool', async () => {
+    // We can't actually connect to Redis because we don't know the port here without testUtils,
+    // but calling connect() sets #isOpen to true immediately before awaiting the socket connection.
+    const pool = RedisClientPool.create({
+        socket: { port: 9999 }
+    });
+    // Fire first connect (will stay pending / eventually fail to connect)
+    pool.connect().catch(() => {});
+    // Fire second connect while first is running / pool is marked as open
+    await assert.rejects(pool.connect(), /Pool already opened/);
+    // Cleanup
+    await pool.close().catch(() => {});
+  });
+
+  it('throws ClientClosedError if close is called on a closed pool', async () => {
+    const pool = RedisClientPool.create({});
+    // Pool is initially closed, so calling close() directly should throw
+    await assert.rejects(pool.close(), ClientClosedError);
   });
 
   testUtils.testWithClientPool('sendCommand', async pool => {

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -413,7 +413,9 @@ export class RedisClientPool<
   }
 
   async connect() {
-    if (this._self.#isOpen) return; // TODO: throw error?
+    if (this._self.#isOpen) {
+      throw new Error('Pool already opened');
+    }
     this._self.#isOpen = true;
 
     const promises = [];
@@ -575,8 +577,9 @@ export class RedisClientPool<
   multi = this.MULTI;
 
   async close() {
-    if (this._self.#isClosing) return; // TODO: throw err?
-    if (!this._self.#isOpen) return; // TODO: throw err?
+    if (this._self.#isClosing || !this._self.#isOpen) {
+      throw new ClientClosedError();
+    }
 
     this._self.#isClosing = true;
     clearTimeout(this._self.cleanupTimeout);


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

This pull request fixes an issue in the Redis Client Pool where invalid connection state transitions were silently ignored. 

Previously, calling `connect()` on a pool that was already open, or `close()` on a pool that was already closed, would simply return early without throwing an error. This behavior masked potential application logic bugs, as developers might assume a connection action succeeded when it was actually silently dropped.

**Changes included:**
* **Connect Validation:** Modified `pool.ts` to explicitly throw `Error('Pool already opened')` when `connect()` is called on an already open pool.
* **Close Validation:** Modified `pool.ts` to throw the standard `ClientClosedError` when `close()` is called on a pool that is already closing or completely closed.
* **Test Coverage:** Added new integration tests in `pool.spec.ts` to strictly verify these error handling paths. 

These updates bring the connection pool lifecycle errors into parity with the standard standalone `RedisClient` behavior.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking behavioral change for callers that relied on idempotent `connect()`/`close()`; errors surface at the API boundary but do not alter successful lifecycle paths.
> 
> **Overview**
> **RedisClientPool** lifecycle calls no longer fail silently when used in the wrong state.
> 
> `connect()` now throws `Error('Pool already opened')` if the pool is already open (replacing a no-op return). `close()` now throws **`ClientClosedError`** when the pool is not open or is already closing (replacing early returns). New unit tests in `pool.spec.ts` cover both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0f5e626484ee853d33c1c35cf78132fad560e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->