### PR TITLE
fix(sentinel): cap post-connect rediscovery retries

### DIFF
--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -1363,6 +1363,40 @@ describe('legacy tests', () => {
       assert.equal(sawRecoverySuccess, true, 'expected periodic GET to recover after restart');
     });
 
+    // Regression test for https://github.com/redis/node-redis/issues/3385
+    //
+    // The rediscovery cap previously applied only before the first successful
+    // connect. A later full Sentinel outage left an operation waiting on the
+    // rediscovery loop forever.
+    it('rejects a command after rediscovery reaches its cap following a full outage', async function () {
+      this.timeout(30000);
+
+      sentinel = frame.getSentinelClient({
+        maxCommandRediscovers: 1,
+        commandOptions: { timeout: undefined }
+      });
+      sentinel.on('error', () => { });
+      await sentinel.connect();
+
+      await Promise.all([
+        ...frame.getAllNodesPort().map(port => frame.stopNode(port.toString())),
+        ...frame.getAllSentinelsPort().map(port => frame.stopSentinel(port.toString()))
+      ]);
+
+      const timeoutError = new Error('rediscovery cap was not enforced');
+      const result = await Promise.race([
+        sentinel.get('some-key').then(
+          () => new Error('command unexpectedly resolved'),
+          err => err
+        ),
+        setTimeout(5000).then(() => timeoutError)
+      ]);
+
+      assert.ok(result instanceof Error);
+      assert.notStrictEqual(result, timeoutError);
+      assert.notStrictEqual(result.message, 'command unexpectedly resolved');
+    });
+
     it('timer works, and updates sentinel list', async function () {
       this.timeout(60000);
 

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -1397,6 +1397,27 @@ describe('legacy tests', () => {
       assert.notStrictEqual(result.message, 'command unexpectedly resolved');
     });
 
+    it('emits an error when background rediscovery reaches its cap', async function () {
+      this.timeout(30000);
+
+      sentinel = frame.getSentinelClient({
+        maxCommandRediscovers: 0,
+        passthroughClientErrorEvents: false
+      });
+      await sentinel.connect();
+
+      const backgroundError = once(sentinel, 'error');
+      await Promise.all(frame.getAllSentinelsPort().map(port => frame.stopSentinel(port.toString())));
+
+      const [err] = await Promise.race([
+        backgroundError,
+        setTimeout(5000).then(() => {
+          throw new Error('background rediscovery did not surface an error');
+        })
+      ]);
+      assert.ok(err instanceof Error);
+    });
+
     it('timer works, and updates sentinel list', async function () {
       this.timeout(60000);
 

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -1005,7 +1005,7 @@ export class RedisSentinelInternal<
     } finally {
       this.#connectPromise = undefined;
       if (this.#isReady && this.#scanInterval > 0) {
-        this.#scanTimer = setInterval(this.#reset.bind(this), this.#scanInterval);
+        this.#scanTimer = setInterval(this.#resetInBackground.bind(this), this.#scanInterval);
       }
     }
   }
@@ -1015,7 +1015,6 @@ export class RedisSentinelInternal<
     while (true) {
       this.#trace("starting connect loop");
 
-      count+=1;
       if (this.#destroy) {
         this.#trace("in #connect and want to destroy")
         return;
@@ -1033,7 +1032,7 @@ export class RedisSentinelInternal<
       } catch (e) {
         const err = e as Error;
         this.#trace(`#connect: exception ${err.message}`);
-        if (count > this.#maxCommandRediscovers) {
+        if (++count > this.#maxCommandRediscovers) {
           throw e;
         }
 
@@ -1104,9 +1103,9 @@ export class RedisSentinelInternal<
     return client;
   }
 
-  async #handlePubSubControlChannel(channel: Buffer, _message: Buffer) {
+  #handlePubSubControlChannel(channel: Buffer, _message: Buffer) {
     this.#trace("pubsub control channel message on " + channel);
-    this.#reset();
+    this.#resetInBackground();
   }
 
   // if clientInfo is defined, it corresponds to a master client in the #masterClients array, otherwise loop around replicaClients
@@ -1147,6 +1146,10 @@ export class RedisSentinelInternal<
     }
   }
 
+  #resetInBackground() {
+    void this.#reset().catch(err => this.emit('error', err));
+  }
+
   #sentinelNodeListKey(nodes: Array<RedisNode>) {
     return nodes.map(node => `${node.host}:${node.port}`).sort().join('|');
   }
@@ -1168,14 +1171,14 @@ export class RedisSentinelInternal<
         this.#sentinelRootNodes.splice(found, 1);
     }
     this.#restoreSentinelRootNodesIfEmpty();
-    this.#reset();
+    this.#resetInBackground();
   }
 
   async close() {
     this.#destroy = true;
 
     if (this.#connectPromise != undefined) {
-      await this.#connectPromise;
+      await this.#connectPromise.catch(() => undefined);
     }
 
     this.#isReady = false;
@@ -1225,7 +1228,7 @@ export class RedisSentinelInternal<
     this.#destroy = true;
 
     if (this.#connectPromise != undefined) {
-      await this.#connectPromise;
+      await this.#connectPromise.catch(() => undefined);
     }
 
     this.#isReady = false;

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -1033,7 +1033,7 @@ export class RedisSentinelInternal<
       } catch (e) {
         const err = e as Error;
         this.#trace(`#connect: exception ${err.message}`);
-        if (!this.#isReady && count > this.#maxCommandRediscovers) {
+        if (count > this.#maxCommandRediscovers) {
           throw e;
         }
 


### PR DESCRIPTION
Fixes #3385.

Apply maxCommandRediscovers to rediscovery after the Sentinel has already connected. This causes the operation waiting on failed rediscovery to reject once the cap is exhausted instead of waiting indefinitely.

Tests:
- npm run build
- npm run test:types -w @redis/client
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Sentinel failover/rediscovery behavior for already-connected clients; mis-tuned caps could cause earlier command failures or background errors, but the fix aligns with documented limits and prevents indefinite hangs.
> 
> **Overview**
> Fixes **#3385** by enforcing **`maxCommandRediscovers`** on every topology rediscovery in `#connect()`, not only before the first successful connect. After a later full Sentinel outage, commands and background resets **reject or emit `error`** once the cap is hit instead of looping forever.
> 
> Periodic scan, pub/sub control messages, and sentinel client failures now trigger **`#resetInBackground()`**, which runs `#reset()` without leaving unhandled rejections and surfaces failures via **`error`**. **`close()`** / **`destroy()`** no longer block on a failing in-flight `#connectPromise` (they swallow rejection while waiting).
> 
> Regression tests cover **in-flight commands** after total outage with a low cap and **background** rediscovery with `maxCommandRediscovers: 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd90ebdb0381d4375b54d40a9ca50ded5e45699b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->